### PR TITLE
arm_neon_simd

### DIFF
--- a/vowpalwabbit/kernel_svm.cc
+++ b/vowpalwabbit/kernel_svm.cc
@@ -15,10 +15,6 @@ license as described in the file LICENSE.
 #include <stdio.h>
 #include <assert.h>
 
-#if defined(__SSE2__) && !defined(VW_LDA_NO_SSE)
-#include <xmmintrin.h>
-#endif
-
 #include "parse_example.h"
 #include "constant.h"
 #include "gd.h"

--- a/vowpalwabbit/lda_core.cc
+++ b/vowpalwabbit/lda_core.cc
@@ -128,7 +128,7 @@ fastdigamma (float x)
 #define mydigamma fastdigamma
 #define mylgamma fastlgamma
 
-#if defined(__SSE2__) && !defined(VW_LDA_NO_SSE)
+#if defined(__SSE2__) && !defined(VW_NO_INLINE_SIMD)
 
 #include <emmintrin.h>
 


### PR DESCRIPTION
Consolidate SIMD used in gd.cc to unify the different implementations of inverse square root. Add ARM NEON implementation.

Rename: VW_LDA_NO_SSE2 -> VW_NO_INLINE_SIMD (i.e., -DVW_NO_INLINE_SIMD on the compiler's command line to disable SIMD, SSE2 or NEON).

NOTE: "static inline" tells g++ and clang++ that InvSqrt() is a leaf function, so it can be aggressively inlined.