### PR TITLE
autotools_cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ $ make install
 
 Note that ``./autogen.sh`` requires *automake* (see the prerequisites, above.)
 
-Options that were passed to `./configure` in 7.6 and earlier may now be passed
-to `./autogen.sh`.
+`./autogen.sh`'s command line arguments are passed directly to `configure` as
+if they were `configure` arguments and flags.
 
 Be sure to read the wiki: https://github.com/JohnLangford/vowpal_wabbit/wiki
 for the tutorial, command line options, etc.  
@@ -60,6 +60,20 @@ for the tutorial, command line options, etc.
 The 'cluster' directory has it's own documentation for cluster
 parallel use, and the examples at the end of test/Runtests give some
 example flags.
+
+## C++ Optimization
+
+The default C++ compiler optimization flags are very aggressive. If you should run into a problem, consider running `configure` with the `--enable-debug` option, e.g.:
+
+```
+$ ./configure --enable-debug
+```
+
+or passing your own compiler flags via the `CXXOPTIMIZE` make variable:
+
+```
+$ make CXXOPTIMIZE="-O0 -g"
+```
 
 ## Mac OS X-specific info
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -16,7 +16,17 @@ case $( uname -s ) in
   ;;
  Linux)
   AC_PATH=/usr/share
-  LIBFILE=`ldconfig -p | grep program_options | tail -n 1 | cut -d '>' -f 2`
+  ldconfig=""
+  for p in `echo ${PATH} | sed 's/:/ /g'` /sbin /usr/sbin; do
+    if test -x ${p}/ldconfig; then
+      ldconfig=${p}/ldconfig
+      break
+    fi
+  done
+  if test "x${ldconfig}" = x; then
+    ldconfig=ldconfig
+  fi
+  LIBFILE=`${ldconfig} -p | grep program_options | tail -n 1 | cut -d '>' -f 2`
   echo "Boost at: $LIBFILE"
   BOOST_DIR_ARG="--with-boost-libdir=`dirname $LIBFILE`"
   echo "Using $BOOST_DIR_ARG"

--- a/configure.ac
+++ b/configure.ac
@@ -46,8 +46,16 @@ AC_ARG_ENABLE([parallelization],AC_HELP_STRING([--enable-parallelization],[enabl
 AM_CONDITIONAL(PARALLELIZE, test x$parallelize = xtrue)
 
 profile=false
-AC_ARG_ENABLE([profiling],AC_HELP_STRING([--enable-profiling],[add -pg -g CPPFLAGS]),[ test "$enableval" = "no" || profile=true ])
+AC_ARG_ENABLE([profiling],
+  AC_HELP_STRING([--enable-profiling], [add -pg to C++ compiler flags]),
+  [ test "$enableval" = "no" || profile=true ])
 AM_CONDITIONAL(PROFILE, test x$profile = xtrue)
+
+vwbug=false
+AC_ARG_ENABLE([debug],
+  AC_HELP_STRING([--enable-debug], [Enable debugging, disable optimization in the compiler]),
+  [ test "$enableval" = "no" || vwbug=true ])
+AM_CONDITIONAL(VWBUG, test x$vwbug = xtrue)
 
 clang_libcxx=false
 AC_ARG_ENABLE([libc++],

--- a/vowpalwabbit/Makefile.am
+++ b/vowpalwabbit/Makefile.am
@@ -16,10 +16,16 @@ ACLOCAL_AMFLAGS = -I acinclude.d
 AM_CXXFLAGS = ${BOOST_CPPFLAGS} ${ZLIB_CPPFLAGS} ${PTHREAD_CFLAGS} -Wall -Wno-unused-local-typedef
 AM_LDFLAGS = ${BOOST_LDFLAGS} ${BOOST_PROGRAM_OPTIONS_LIB} ${ZLIB_LDFLAGS} ${PTHREAD_LIBS}
 
+CXXOPTIMIZE = -ffast-math
+
 if PROFILE
-AM_CXXFLAGS += -pg -g -D_FILE_OFFSET_BITS=64
+CXXOPTIMIZE += -pg
+endif
+
+if VWBUG
+CXXOPTIMIZE += -g -O1
 else
-AM_CXXFLAGS += -O3 -fomit-frame-pointer -ffast-math -fno-strict-aliasing -D_FILE_OFFSET_BITS=64 -DNDEBUG 
+CXXOPTIMIZE += -O3 -fomit-frame-pointer -fno-strict-aliasing -DNDEBUG 
 endif
 
 if NITPICK
@@ -40,6 +46,8 @@ endif
 if CLANG_LIBCXX
 AM_CXXFLAGS += -stdlib=libc++
 endif
+
+AM_CXXFLAGS += $(CXXOPTIMIZE)
 
 vw_SOURCES = main.cc
 vw_CXXFLAGS = $(AM_CXXFLAGS)


### PR DESCRIPTION
Add tests for large file support, eliminating the hacky  _FILE_OFFSET_BITS=64 command line definition. Large file support is enabled on platforms where this is an option.

Disentangle profiling option from compiler optimization. Adds a new configure flag, "--enable-debug", that sets the compiler's optimization to "-g -O1". The default is the highly optimized compiler setting.

NOTE: Regenerate Makefile(s) after the pull request is merged for the default platform.