### PR TITLE
utl/vw-hypersearch: add --affix to options accepting integer-only

### DIFF
--- a/utl/vw-hypersearch
+++ b/utl/vw-hypersearch
@@ -474,6 +474,7 @@ sub is_integer_option($) {
     my $expects_integer =
         ($opt =~ qr{^-*
             bs?
+            |affix
             |autolink
             |batch_sz
             |bootstrap|B

--- a/vowpalwabbit/active.cc
+++ b/vowpalwabbit/active.cc
@@ -1,3 +1,4 @@
+#include <errno.h>
 #include "reductions.h"
 #include "rand48.h"
 #include "float.h"
@@ -96,7 +97,7 @@ float get_active_coin_bias(float k, float avg_loss, float g, float c0)
 	ssize_t len = ss.str().size();
 	ssize_t t = io_buf::write_file_or_socket(f, ss.str().c_str(), (unsigned int)len);
 	if (t != len)
-	cerr << "write error" << endl;
+	  cerr << "write error: " << strerror(errno) << endl;
       }
   }
   

--- a/vowpalwabbit/bs.cc
+++ b/vowpalwabbit/bs.cc
@@ -5,6 +5,7 @@ license as described in the file LICENSE.
  */
 #include <float.h>
 #include <math.h>
+#include <errno.h>
 #include <sstream>
 #include <numeric>
 #include <vector>
@@ -129,7 +130,7 @@ using namespace LEARNER;
       ssize_t len = ss.str().size();
       ssize_t t = io_buf::write_file_or_socket(f, ss.str().c_str(), (unsigned int)len);
       if (t != len)
-        cerr << "write error" << endl;
+        cerr << "write error: " << strerror(errno) << endl;
     }    
   }
 

--- a/vowpalwabbit/csoaa.cc
+++ b/vowpalwabbit/csoaa.cc
@@ -4,6 +4,7 @@ individual contributors. All rights reserved.  Released under a BSD (revised)
 license as described in the file LICENSE.
  */
 #include <float.h>
+#include <errno.h>
 
 #include "reductions.h"
 #include "v_hashmap.h"
@@ -500,7 +501,7 @@ namespace LabelDict {
       ssize_t t;
       t = io_buf::write_file_or_socket(f, temp, 1);
       if (t != 1)
-        std::cerr << "write error" << std::endl;
+        cerr << "write error: " << strerror(errno) << endl;
     }
   }
 

--- a/vowpalwabbit/global_data.cc
+++ b/vowpalwabbit/global_data.cc
@@ -5,6 +5,7 @@ license as described in the file LICENSE.
  */
 #include <stdio.h>
 #include <float.h>
+#include <errno.h>
 #include <iostream>
 #include <sstream>
 #include <math.h>
@@ -105,7 +106,7 @@ void print_result(int f, float res, float weight, v_array<char> tag)
       ssize_t t = io_buf::write_file_or_socket(f, ss.str().c_str(), (unsigned int)len);
       if (t != len)
         {
-          cerr << "write error" << endl;
+          cerr << "write error: " << strerror(errno) << endl;
         }
     }
 }
@@ -123,7 +124,7 @@ void print_raw_text(int f, string s, v_array<char> tag)
   ssize_t t = io_buf::write_file_or_socket(f, ss.str().c_str(), (unsigned int)len);
   if (t != len)
     {
-      cerr << "write error" << endl;
+      cerr << "write error: " << strerror(errno) << endl;
     }
 }
 
@@ -144,7 +145,7 @@ void print_lda_result(vw& all, int f, float* res, float weight, v_array<char> ta
       ssize_t t = io_buf::write_file_or_socket(f, ss.str().c_str(), (unsigned int)len);
 
       if (t != len)
-	cerr << "write error" << endl;
+        cerr << "write error: " << strerror(errno) << endl;
     }
 }
 

--- a/vowpalwabbit/topk.cc
+++ b/vowpalwabbit/topk.cc
@@ -49,7 +49,7 @@ void print_result(int f, priority_queue<scored_example, vector<scored_example>, 
       ssize_t t = write(f, ss.str().c_str(), (unsigned int)len);
 #endif
       if (t != len)
-        cerr << "write error" << endl;
+        cerr << "write error: " << strerror(errno) << endl;
     }    
 }
 


### PR DESCRIPTION
Was missing so vw barfs when presented with a floating point numbers inside --affix args.

Also unrelated enhancement for cryptic "write error" cases (just has a bunch of these in daemon mode which makes it hard to figure out root cause).