### PR TITLE
prefer_cxx_io

### DIFF
--- a/vowpalwabbit/cb_algs.cc
+++ b/vowpalwabbit/cb_algs.cc
@@ -303,15 +303,13 @@ using namespace CB;
   {
     if (all.sd->weighted_examples >= all.sd->dump_interval && !all.quiet && !all.bfgs)
       {
-        char label_buf[32];
+	std::string label_buf;
         if (is_test)
-          strcpy(label_buf," unknown");
+          label_buf = " unknown";
         else
-          sprintf(label_buf," known");
-	char pred_buf[32];
-	sprintf(pred_buf,"%8lu",(long unsigned int)ec.pred.multiclass);
+          label_buf = " known";
 
-	all.sd->print_update(all.holdout_set_off, all.current_pass, label_buf, pred_buf, 
+	all.sd->print_update(all.holdout_set_off, all.current_pass, label_buf, ec.pred.multiclass, 
 			     ec.num_features, all.progress_add, all.progress_arg);
       }
   }

--- a/vowpalwabbit/cost_sensitive.cc
+++ b/vowpalwabbit/cost_sensitive.cc
@@ -193,15 +193,13 @@ namespace COST_SENSITIVE {
 	    num_current_features += (*ecc)->num_features;
         }
 
-        char label_buf[32];
+	std::string label_buf;
         if (is_test)
-          strcpy(label_buf," unknown");
+          label_buf = " unknown";
         else
-          sprintf(label_buf," known");
-	char pred_buf[32];
-	sprintf(pred_buf,"%8lu",(long unsigned int)ec.pred.multiclass);
+          label_buf = " known";
 
-	all.sd->print_update(all.holdout_set_off, all.current_pass, label_buf, pred_buf, 
+	all.sd->print_update(all.holdout_set_off, all.current_pass, label_buf, ec.pred.multiclass, 
 			     num_current_features, all.progress_add, all.progress_arg);
       }
   }

