### PR TITLE
save_resume fix 2 (9)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([vowpal_wabbit], [7.10], [jl@hunch.net])
+AC_INIT([vowpal_wabbit], [7.10.1], [jl@hunch.net])
 AC_DEFINE([PACKAGE_URL],["https://github.com/JohnLangford/vowpal_wabbit"],[project url])
 AC_CONFIG_HEADERS(vowpalwabbit/config.h)
 AM_INIT_AUTOMAKE()

--- a/vowpalwabbit/gd.h
+++ b/vowpalwabbit/gd.h
@@ -14,10 +14,12 @@
 namespace GD{
   LEARNER::base_learner* setup(vw& all);
 
+  struct gd;
+
   float finalize_prediction(shared_data* sd, float ret);
   void print_audit_features(vw&, example& ec);
   void save_load_regressor(vw& all, io_buf& model_file, bool read, bool text);
-  void save_load_online_state(vw& all, io_buf& model_file, bool read, bool text);
+  void save_load_online_state(vw& all, io_buf& model_file, bool read, bool text, GD::gd *g = NULL);
 
   // iterate through one namespace (or its part), callback function T(some_data_R, feature_value_x, feature_weight)
   template <class R, void (*T)(R&, const float, float&)>

--- a/vowpalwabbit/global_data.h
+++ b/vowpalwabbit/global_data.h
@@ -25,7 +25,7 @@ struct version_struct {
   int major;
   int minor;
   int rev;
-  version_struct(int maj, int min, int rv)
+  version_struct(int maj = 0, int min = 0, int rv = 0)
   {
     major = maj;
     minor = min;
@@ -261,6 +261,7 @@ struct vw {
   bool hessian_on;
 
   bool save_resume;
+  version_struct model_file_ver;
   double normalized_sum_norm_x;
 
   po::options_description opts;

--- a/vowpalwabbit/parse_regressor.cc
+++ b/vowpalwabbit/parse_regressor.cc
@@ -73,12 +73,12 @@ void save_load_header(vw& all, io_buf& model_file, bool read, bool text)
       bin_text_read_write(model_file, buff2, v_length, 
 			  "", read, 
 			  buff, text_len, text);
-      version_struct v_tmp(buff2);
-      if (v_tmp < LAST_COMPATIBLE_VERSION)
-	{
-	  cout << "Model has possibly incompatible version! " << v_tmp.to_string() << endl;
-	  throw exception();
-	}
+      all.model_file_ver = buff2; //stord in all to check save_resume fix in gd
+      if (all.model_file_ver < LAST_COMPATIBLE_VERSION)
+            {
+                cout << "Model has possibly incompatible version! " << all.model_file_ver.to_string() << endl;
+                throw exception();
+            }
       
       char model = 'm';
       bin_text_read_write_fixed(model_file,&model,1,


### PR DESCRIPTION
Few notes on this one (9): https://github.com/JohnLangford/vowpal_wabbit/issues/510

This patch affects GD and FTRL
I found 3 problems in GD if its state is restored from save_resume model:
a). average loss is different 
b). average loss since last is different in print_update() for first outputted value
c). number of examples per pass is wrong in vw' s summary

a) could be fixed by restoring `g.total_weight value`, b) - by restoring `sd->old_weighted_examples` and c). by restoring `all.current_pass` values.

as `g` object was removed from `save_load_online_state` arguments list (bcs of its call from ftrl, suppose)I've added `g*` as an optional argument. That required `save_load_online_state()` declaration change in `gd.h` and forward declaration of `struct gd;` before it. (As `struct gd` is declared and implemented solely in gd.cc. Moving it to .h caused some missing declarations for its fields)

I've defined new constant 
``#define VERSION_SAVE_RESUME_FIX "7.10.1"``
to compare while loading model. Current value in config.am is 7.8 which confused me a little, as latest ver should be 7.10. Perheps i'm doing something wrong here.

Warnings are shown only if both `--save_resume` and `-i` parameters are used and model file format is old. I'm checking save_resume field of file instead of related parameter of vw command line as it may be missing.

As model file version is checked in one .cc file and save_resume flag of model file in another .cc file I was forced to store model file version in all.model_file_version filed. This in its turn required a small modification in constructor of `version_struct``