### PR TITLE
--save_resume fix (9)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([vowpal_wabbit], [7.8], [jl@hunch.net])
+AC_INIT([vowpal_wabbit], [7.10.1], [jl@hunch.net])
 AC_DEFINE([PACKAGE_URL],["https://github.com/JohnLangford/vowpal_wabbit"],[project url])
 AC_CONFIG_HEADERS(vowpalwabbit/config.h)
 AM_INIT_AUTOMAKE()

--- a/vowpalwabbit/ftrl_proximal.cc
+++ b/vowpalwabbit/ftrl_proximal.cc
@@ -92,7 +92,7 @@ void save_load(ftrl& b, io_buf& model_file, bool read, bool text)
     uint32_t text_len = sprintf(buff, ":%d\n", resume);
     bin_text_read_write_fixed(model_file,(char *)&resume, sizeof (resume), "", read, buff, text_len, text);
     
-    if (resume) 
+    if (resume)
       GD::save_load_online_state(*all, model_file, read, text);
     else
       GD::save_load_regressor(*all, model_file, read, text);

--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -19,6 +19,8 @@ license as described in the file LICENSE.
 #include "reductions.h"
 #include "vw.h"
 
+#define VERSION_SAVE_RESUME_FIX "7.10.1"
+
 using namespace std;
 using namespace LEARNER;
 //todo: 
@@ -33,6 +35,7 @@ namespace GD
     float initial_constant;
     float neg_norm_power;
     float neg_power_t;
+    float sparse_l2;
     float update_multiplier;
     void (*predict)(gd&, base_learner&, example&);
     void (*learn)(gd&, base_learner&, example&);
@@ -605,7 +608,7 @@ void save_load_regressor(vw& all, io_buf& model_file, bool read, bool text)
 }
 
 //void save_load_online_state(gd& g, io_buf& model_file, bool read, bool text)
-void save_load_online_state(vw& all, io_buf& model_file, bool read, bool text)
+void save_load_online_state(vw& all, io_buf& model_file, bool read, bool text, gd* g)
 {
   //vw& all = *g.all;
   
@@ -675,6 +678,32 @@ void save_load_online_state(vw& all, io_buf& model_file, bool read, bool text)
   bin_text_read_write_fixed(model_file,(char*)&all.sd->total_features, sizeof(all.sd->total_features), 
 			    "", read, 
 			    buff, text_len, text);
+
+  if (!read || all.model_file_ver >= VERSION_SAVE_RESUME_FIX)
+  { // restore some data to allow --save_resume work more accurate
+
+      // fix average loss
+      double total_weight = 0.; //value holder as g* may be null
+      if (!read && g != NULL) total_weight = g->total_weight;
+      text_len = sprintf(buff, "gd::total_weight %f\n", total_weight);
+      bin_text_read_write_fixed(model_file,(char*)&total_weight, sizeof(total_weight),
+                                "", read,
+                                buff, text_len, text);
+      if (read && g != NULL) g->total_weight = total_weight;
+
+      // fix "loss since last" for first printed out example details
+      text_len = sprintf(buff, "sd::old_weighted_examples %f\n", all.sd->old_weighted_examples);
+      bin_text_read_write_fixed(model_file,(char*)&all.sd->old_weighted_examples, sizeof(all.sd->old_weighted_examples),
+                                "", read,
+                                buff, text_len, text);
+
+      // fix "number of examples per pass"
+      text_len = sprintf(buff, "current_pass %u\n", (uint32_t)all.current_pass);
+      bin_text_read_write_fixed(model_file,(char*)&all.current_pass, sizeof(all.current_pass),
+                                "", read,
+                                buff, text_len, text);
+  }
+
   if (!all.training) // reset various things so that we report test set performance properly
     {
       all.sd->sum_loss = 0;
@@ -776,8 +805,12 @@ void save_load(gd& g, io_buf& model_file, bool read, bool text)
 				"", read,
 				buff, text_len, text);
       if (resume)
-	//save_load_online_state(g, model_file, read, text);
-        save_load_online_state(all, model_file, read, text);
+      {
+          if (read && all.model_file_ver < VERSION_SAVE_RESUME_FIX)
+           cerr << endl << "WARNING: --save_resume functionality is known to have inaccuracy in model files version less than " << VERSION_SAVE_RESUME_FIX << endl << endl;
+    //save_load_online_state(g, model_file, read, text);
+        save_load_online_state(all, model_file, read, text, &g);
+      }
       else
 	save_load_regressor(all, model_file, read, text);
     }

--- a/vowpalwabbit/gd.h
+++ b/vowpalwabbit/gd.h
@@ -14,10 +14,12 @@
 namespace GD{
   LEARNER::base_learner* setup(vw& all);
 
+  struct gd;
+
   float finalize_prediction(shared_data* sd, float ret);
   void print_audit_features(vw&, example& ec);
   void save_load_regressor(vw& all, io_buf& model_file, bool read, bool text);
-  void save_load_online_state(vw& all, io_buf& model_file, bool read, bool text);
+  void save_load_online_state(vw& all, io_buf& model_file, bool read, bool text, GD::gd *g = NULL);
 
   // iterate through one namespace (or its part), callback function T(some_data_R, feature_value_x, feature_weight)
   template <class R, void (*T)(R&, const float, float&)>

--- a/vowpalwabbit/global_data.h
+++ b/vowpalwabbit/global_data.h
@@ -25,7 +25,7 @@ struct version_struct {
   int major;
   int minor;
   int rev;
-  version_struct(int maj, int min, int rv)
+  version_struct(int maj = 0, int min = 0, int rv = 0)
   {
     major = maj;
     minor = min;
@@ -261,6 +261,7 @@ struct vw {
   bool hessian_on;
 
   bool save_resume;
+  version_struct model_file_ver;
   double normalized_sum_norm_x;
 
   po::options_description opts;

--- a/vowpalwabbit/parse_regressor.cc
+++ b/vowpalwabbit/parse_regressor.cc
@@ -73,12 +73,12 @@ void save_load_header(vw& all, io_buf& model_file, bool read, bool text)
       bin_text_read_write(model_file, buff2, v_length, 
 			  "", read, 
 			  buff, text_len, text);
-      version_struct v_tmp(buff2);
-      if (v_tmp < LAST_COMPATIBLE_VERSION)
-	{
-	  cout << "Model has possibly incompatible version! " << v_tmp.to_string() << endl;
-	  throw exception();
-	}
+      all.model_file_ver = buff2; //stord in all to check save_resume fix in gd
+      if (all.model_file_ver < LAST_COMPATIBLE_VERSION)
+      {
+          cout << "Model has possibly incompatible version! " << all.model_file_ver.to_string() << endl;
+          throw exception();
+      }
       
       char model = 'm';
       bin_text_read_write_fixed(model_file,&model,1,


### PR DESCRIPTION
This shall fix --save_resume
I'll add a sample a bit later

As I can see line
``float sparse_l2;``
Isn't in gd.cc anymore. Was it deleted? Shall I reflect this in my pull request?
I also quite unsure in confiure.ac changes. Is it ok or there is other way to handle VW version change?