### PR TITLE
remove classhing redefinition of fmax and fmin

### DIFF
--- a/vowpalwabbit/lda_core.cc
+++ b/vowpalwabbit/lda_core.cc
@@ -52,10 +52,6 @@ public:
     vw* all;
   };
   
-#ifdef _WIN32
-inline float fmax(float f1, float f2) { return (f1 < f2 ? f2 : f1); }
-inline float fmin(float f1, float f2) { return (f1 > f2 ? f2 : f1); }
-#endif
 
 #define MINEIRO_SPECIAL
 #ifdef MINEIRO_SPECIAL

--- a/vowpalwabbit/vw.sln
+++ b/vowpalwabbit/vw.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libvw", "libvw.vcxproj", "{EA52DE0D-A5BE-4FB9-8C84-3A57BDFEBED9}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -160,8 +160,8 @@ Global
 		{2720BCD9-6731-4A11-BA24-1F74E35BA97F}.Release|x86.ActiveCfg = Release|Win32
 		{2720BCD9-6731-4A11-BA24-1F74E35BA97F}.Release|x86.Build.0 = Release|Win32
 		{ACE47E98-488C-4CDF-B9F1-36337B2855AD}.Debug|Any CPU.ActiveCfg = Debug|Win32
-		{ACE47E98-488C-4CDF-B9F1-36337B2855AD}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
-		{ACE47E98-488C-4CDF-B9F1-36337B2855AD}.Debug|Mixed Platforms.Build.0 = Debug|Win32
+		{ACE47E98-488C-4CDF-B9F1-36337B2855AD}.Debug|Mixed Platforms.ActiveCfg = Debug|x64
+		{ACE47E98-488C-4CDF-B9F1-36337B2855AD}.Debug|Mixed Platforms.Build.0 = Debug|x64
 		{ACE47E98-488C-4CDF-B9F1-36337B2855AD}.Debug|Win32.ActiveCfg = Debug|Win32
 		{ACE47E98-488C-4CDF-B9F1-36337B2855AD}.Debug|Win32.Build.0 = Debug|Win32
 		{ACE47E98-488C-4CDF-B9F1-36337B2855AD}.Debug|x64.ActiveCfg = Debug|x64
@@ -178,8 +178,8 @@ Global
 		{ACE47E98-488C-4CDF-B9F1-36337B2855AD}.Release|x86.ActiveCfg = Release|Win32
 		{ACE47E98-488C-4CDF-B9F1-36337B2855AD}.Release|x86.Build.0 = Release|Win32
 		{8400DA16-1F46-4A31-A126-BBE16F62BFD7}.Debug|Any CPU.ActiveCfg = Debug|Win32
-		{8400DA16-1F46-4A31-A126-BBE16F62BFD7}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
-		{8400DA16-1F46-4A31-A126-BBE16F62BFD7}.Debug|Mixed Platforms.Build.0 = Debug|Win32
+		{8400DA16-1F46-4A31-A126-BBE16F62BFD7}.Debug|Mixed Platforms.ActiveCfg = Debug|x64
+		{8400DA16-1F46-4A31-A126-BBE16F62BFD7}.Debug|Mixed Platforms.Build.0 = Debug|x64
 		{8400DA16-1F46-4A31-A126-BBE16F62BFD7}.Debug|Win32.ActiveCfg = Debug|Win32
 		{8400DA16-1F46-4A31-A126-BBE16F62BFD7}.Debug|Win32.Build.0 = Debug|Win32
 		{8400DA16-1F46-4A31-A126-BBE16F62BFD7}.Debug|x64.ActiveCfg = Debug|x64


### PR DESCRIPTION
remove clashing redefinition of fmax and fmin. This causes a build error

change configuration of explore to x64 to avoid incompatible project errors

