### PR TITLE
fix for typo in initial_weight help (14)

### DIFF
--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -800,7 +800,7 @@ vw& parse_args(int argc, char *argv[])
 
   new_options(all, "Weight options")
     ("initial_regressor,i", po::value< vector<string> >(), "Initial regressor(s)")
-    ("initial_weight", po::value<float>(&(all.initial_weight)), "Set all weights to an initial value of 1.")
+    ("initial_weight", po::value<float>(&(all.initial_weight)), "Set all weights to an initial value of arg.")
     ("random_weights", po::value<bool>(&(all.random_weights)), "make initial weights random")
     ("input_feature_regularizer", po::value< string >(&(all.per_feature_regularizer_input)), "Per feature regularization input file");
   add_options(all);


### PR DESCRIPTION
Fixing help for initial_weight as described in 14 of
https://github.com/JohnLangford/vowpal_wabbit/issues/510

Copy of original bug report
## 14. Typos.
The help line for initial_weight says:
``--initial_weight arg              Set all weights to an initial value of 1.``

Shall " be to an initial value of **arg**." I suppose. 