--- a/vowpalwabbit/global_data.h
+++ b/vowpalwabbit/global_data.h
@@ -154,7 +154,19 @@ struct shared_data {
   double holdout_best_loss;
   double weighted_holdout_examples_since_last_pass;//reserved for best predictor selection
   double holdout_sum_loss_since_last_pass;
-  size_t holdout_best_pass; 
+  size_t holdout_best_pass;
+
+  // Column width, precision constants:
+  static const int col_avg_loss = 10;
+  static const int prec_avg_loss = 6;
+  static const int col_since_last = 10;
+  static const int prec_since_last = 6;
+  static const int col_example_counter = 11;
+  static const int col_example_weight = 12;
+  static const int prec_example_weight = 1;
+  static const int col_current_label = 8;
+  static const int col_current_predict = 8;
+  static const int col_current_features = 8;
 
   void update(bool test_example, float loss, float weight, size_t num_features)
   {
@@ -197,16 +209,17 @@ struct shared_data {
     if(!holdout_set_off && current_pass >= 1)
       {
 	if(holdout_sum_loss == 0. && weighted_holdout_examples == 0.)
-	  std::cerr << " unknown   ";
+	  std::cerr << std::setw(col_avg_loss) << std::left << " unknown";
 	else
-	  std::cerr << std::setw(10) << std::setprecision(6) << std::fixed << std::right
-		    << (holdout_sum_loss / weighted_holdout_examples)
-		    << " ";
+	  std::cerr << std::setw(col_avg_loss) << std::setprecision(prec_avg_loss) << std::fixed << std::right
+		    << (holdout_sum_loss / weighted_holdout_examples);
+
+	std::cerr << " ";
 
 	if(holdout_sum_loss_since_last_dump == 0. && weighted_holdout_examples_since_last_dump == 0.)
-	  std::cerr << " unknown  ";
+	  std::cerr << std::setw(col_since_last) << std::left << " unknown";
 	else
-	  std::cerr << std::setw(10) << std::setprecision(6) << std::fixed << std::right
+	  std::cerr << std::setw(col_since_last) << std::setprecision(prec_since_last) << std::fixed << std::right
 		    << (holdout_sum_loss_since_last_dump/weighted_holdout_examples_since_last_dump);
 	
 	weighted_holdout_examples_since_last_dump = 0;
@@ -216,23 +229,23 @@ struct shared_data {
       }
     else
       {
-	std::cerr << std::setw(10) << std::setprecision(6) << std::right << std::fixed
+	std::cerr << std::setw(col_avg_loss) << std::setprecision(prec_avg_loss) << std::right << std::fixed
 		  << (sum_loss / weighted_examples)
 		  << " "
-	          << std::setw(10) << std::setprecision(6) << std::right << std::fixed
+	          << std::setw(col_since_last) << std::setprecision(prec_avg_loss) << std::right << std::fixed
 		  << (sum_loss_since_last_dump / (weighted_examples - old_weighted_examples));
       }
 
     std::cerr << " "
-	      << std::setw(10) << std::right << example_number
+	      << std::setw(col_example_counter) << std::right << example_number
 	      << " "
-	      << std::setw(11) << std::setprecision(1) << std::right << weighted_examples
+	      << std::setw(col_example_weight) << std::setprecision(prec_example_weight) << std::right << weighted_examples
 	      << " "
-	      << std::setw(8) << std::right << label_buf
+	      << std::setw(col_current_label) << std::right << label_buf
 	      << " "
-	      << std::setw(8) << std::right << pred_buf
+	      << std::setw(col_current_predict) << std::right << pred_buf
 	      << " "
-	      << std::setw(8) << std::right << num_features;
+	      << std::setw(col_current_features) << std::right << num_features;
 
     if (holding_out)
 	std::cerr << " h";

--- a/vowpalwabbit/global_data.h
+++ b/vowpalwabbit/global_data.h
@@ -206,7 +206,8 @@ struct shared_data {
   {
     std::ostringstream label_buf, pred_buf;
 
-    label_buf << std::setw(col_current_label);
+    label_buf << std::setw(col_current_label)
+              << std::setfill(' ');
     if (label < FLT_MAX)
 	label_buf << std::setprecision(prec_current_label) << std::fixed << std::right << label;
     else
@@ -214,6 +215,7 @@ struct shared_data {
 
     pred_buf << std::setw(col_current_predict) << std::setprecision(prec_current_predict)
 	     << std::fixed << std::right
+             << std::setfill(' ')
 	     << prediction;
 
     print_update(holdout_set_off, current_pass, label_buf.str(), pred_buf.str(), num_features,
@@ -225,13 +227,16 @@ struct shared_data {
   {
     std::ostringstream label_buf, pred_buf;
 
-    label_buf << std::setw(col_current_label);
+    label_buf << std::setw(col_current_label)
+              << std::setfill(' ');
     if (label < INT_MAX)
 	label_buf << std::right << label;
     else
 	label_buf << std::left << " unknown";
 
-    pred_buf << std::setw(col_current_predict) << std::right << prediction;
+    pred_buf << std::setw(col_current_predict) << std::right 
+             << std::setfill(' ')
+             << prediction;
 
     print_update(holdout_set_off, current_pass, label_buf.str(), pred_buf.str(), num_features,
 		 progress_add, progress_arg);
@@ -242,7 +247,8 @@ struct shared_data {
   {
     std::ostringstream pred_buf;
 
-    pred_buf << std::setw(col_current_predict) << std::right << prediction;
+    pred_buf << std::setw(col_current_predict) << std::right << std::setfill(' ')
+             << prediction;
 
     print_update(holdout_set_off, current_pass, label, pred_buf.str(), num_features,
 		 progress_add, progress_arg);

--- a/vowpalwabbit/main.cc
+++ b/vowpalwabbit/main.cc
@@ -25,13 +25,36 @@ int main(int argc, char *argv[])
     
     if (!all.quiet && !all.bfgs && !all.searchstr)
         {
-        const char * header_fmt = "%-10s %-10s %10s %11s %8s %8s %8s\n";
-        fprintf(stderr, header_fmt,
-                "average", "since", "example", "example",
-                "current", "current", "current");
-        fprintf(stderr, header_fmt,
-                "loss", "last", "counter", "weight", "label", "predict", "features");
-        cerr.precision(5);
+	std::cerr << std::setw(10) << "average"
+		  << " "
+		  << std::setw(10) << "since"
+		  << " "
+		  << std::setw(10) << "example"
+		  << " "
+		  << std::setw(11) << "example"
+		  << " "
+		  << std::setw(8) << "current"
+		  << " "
+		  << std::setw(8) << "current"
+		  << " "
+		  << std::setw(8) << "current"
+		  << std::endl;
+	std::cerr << std::setw(10) << "loss"
+		  << " "
+		  << std::setw(10) << "last"
+		  << " "
+		  << std::setw(10) << "counter"
+		  << " "
+		  << std::setw(11) << "weight"
+		  << " "
+		  << std::setw(8) << "label"
+		  << " "
+		  << std::setw(8) << "predict"
+		  << " "
+		  << std::setw(8) << "features"
+		  << std::endl;
+
+	std::cerr.precision(5);
         }
 
     VW::start_parser(all);

--- a/vowpalwabbit/main.cc
+++ b/vowpalwabbit/main.cc
@@ -25,36 +25,34 @@ int main(int argc, char *argv[])
     
     if (!all.quiet && !all.bfgs && !all.searchstr)
         {
-	std::cerr << std::setw(10) << "average"
-		  << " "
-		  << std::setw(10) << "since"
-		  << " "
-		  << std::setw(10) << "example"
-		  << " "
-		  << std::setw(11) << "example"
-		  << " "
-		  << std::setw(8) << "current"
-		  << " "
-		  << std::setw(8) << "current"
-		  << " "
-		  << std::setw(8) << "current"
-		  << std::endl;
-	std::cerr << std::setw(10) << "loss"
-		  << " "
-		  << std::setw(10) << "last"
-		  << " "
-		  << std::setw(10) << "counter"
-		  << " "
-		  << std::setw(11) << "weight"
-		  << " "
-		  << std::setw(8) << "label"
-		  << " "
-		  << std::setw(8) << "predict"
-		  << " "
-		  << std::setw(8) << "features"
-		  << std::endl;
-
-	std::cerr.precision(5);
+        	std::cerr << std::setw(shared_data::col_avg_loss) << "average"
+        		  << " "
+        		  << std::setw(shared_data::col_since_last) << "since"
+        		  << " "
+        		  << std::setw(shared_data::col_example_counter) << "example"
+        		  << " "
+        		  << std::setw(shared_data::col_example_weight) << "example"
+        		  << " "
+        		  << std::setw(shared_data::col_current_label) << "current"
+        		  << " "
+        		  << std::setw(shared_data::col_current_predict) << "current"
+        		  << " "
+        		  << std::setw(shared_data::col_current_features) << "current"
+        		  << std::endl;
+        	std::cerr << std::setw(shared_data::col_avg_loss) << "loss"
+        		  << " "
+        		  << std::setw(shared_data::col_since_last) << "last"
+        		  << " "
+        		  << std::setw(shared_data::col_example_counter) << "counter"
+        		  << " "
+        		  << std::setw(shared_data::col_example_weight) << "weight"
+        		  << " "
+        		  << std::setw(shared_data::col_current_label) << "label"
+        		  << " "
+        		  << std::setw(shared_data::col_current_predict) << "predict"
+        		  << " "
+        		  << std::setw(shared_data::col_current_features) << "features"
+        		  << std::endl;
         }
 
     VW::start_parser(all);

--- a/vowpalwabbit/main.cc
+++ b/vowpalwabbit/main.cc
@@ -25,10 +25,12 @@ int main(int argc, char *argv[])
     
     if (!all.quiet && !all.bfgs && !all.searchstr)
         {
-        	std::cerr << std::setw(shared_data::col_avg_loss) << "average"
+        	std::cerr << std::left
+        	          << std::setw(shared_data::col_avg_loss) << std::left << "average"
         		  << " "
-        		  << std::setw(shared_data::col_since_last) << "since"
+        		  << std::setw(shared_data::col_since_last) << std::left << "since"
         		  << " "
+			  << std::right
         		  << std::setw(shared_data::col_example_counter) << "example"
         		  << " "
         		  << std::setw(shared_data::col_example_weight) << "example"
@@ -39,10 +41,12 @@ int main(int argc, char *argv[])
         		  << " "
         		  << std::setw(shared_data::col_current_features) << "current"
         		  << std::endl;
-        	std::cerr << std::setw(shared_data::col_avg_loss) << "loss"
+        	std::cerr << std::left
+        	          << std::setw(shared_data::col_avg_loss) << std::left << "loss"
         		  << " "
-        		  << std::setw(shared_data::col_since_last) << "last"
+        		  << std::setw(shared_data::col_since_last) << std::left << "last"
         		  << " "
+			  << std::right
         		  << std::setw(shared_data::col_example_counter) << "counter"
         		  << " "
         		  << std::setw(shared_data::col_example_weight) << "weight"

--- a/vowpalwabbit/multiclass.cc
+++ b/vowpalwabbit/multiclass.cc
@@ -93,16 +93,7 @@ namespace MULTICLASS {
   {
     if (all.sd->weighted_examples >= all.sd->dump_interval && !all.quiet && !all.bfgs)
       {
-        label_t ld = ec.l.multi;
-        char label_buf[32];
-        if (ld.label == INT_MAX)
-          strcpy(label_buf," unknown");
-        else
-          sprintf(label_buf,"%8ld",(long int)ld.label);
-	char pred_buf[32];
-	sprintf(pred_buf,"%8lu",(long unsigned int)ec.pred.multiclass);
-
-	all.sd->print_update(all.holdout_set_off, all.current_pass, label_buf, pred_buf, 
+	all.sd->print_update(all.holdout_set_off, all.current_pass, ec.l.multi.label, ec.pred.multiclass,
 			     ec.num_features, all.progress_add, all.progress_arg);
       }
   }

--- a/vowpalwabbit/simple_label.cc
+++ b/vowpalwabbit/simple_label.cc
@@ -106,16 +106,7 @@ void print_update(vw& all, example& ec)
 {
   if (all.sd->weighted_examples >= all.sd->dump_interval && !all.quiet && !all.bfgs)
     {
-      label_data ld = ec.l.simple;
-      char label_buf[32];
-      if (ld.label == FLT_MAX)
-	strcpy(label_buf," unknown");
-      else
-	sprintf(label_buf,"%8.4f",ld.label);
-      char pred_buf[32];
-      sprintf(pred_buf,"%8.4f",ec.pred.scalar);
-      
-      all.sd->print_update(all.holdout_set_off, all.current_pass, label_buf, pred_buf, 
+      all.sd->print_update(all.holdout_set_off, all.current_pass, ec.l.simple.label, ec.pred.scalar, 
 			   ec.num_features, all.progress_add, all.progress_arg);
     }
 }


### PR DESCRIPTION
Remove some vestiges of C printf formatting. Reduces warnings on non-x86
platforms, like ARM, where size_t isn't necessarily unsigned long and formatting
warnings are enabled.