### PR TITLE
Multiple regressor initialisation fix (12)

### DIFF
--- a/vowpalwabbit/parse_regressor.cc
+++ b/vowpalwabbit/parse_regressor.cc
@@ -36,20 +36,22 @@ void initialize_regressor(vw& all)
     {
       cerr << all.program_name << ": Failed to allocate weight array with " << all.num_bits << " bits: try decreasing -b <bits>" << endl;
       throw exception();
-    }
+    } else
+  if (all.initial_weight != 0.)
+    {
+     for (size_t j = 0; j < length << all.reg.stride_shift; j+= ( ((size_t)1) << all.reg.stride_shift))
+       all.reg.weight_vector[j] = all.initial_weight;      
+    } else
+  if (all.random_positive_weights)
+    {
+      for (size_t j = 0; j < length; j++)
+	all.reg.weight_vector[j << all.reg.stride_shift] = (float)(0.1 * frand48());
+    } else      
   if (all.random_weights)
     {
       for (size_t j = 0; j < length; j++)
 	all.reg.weight_vector[j << all.reg.stride_shift] = (float)(frand48() - 0.5);
     }
-  if (all.random_positive_weights)
-    {
-      for (size_t j = 0; j < length; j++)
-	all.reg.weight_vector[j << all.reg.stride_shift] = (float)(0.1 * frand48());
-    }
-  if (all.initial_weight != 0.)
-    for (size_t j = 0; j < length << all.reg.stride_shift; j+= ( ((size_t)1) << all.reg.stride_shift))
-      all.reg.weight_vector[j] = all.initial_weight;
 }
 
 const size_t buf_size = 512;


### PR DESCRIPTION
Fix for https://github.com/JohnLangford/vowpal_wabbit/issues/510
*if* clauses are reordered and *else* are added between them.
The copy of original bug report is:

## 12. Multiple regressor initialisation

In `initialize_regressor()` in `parse_regerssor.cc` it's worth adding else between these blocks
```
  if (all.random_weights)
{...}
   if (all.random_positive_weights)
{...}
   if (all.initial_weight != 0.)
{...}
```
 
 The `random_positive_weights` is set to true automatically with `--new_mf` mode in `mf.cc`. I found that these random values ( `0.1 * frand48()` ) are too big for my dataset (9000 features per example). So I initialised regressor with help of `--initial_weight` with something like 1e-5 and got better convergence. But now regressor initialises twice. I would put *else* clauses between these 3 *if*'s and reorder them so `all.initial_weight` comes first.