### PR TITLE
assume_stricter_alignment

### DIFF
--- a/vowpalwabbit/cache.cc
+++ b/vowpalwabbit/cache.cc
@@ -148,9 +148,9 @@ void output_features(io_buf& cache, unsigned char index, feature* begin, feature
   size_t storage = (end-begin) * int_size;
   for (feature* i = begin; i != end; i++)
     if (i->x != 1. && i->x != -1.)
-      storage+=sizeof(float);
+      storage += sizeof(float);
   buf_write(cache, c, sizeof(index) + storage + sizeof(size_t));
-  *(unsigned char*)c = index;
+  *reinterpret_cast<unsigned char*>(c) = index;
   c += sizeof(index);
 
   char *storage_size_loc = c;
@@ -170,8 +170,8 @@ void output_features(io_buf& cache, unsigned char index, feature* begin, feature
 	c = run_len_encode(c, diff | neg_1);
       else {
 	c = run_len_encode(c, diff | general);
-	*(float *)c = i->x;
-	c += sizeof(float);
+	memcpy(c, &i->x, sizeof(i->x));
+	c += sizeof(i->x);
       }
     }
   cache.set(c);

--- a/vowpalwabbit/multiclass.cc
+++ b/vowpalwabbit/multiclass.cc
@@ -1,4 +1,5 @@
-#include <limits.h>
+#include <cstring>
+#include <climits>
 #include "global_data.h"
 #include "vw.h"
 
@@ -6,9 +7,9 @@ namespace MULTICLASS {
 
   char* bufread_label(label_t* ld, char* c)
   {
-    ld->label = *(uint32_t *)c;
+    memcpy(&ld->label, c, sizeof(ld->label));
     c += sizeof(ld->label);
-    ld->weight = *(float *)c;
+    memcpy(&ld->weight, c, sizeof(ld->weight));
     c += sizeof(ld->weight);
     return c;
   }
@@ -33,9 +34,9 @@ namespace MULTICLASS {
   
   char* bufcache_label(label_t* ld, char* c)
   {
-    *(uint32_t *)c = ld->label;
+    memcpy(c, &ld->label, sizeof(ld->label));
     c += sizeof(ld->label);
-    *(float *)c = ld->weight;
+    memcpy(c, &ld->weight, sizeof(ld->weight));
     c += sizeof(ld->weight);
     return c;
   }

--- a/vowpalwabbit/simple_label.cc
+++ b/vowpalwabbit/simple_label.cc
@@ -1,3 +1,4 @@
+#include <cstring>
 #include <float.h>
 #include <math.h>
 #include <stdio.h>
@@ -10,11 +11,11 @@ using namespace std;
 
 char* bufread_simple_label(shared_data* sd, label_data* ld, char* c)
 {
-  ld->label = *(float *)c;
+  memcpy(&ld->label, c, sizeof(ld->label));
   c += sizeof(ld->label);
-  ld->weight = *(float *)c;
+  memcpy(&ld->weight, c, sizeof(ld->weight));
   c += sizeof(ld->weight);
-  ld->initial = *(float *)c;
+  memcpy(&ld->initial, c, sizeof(ld->initial));
   c += sizeof(ld->initial);
 
   count_label(ld->label);
@@ -41,11 +42,11 @@ float get_weight(void* v)
 
 char* bufcache_simple_label(label_data* ld, char* c)
 {
-  *(float *)c = ld->label;
+  memcpy(c, &ld->label, sizeof(ld->label));
   c += sizeof(ld->label);
-  *(float *)c = ld->weight;
+  memcpy(c, &ld->weight, sizeof(ld->weight));
   c += sizeof(ld->weight);
-  *(float *)c = ld->initial;
+  memcpy(c, &ld->initial, sizeof(ld->initial));
   c += sizeof(ld->initial);
   return c;
 }


### PR DESCRIPTION
Don't assume x86-like lax alignment or bus errors occur. Use memcpy() to
ensure unaligned data is copied correctly on all platforms. (Found on ARM).