### PR TITLE
fixed to_string errors for MwtExplorer.h

### DIFF
--- a/explore/static/MWTExplorer.h
+++ b/explore/static/MWTExplorer.h
@@ -180,7 +180,7 @@ struct StringRecorder : public IRecorder<Ctx>
 	void Record(Ctx& context, u32 action, float probability, string unique_key)
 	{
 		// Implicitly enforce To_String() API on the context
-	  m_recording.append(to_string((unsigned long)action));
+	  m_recording.append(to_string((unsigned long long)action));
 		m_recording.append(" ", 1);
 		m_recording.append(unique_key);
 		m_recording.append(" ", 1);


### PR DESCRIPTION
We could use sprintf here instead, but the simpler fix of using “unsigned long long” seems to be working. This previously fixed to_string errors in cbify.cc as well. 