### PR TITLE
lrq audit bugfixes

### DIFF
--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -151,7 +151,7 @@ bool operator<(const string_value& first, const string_value& second)
   
   string tmp = "";
   
-  if (a != NULL){
+  if (a != NULL && all.audit){
     tmp += a->space;
     tmp += '^';
     tmp += a->feature; 

--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -151,7 +151,7 @@ bool operator<(const string_value& first, const string_value& second)
   
   string tmp = "";
   
-  if (a != NULL && all.audit){
+  if (a != NULL){
     tmp += a->space;
     tmp += '^';
     tmp += a->feature; 

--- a/vowpalwabbit/lrq.cc
+++ b/vowpalwabbit/lrq.cc
@@ -126,16 +126,19 @@ void predict_or_learn(LRQstate& lrq, base_learner& base, example& ec)
 
                             if (iter == 0 && (all.audit || all.hash_inv))
                               {
-                                char* new_space = calloc_or_die<char>(4);
-                                strcpy(new_space, "lrq");
-                                size_t n_len = strlen(i->c_str () + 4);
-                                size_t len = strlen(ra->feature) + n_len + 2;
-                                char* new_feature = calloc_or_die<char>(len);
-                                new_feature[0] = right;
-                                new_feature[1] = '^';
-                                strcat(new_feature, ra->feature);
-                                strcat(new_feature, "^");
-                                sprintf(new_feature+strlen(new_feature), "%d", n);
+                                std::stringstream new_space_buffer;
+                                std::stringstream new_feature_buffer;
+
+                                new_space_buffer << "lrq";
+                                new_feature_buffer << right << '^' 
+                                                   << ra->feature << '^'
+                                                   << n;
+
+                                char* new_space = 
+                                  strdup (new_space_buffer.str().c_str());
+                                char* new_feature = 
+                                  strdup (new_feature_buffer.str().c_str());
+
                                 audit_data ad = { new_space, new_feature, lrq.weight_index, lrq.x, true };
                                 ec.audit_features[right].push_back (ad);
                               }
@@ -145,10 +148,22 @@ void predict_or_learn(LRQstate& lrq, base_learner& base, example& ec)
               }
           }
 
+        bool save_audit = all.audit;
+        bool save_hash_inv = all.hash_inv;
+
+        if (iter == 1)
+          {
+            all.audit = false;
+            all.hash_inv = false;
+          }
+
 	if (is_learn)
 	  base.learn(ec);
 	else
 	  base.predict(ec);
+
+        all.audit = save_audit;
+        all.hash_inv = save_hash_inv;
 
         // Restore example
         if (iter == 0)
@@ -171,9 +186,19 @@ void predict_or_learn(LRQstate& lrq, base_learner& base, example& ec)
             ec.atomics[right].end = 
               ec.atomics[right].begin + lrq.orig_size[right];
 
-            if (all.audit)
-              ec.audit_features[right].end = 
-                ec.audit_features[right].begin + lrq.orig_size[right];
+            if (iter == 0 && (all.audit || all.hash_inv))
+              {
+                for (audit_data* a = ec.audit_features[right].begin + lrq.orig_size[right];
+                     a < ec.audit_features[right].end;
+                     ++a)
+                  {
+                    free (a->space);
+                    free (a->feature);
+                  }
+
+                ec.audit_features[right].end = 
+                  ec.audit_features[right].begin + lrq.orig_size[right];
+              }
           }
       }
   }

--- a/vowpalwabbit/lrq.cc
+++ b/vowpalwabbit/lrq.cc
@@ -124,7 +124,7 @@ void predict_or_learn(LRQstate& lrq, base_learner& base, example& ec)
 
                             ec.atomics[right].push_back (lrq);
 
-                            if (iter == 0 && (all.audit || all.hash_inv))
+                            if (all.audit || all.hash_inv)
                               {
                                 std::stringstream new_feature_buffer;
 
@@ -145,22 +145,10 @@ void predict_or_learn(LRQstate& lrq, base_learner& base, example& ec)
               }
           }
 
-        bool save_audit = all.audit;
-        bool save_hash_inv = all.hash_inv;
-
-        if (iter == 1)
-          {
-            all.audit = false;
-            all.hash_inv = false;
-          }
-
 	if (is_learn)
 	  base.learn(ec);
 	else
 	  base.predict(ec);
-
-        all.audit = save_audit;
-        all.hash_inv = save_hash_inv;
 
         // Restore example
         if (iter == 0)
@@ -183,7 +171,7 @@ void predict_or_learn(LRQstate& lrq, base_learner& base, example& ec)
             ec.atomics[right].end = 
               ec.atomics[right].begin + lrq.orig_size[right];
 
-            if (iter == 0 && (all.audit || all.hash_inv))
+            if (all.audit || all.hash_inv)
               {
                 for (audit_data* a = ec.audit_features[right].begin + lrq.orig_size[right];
                      a < ec.audit_features[right].end;

--- a/vowpalwabbit/lrq.cc
+++ b/vowpalwabbit/lrq.cc
@@ -126,16 +126,13 @@ void predict_or_learn(LRQstate& lrq, base_learner& base, example& ec)
 
                             if (iter == 0 && (all.audit || all.hash_inv))
                               {
-                                std::stringstream new_space_buffer;
                                 std::stringstream new_feature_buffer;
 
-                                new_space_buffer << "lrq";
                                 new_feature_buffer << right << '^' 
                                                    << ra->feature << '^'
                                                    << n;
 
-                                char* new_space = 
-                                  strdup (new_space_buffer.str().c_str());
+                                char* new_space = strdup("lrq");
                                 char* new_feature = 
                                   strdup (new_feature_buffer.str().c_str());
 


### PR DESCRIPTION
DO NOT MERGE, there is still something that is not right.  Allow me to explain.

This code was a hot mess.  First, the fixes:
  * gd.cc tries to access audit data even when all.audit=false
  * lrq.cc crazy unsafe and unreadable string manipulations replaced with stringstream
  * lrq.cc to tell core not to audit/invert_hash if iter>0
  * audit data memory leaked fixed

Ok now the problem.  Audit works great:

./vw  --lrq wc1 z --audit
...
        w^main:216796:1:0@0     c^foo:53090:1:0@0       lrq^c^foo^1:53091:0.389678:0@0     Constant:232120:1:0@0
...

However invert_hash doesn't print human readable stuff, except for Constant:

./vw  --lrq wc1 z --invert_hash foo; cat foo
...
Version 7.8.0
Min label:0.000000
Max label:1.000000
bits:18
0 pairs: 
0 triples: 
lda:0
0 ngram: 
0 skip: 
options: --lrq wc1
:0
:216796:0.204778
:216797:0.723558
:53090:0.204778
:53091:0.405543
Constant:232120:0.204778

I'm not sure how to fix this last problem.