### PR TITLE
Makefile: 'make test' depends on vw and library_example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ endif
 
 .FORCE:
 
-test: .FORCE
+test: .FORCE vw library_example
 	@echo "vw running test-suite..."
 	(cd test && ./RunTests -d -fe -E 0.001 ../vowpalwabbit/vw ../vowpalwabbit/vw)
 

--- a/test/daemon-test.sh
+++ b/test/daemon-test.sh
@@ -26,8 +26,13 @@ NETCAT=`which netcat`
 if [ -x "$NETCAT" ]; then
     : cool found netcat at: $NETCAT
 else
-    echo "$NAME: can not find 'netcat' in $PATH - sorry"
-    exit 1
+    NETCAT=`which nc`
+    if [ -x "$NETCAT" ]; then
+        : "no netcat but found 'nc' at: $NETCAT"
+    else
+        echo "$NAME: can not find 'netcat' not 'nc' in $PATH - sorry"
+        exit 1
+    fi
 fi
 
 # -- and pkill


### PR DESCRIPTION
This should help those who run `make test` and fail because they are missing `library/ezexample_predict`

Also added a fix for `daemon-test.sh` based on the Fedora report where `netcat` is missing but `nc` exists.  They seem to be compatible for simple usage.