### PR TITLE
Enable TCP KeepAlive

### DIFF
--- a/vowpalwabbit/allreduce.cc
+++ b/vowpalwabbit/allreduce.cc
@@ -92,6 +92,12 @@ socket_t getsock()
     if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (char*)&on, sizeof(on)) < 0)
       cerr << "setsockopt SO_REUSEADDR: " << strerror(errno) << endl;
 #endif
+
+  // Enable TCP Keep Alive to prevent socket leaks
+  int enableTKA = 1;
+  if (setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE, (char*)&enableTKA, sizeof(enableTKA)) < 0)
+    cerr << "setsockopt SO_KEEPALIVE: " << strerror(errno) << endl;
+
   return sock;
 }
 

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -419,6 +419,11 @@ void enable_sources(vw& all, bool quiet, size_t passes)
       if (setsockopt(all.p->bound_sock, SOL_SOCKET, SO_REUSEADDR, (char*)&on, sizeof(on)) < 0)
 	cerr << "setsockopt SO_REUSEADDR: " << strerror(errno) << endl;
 
+      // Enable TCP Keep Alive to prevent socket leaks
+      int enableTKA = 1;
+      if (setsockopt(all.p->bound_sock, SOL_SOCKET, SO_KEEPALIVE, (char*)&enableTKA, sizeof(enableTKA)) < 0)
+        cerr << "setsockopt SO_KEEPALIVE: " << strerror(errno) << endl;
+
       sockaddr_in address;
       address.sin_family = AF_INET;
       address.sin_addr.s_addr = htonl(INADDR_ANY);


### PR DESCRIPTION
In our test and production environments we see server slots in use by clients that have long disappeared (by normal program termination). Somehow the TCP connections are not properly closed and the TCP connection on the server remains in an ESTABLISHED state. 

If TCP keepalive is enabled these stale connection slots will be reused, preventing the need for a vw restart.