### PR TITLE
cbify.cc/MWTExplorer.h -- minimally required virtual destructors.

### DIFF
--- a/explore/static/MWTExplorer.h
+++ b/explore/static/MWTExplorer.h
@@ -90,6 +90,9 @@ public:
 		return action;
 	}
 
+	virtual ~MwtExplorer()
+	{ }
+
 private:
 	u64 m_app_id;
 	IRecorder<Ctx>& m_recorder;
@@ -296,6 +299,9 @@ public:
 		}
 	}
 
+	virtual ~EpsilonGreedyExplorer()
+	{ }
+
 private:
 	std::tuple<u32, float, bool> Choose_Action(u64 salted_seed, Ctx& context)
 	{
@@ -461,6 +467,9 @@ public:
 		}
 	}
 
+	virtual ~GenericExplorer()
+	{ }
+
 private:
 	std::tuple<u32, float, bool> Choose_Action(u64 salted_seed, Ctx& context)
 	{
@@ -544,6 +553,9 @@ public:
 		}
 	}
 
+	virtual ~TauFirstExplorer()
+	{ }
+
 private:
 	std::tuple<u32, float, bool> Choose_Action(u64 salted_seed, Ctx& context)
 	{
@@ -616,6 +628,9 @@ public:
 			throw std::invalid_argument("Number of bags must be at least 1.");
 		}
 	}
+
+	virtual ~BootstrapExplorer()
+	{ }
 
 private:
 	std::tuple<u32, float, bool> Choose_Action(u64 salted_seed, Ctx& context)

--- a/vowpalwabbit/cbify.cc
+++ b/vowpalwabbit/cbify.cc
@@ -32,6 +32,9 @@ public:
     return (u32)(ctx.e.pred.multiclass);
   }
 
+  virtual ~vw_policy()
+  { }
+
 private:
   size_t m_index;
 };
@@ -47,6 +50,9 @@ public:
     predictions = v_init<uint32_t>();
     predictions.resize(s);
   }
+
+  virtual ~vw_cover()
+  { }
   
   v_array<float>& Get_Scores()
   { 
@@ -76,6 +82,9 @@ struct vw_recorder : public IRecorder<vw_context>
   }
   u32 action;
   float probability;
+
+  virtual ~vw_recorder()
+  { }
 };
 
 struct cbify {


### PR DESCRIPTION
Clean up after clang++ warnings (and gcc 4.7+ too!) about needing virtual destructors in derived classes. Without the virtual dtors, gcc 4.7 warns about undefined behavior... but it's just good practice and eliminates the warnings. clang++, OTOH, just warns about needing virtual dtors.