### PR TITLE
Fix for *parseFloat() is too cautious* (11)

### DIFF
--- a/vowpalwabbit/parse_primitives.h
+++ b/vowpalwabbit/parse_primitives.h
@@ -93,7 +93,7 @@ inline float parseFloat(char * p, char **end)
     exp_acc *= exp_s;
     
   }
-  if (*p == ' ')//easy case succeeded.
+  if (*p == ' ' || *p == '\n' || *p == '\t')//easy case succeeded.
     {
       acc *= powf(10,(float)(exp_acc-num_dec));
       *end = p;


### PR DESCRIPTION
Fix for *Is parseFloat() too cautious?* from
https://github.com/JohnLangford/vowpal_wabbit/issues/510

Copy of original report:

## 11. Is parseFloat() too cautious?

I suspect that `strtod()` is unnecessary called in `parseFloat()` in `parse_primitives.h` in case the float ends with a new line bcs of
https://github.com/JohnLangford/vowpal_wabbit/blob/master/vowpalwabbit/parse_primitives.h#L96
``if (*p == ' ')//easy case succeeded.``
Perhaps it's better to use
``if (*p == ' ' || *p == '\n')//easy case succeeded.``

I would also include `'\t'` as it's default separator when you join two files with Unix *paste* command
