### PR TITLE
Redefine namespace param implementation (1)

### DIFF
--- a/vowpalwabbit/global_data.h
+++ b/vowpalwabbit/global_data.h
@@ -293,6 +293,9 @@ struct vw {
   bool ignore_some;
   bool ignore[256];//a set of namespaces to ignore
 
+  bool redefine_some;          // --redefine param was used
+  unsigned char redefine[256]; // keeps new chars for amespaces
+
   std::vector<std::string> ngram_strings; // pairs of features to cross.
   std::vector<std::string> skip_strings; // triples of features to cross.
   uint32_t ngram[256];//ngrams to generate.

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -311,7 +311,7 @@ void parse_feature_tweaks(vw& all)
     ("hash", po::value< string > (), "how to hash the features. Available options: strings, all")
     ("ignore", po::value< vector<unsigned char> >(), "ignore namespaces beginning with character <arg>")
     ("keep", po::value< vector<unsigned char> >(), "keep namespaces beginning with character <arg>")
-    ("redefine", po::value< vector<string> >(), "redefine namespaces beginning with characters from string <s>... as namespace <n>. <arg> shall be in form 's:=n' where := is operator. Use ':=n' to redefine all namespaces.")
+    ("redefine", po::value< vector<string> >(), "redefine namespaces beginning with characters of string <s> as namespace <n>. <arg> shall be in form 's:=n' where := is operator. Use ':=n' to redefine all namespaces.")
     ("bit_precision,b", po::value<size_t>(), "number of bits in the feature table")
     ("noconstant", "Don't add a constant feature")
     ("constant,C", po::value<float>(&(all.initial_constant)), "Set initial value of constant")
@@ -532,7 +532,7 @@ void parse_feature_tweaks(vw& all)
   if (vm.count("redefine"))
   {
       // initail values i-th namespace is redefined to i itself
-      for (uint i = 0; i < 256; i++)
+      for (size_t i = 0; i < 256; i++)
           all.redefine[i] = i;
 
       // note: --redefine declaration order is matter
@@ -548,11 +548,11 @@ void parse_feature_tweaks(vw& all)
           unsigned char new_namespace = ' ';
 
           // let's find operator ':=' and new namespace's character after it
-          for (int i = 0; i < arg.length(); i++)
+          for (size_t i = 0; i < arg.length(); i++)
           {
               if (arg[i] == ':')
                   operator_pos = i;
-              else if ( (arg[i] == '=') && (operator_pos == i-1) )
+              else if ( (arg[i] == '=') && (operator_pos == (int)i-1) )
                   operator_found = true;
               else if (operator_found)
               {
@@ -571,7 +571,7 @@ void parse_feature_tweaks(vw& all)
 
           if (operator_pos != 0)
               for (int i = 0; i < operator_pos; i++) // namespaces from s in s:=k are redefined to k
-                  all.redefine[arg[i]] = new_namespace;
+                  all.redefine[(size_t)arg[i]] = new_namespace;
           else
               for (int i = 0; i < 256; i++) //s is empty - all nammespaces must be redefined to k
                   all.redefine[i] = new_namespace;

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -569,8 +569,10 @@ void parse_feature_tweaks(vw& all)
               throw exception();
           }
 
-          all.redefine_some = true;
-          operator_pos++; // seek operator end
+          if (++operator_pos > 3) // seek operator end
+              cerr << "WARNING: multiple namespaces are used in target part of --redefine argument. Only first one ('" << new_namespace << "') will be used as target namespace." << endl;
+
+          all.redefine_some = true;         
 
           // case ':=S' doesn't require any additional code as new_namespace = ' ' by default
 

--- a/vowpalwabbit/parse_example.cc
+++ b/vowpalwabbit/parse_example.cc
@@ -313,7 +313,7 @@ public:
 	this->ae = ae;
 	this->affix_features = all.affix_features;
 	this->spelling_features = all.spelling_features;
-        this->namespace_dictionaries = all.namespace_dictionaries;
+    this->namespace_dictionaries = all.namespace_dictionaries;
 	this->base = NULL;
 	listNameSpace();
 	if (base != NULL)

--- a/vowpalwabbit/parse_example.cc
+++ b/vowpalwabbit/parse_example.cc
@@ -37,6 +37,8 @@ public:
   char* base;
   unsigned char index;
   float v;
+  bool redefine_some;
+  unsigned char (*redefine)[256];
   parser* p;
   example* ae;
   uint32_t* affix_features;
@@ -226,6 +228,7 @@ public:
     }else{
       // NameSpaceInfo --> 'String' NameSpaceInfoValue
       index = (unsigned char)(*reading_head);
+      if (redefine_some) index = (*redefine)[index]; //redefine index
       if(ae->atomics[index].begin == ae->atomics[index].end)
 	new_index = true;
       substring name = read_name();
@@ -305,6 +308,8 @@ public:
 	this->reading_head = reading_head;
 	this->endLine = endLine;
 	this->p = all.p;
+    this->redefine_some = all.redefine_some;
+    this->redefine = &all.redefine;
 	this->ae = ae;
 	this->affix_features = all.affix_features;
 	this->spelling_features = all.spelling_features;

--- a/vowpalwabbit/parse_example.cc
+++ b/vowpalwabbit/parse_example.cc
@@ -308,12 +308,12 @@ public:
 	this->reading_head = reading_head;
 	this->endLine = endLine;
 	this->p = all.p;
-    this->redefine_some = all.redefine_some;
-    this->redefine = &all.redefine;
+	this->redefine_some = all.redefine_some;
+	this->redefine = &all.redefine;
 	this->ae = ae;
 	this->affix_features = all.affix_features;
 	this->spelling_features = all.spelling_features;
-    this->namespace_dictionaries = all.namespace_dictionaries;
+	this->namespace_dictionaries = all.namespace_dictionaries;
 	this->base = NULL;
 	listNameSpace();
 	if (base != NULL)


### PR DESCRIPTION
According to https://github.com/JohnLangford/vowpal_wabbit/issues/510
This pull request contains implementation of --redefine param.

Original proposal:

## 1. namspaces redefinition
The first thing I have implemented in my VW fork is *--redefine* parameter which allows me to rename any namespace or set of namespaces. I gave  a new namespaces to each feature of original dataset taking their names were from [a-Z] interval. Then I declared a parameter *--redefine* which takes string argument in form of *x:=n* where *x* is a list of old namespaces, *:=* is an operator and *n* is a new namespace to which they should be assigned. That allowed me to put something like following in my vw command line:

``--redefine abcdefgihjklmnoprstquwz:=L --redefine abcdegf:=a --ignore L  --q aa``

In example above we assign all our namespaces to namespace *L* and then (order is matter) reassign some of them to namespace *a*. As all features got their own namespaces the namespace *a* will contain 7 features and *L* 23-7=16. Then namespace a is used to generate quadratic features.

Why it's convenient? I can now experiment with different features used for quadratic features generation by just addition or removal literals in  `--redefine abcdegf:=a `.
On practice I wrote a bash script which started with `abcdefgihjklmnoprstquwz:=a` as a baseline and used leave-one-out with validation to find features which removal could improve the result.

This parameter also allows you to do something like

``--redefine abc:=a --ignore a --redefine def:=b --redefine klmn:=c -q bc``

All namespaces which were not redefined will be used as before - as ordinary feature.

Another thing why I'm so enthusiastic about this function is because it's very easy to implement without any performance penalties. 