### PR TITLE
fixed warnings in /explore with: 1. early return statement, 2. sprintf not secure, 3...

### DIFF
--- a/cs_test/Program.cs
+++ b/cs_test/Program.cs
@@ -18,7 +18,6 @@ namespace cs_test
             //ExploreClock.Clock();
             //LabDemo.Run();
             ExploreOnlySample.Run();
-            return;
             RunFeaturesTest();
             RunParserTest();
             RunSpeedTest();

--- a/explore/clr/explore_interface.h
+++ b/explore/clr/explore_interface.h
@@ -21,7 +21,7 @@ namespace MultiWorldTesting {
 /// </summary>
 /// <typeparam name="Ctx">The Context type.</typeparam>
 /// <remarks>
-/// Exploration data is specified as a set of tuples <context, action, probability, key> as described below. An 
+/// Exploration data is specified as a set of tuples (context, action, probability, key) as described below. An 
 /// application passes an IRecorder object to the @MwtExplorer constructor. See 
 /// @StringRecorder for a sample IRecorder object.
 /// </remarks>

--- a/explore/static/MWTExplorer.h
+++ b/explore/static/MWTExplorer.h
@@ -186,7 +186,9 @@ struct StringRecorder : public IRecorder<Ctx>
 		m_recording.append(" ", 1);
 
 		char prob_str[10] = { 0 };
-		NumberUtils::Float_To_String(probability, prob_str);
+        int x = (int)probability;
+        int d = (int)(fabs(probability - x) * 100000);
+        cpfloat_sprintf(prob_str, 10 * sizeof(char), "%d.%05d", x, d);
 		m_recording.append(prob_str);
 
 		m_recording.append(" | ", 3);
@@ -248,13 +250,13 @@ public:
 			int chars;
 			if (i == 0)
 			{
-				chars = sprintf(feature_str, "%d:", m_features[i].Id);
+                chars = cpfloat_sprintf(feature_str, sizeof(feature_str), "%d:", m_features[i].Id, 0);
 			}
 			else
 			{
-				chars = sprintf(feature_str, " %d:", m_features[i].Id);
+                chars = cpfloat_sprintf(feature_str, sizeof(feature_str), " %d:", m_features[i].Id, 0);
 			}
-			NumberUtils::print_float(feature_str + chars, m_features[i].Value);
+            NumberUtils::print_float(feature_str + chars, sizeof(feature_str), m_features[i].Value);
 			out_string.append(feature_str);
 		}
 		return out_string;

--- a/explore/static/utility.h
+++ b/explore/static/utility.h
@@ -15,6 +15,8 @@ typedef signed __int64 i64;
 typedef signed __int32 i32;
 typedef signed __int16 i16;
 typedef signed __int8  i8;
+// cross-platform float to_string
+#define cpfloat_sprintf(str, size, format, x, d) sprintf_s(str, size, format, x, d)
 #else
 typedef uint64_t u64;
 typedef uint32_t u32;
@@ -24,6 +26,8 @@ typedef int64_t i64;
 typedef int32_t i32;
 typedef int16_t i16;
 typedef int8_t i8;
+// cross-platform float to_string
+#define cpfloat_sprintf(str, size, format, x, d) sprintf(str, format, x, d)
 #endif
 
 typedef unsigned char    byte;
@@ -181,13 +185,6 @@ const size_t max_digits = (size_t) roundf((float) (-log(min_float) / log(10.)));
 class NumberUtils
 {
 public:
-	static void Float_To_String(float f, char* str)
-	{
-		int x = (int)f;
-		int d = (int)(fabs(f - x) * 100000);
-		sprintf(str, "%d.%05d", x, d);
-	}
-
 	template<bool trailing_zeros>
 	static void print_mantissa(char*& begin, float f)
 	{ // helper for print_float
@@ -211,7 +208,7 @@ public:
 			*begin++ = values[--digit];
 	}
 
-	static void print_float(char* begin, float f)
+    static void print_float(char* begin, size_t size, float f)
 	{
 		bool sign = false;
 		if (f < 0.f)
@@ -234,7 +231,7 @@ public:
 			*begin++ = '0';
 		else
 		{
-			sprintf(begin, "%g", f);
+            cpfloat_sprintf(begin, size, "%g", f, 0);
 			return;
 		}
 		*begin = '\0';


### PR DESCRIPTION
.... malformed xml comments

I did a quick performance test between sprintf vs sprintf_s and found that the secure version is slightly slower, but only at 4% slower in printing 10 million floats. Since perf is negligible, this fix uses sprintf_s under Win32 to remove warnings with secure printing. The #ifdef is contained in a single header file utility.h to avoid spaghetti code.