### PR TITLE
prefer_nullptr

### DIFF
--- a/vowpalwabbit/active.cc
+++ b/vowpalwabbit/active.cc
@@ -128,7 +128,7 @@ float get_active_coin_bias(float k, float avg_loss, float g, float c0)
   
 base_learner* active_setup(vw& all)
 {//parse and set arguments
-  if(missing_option(all, false, "active", "enable active learning")) return NULL;
+  if(missing_option(all, false, "active", "enable active learning")) return nullptr;
   new_options(all, "Active Learning options")
     ("simulation", "active learning simulation mode")
     ("mellowness", po::value<float>(), "active learning mellowness parameter c_0. Default 8");

--- a/vowpalwabbit/active_interactor.cc
+++ b/vowpalwabbit/active_interactor.cc
@@ -26,7 +26,7 @@ int open_socket(const char* host, unsigned short port)
   hostent* he;
   he = gethostbyname(host);
 
-  if (he == NULL)
+  if (he == nullptr)
     {
       cerr << "gethostbyname(" << host << "): " << strerror(errno) << endl;
       throw exception();
@@ -111,7 +111,7 @@ int main(int argc, char* argv[]){
         ttag=strsep(&toks," ");
         tag=ttag?string(ttag):string("'empty");
         itok=strsep(&toks,"\n");
-        if(itok==NULL || itok[0]=='\0'){
+        if(itok==nullptr || itok[0]=='\0'){
             continue;
         }
 

--- a/vowpalwabbit/allreduce.cc
+++ b/vowpalwabbit/allreduce.cc
@@ -46,7 +46,7 @@ socket_t sock_connect(const uint32_t ip, const int port) {
 
   {
     char dotted_quad[INET_ADDRSTRLEN];
-    if (NULL == inet_ntop(AF_INET, &(far_end.sin_addr), dotted_quad, INET_ADDRSTRLEN)) {
+    if (nullptr == inet_ntop(AF_INET, &(far_end.sin_addr), dotted_quad, INET_ADDRSTRLEN)) {
       cerr << "inet_ntop: " << strerror(errno) << endl;
       throw exception();
     }
@@ -113,7 +113,7 @@ void all_reduce_init(const string master_location, const size_t unique_id, const
 
   struct hostent* master = gethostbyname(master_location.c_str());
 
-  if (master == NULL) {
+  if (master == nullptr) {
     cerr << "gethostbyname(" << master_location << "): " << strerror(errno) << endl;
     throw exception();
   }
@@ -201,7 +201,7 @@ void all_reduce_init(const string master_location, const size_t unique_id, const
     cerr << "read parent_ip failed!" << endl;
   else {
     char dotted_quad[INET_ADDRSTRLEN];
-    if (NULL == inet_ntop(AF_INET, (char*)&parent_ip, dotted_quad, INET_ADDRSTRLEN)) {
+    if (nullptr == inet_ntop(AF_INET, (char*)&parent_ip, dotted_quad, INET_ADDRSTRLEN)) {
       cerr << "read parent_ip=" << parent_ip << "(inet_ntop: " << strerror(errno) << ")" << endl;
     } else
       cerr << "read parent_ip=" << dotted_quad << endl;

--- a/vowpalwabbit/allreduce.h
+++ b/vowpalwabbit/allreduce.h
@@ -107,7 +107,7 @@ template <class T, void (*f)(T&, const T&)>void reduce(char* buffer, const size_
       if(parent_sent_pos >= n && child_read_pos[0] >= n && child_read_pos[1] >= n) break;
 
       if(child_read_pos[0] < n || child_read_pos[1] < n) {
-	if (max_fd > 0 && select((int)max_fd,&fds,NULL, NULL, NULL) == -1)
+	if (max_fd > 0 && select((int)max_fd,&fds, nullptr, nullptr, nullptr) == -1)
 	  {
 	    cerr << "select: " << strerror(errno) << endl;
 	    throw exception();

--- a/vowpalwabbit/autolink.cc
+++ b/vowpalwabbit/autolink.cc
@@ -38,7 +38,7 @@ void predict_or_learn(autolink& b, LEARNER::base_learner& base, example& ec)
 LEARNER::base_learner* autolink_setup(vw& all)
 {
   if (missing_option<size_t, true>(all, "autolink", "create link function with polynomial d"))
-    return NULL;
+    return nullptr;
   
   autolink& data = calloc_or_die<autolink>();
   data.d = (uint32_t)all.vm["autolink"].as<size_t>();

--- a/vowpalwabbit/beam.h
+++ b/vowpalwabbit/beam.h
@@ -69,10 +69,10 @@ inline int compare_on_hash_then_cost(const void *void_a, const void *void_b) {
 
   //  static size_t NUM_RECOMB_BUCKETS = 10231;
   
-  bool (*is_equivalent)(T*,T*);  // test if two items are equivalent; NULL means don't do hypothesis recombination
+  bool (*is_equivalent)(T*,T*);  // test if two items are equivalent; nullptr means don't do hypothesis recombination
   
  public:
-  beam(size_t beam_size, float prune_coeff=FLT_MAX, bool (*test_equiv)(T*,T*)=NULL, bool kbest=false)
+  beam(size_t beam_size, float prune_coeff=FLT_MAX, bool (*test_equiv)(T*,T*)=nullptr, bool kbest=false)
       : beam_size(beam_size)
       , pruning_coefficient(prune_coeff)
       , do_kbest(kbest)
@@ -82,7 +82,7 @@ inline int compare_on_hash_then_cost(const void *void_a, const void *void_b) {
     worst_cost  = -FLT_MAX;
     best_cost   =  FLT_MAX;
     prune_if_gt =  FLT_MAX;
-    best_cost_data = NULL;
+    best_cost_data = nullptr;
     A = v_init<beam_element<T>>();
     if (beam_size <= BEAM_CONSTANT_SIZE)
       A.resize(beam_size, true);
@@ -106,7 +106,7 @@ inline int compare_on_hash_then_cost(const void *void_a, const void *void_b) {
     //       // we are more expensive, so ignore
     //       we_were_worse = true;
     //       beam_element<T> * be = new beam_element<T>;
-    //       be->hash = hash; be->cost = cost; be->data = data; be->active = true; be->recombined = false; be->recomb_friends = NULL;
+    //       be->hash = hash; be->cost = cost; be->data = data; be->active = true; be->recombined = false; be->recomb_friends = nullptr;
     //       add_recomb_friend(recomb_buckets[i][equiv_pos], be);
     //   }
     // }
@@ -130,7 +130,7 @@ inline int compare_on_hash_then_cost(const void *void_a, const void *void_b) {
       A[worst_idx].data = data;
       A[worst_idx].active = true;
       // A[worst_idx].recombined = false;
-      // A[worst_idx].recomb_friends = NULL;  // TODO: free it if it isn't NULL
+      // A[worst_idx].recomb_friends = nullptr;  // TODO: free it if it isn't nullptr
       worst_cost = cost;
     } else {
       beam_element<T> be;
@@ -139,7 +139,7 @@ inline int compare_on_hash_then_cost(const void *void_a, const void *void_b) {
       be.data = data;
       be.active = true;
       // be.recombined = false;
-      // be.recomb_friends = NULL;
+      // be.recomb_friends = nullptr;
 
       A.push_back(be);
       count++;
@@ -158,19 +158,19 @@ inline int compare_on_hash_then_cost(const void *void_a, const void *void_b) {
 
   beam_element<T>* pop_best_item() {
     if (count == 0)
-      return NULL;
+      return nullptr;
 
-    beam_element<T> *ret = NULL;
+    beam_element<T> *ret = nullptr;
     float next_best_cost = FLT_MAX;
     for (beam_element<T> *el = A.begin; el!=A.end; el++)
-      if ((ret == NULL) && el->active && (el->cost <= best_cost))
+      if ((ret == nullptr) && el->active && (el->cost <= best_cost))
         ret = el;
       else if (el->active && (el->cost < next_best_cost)) {
         next_best_cost = el->cost;
         best_cost_data = el->data;
       }
 
-    if (ret != NULL) {
+    if (ret != nullptr) {
       best_cost = next_best_cost;
       prune_if_gt = max(1.f, best_cost) * pruning_coefficient;
       ret->active = false;
@@ -178,7 +178,7 @@ inline int compare_on_hash_then_cost(const void *void_a, const void *void_b) {
     } else {
       best_cost = FLT_MAX;
       prune_if_gt = FLT_MAX;
-      best_cost_data = NULL;
+      best_cost_data = nullptr;
     }
     
     return ret;
@@ -211,7 +211,7 @@ inline int compare_on_hash_then_cost(const void *void_a, const void *void_b) {
     }
   }
   
-  void compact(void (*free_data)(T*)=NULL) {
+  void compact(void (*free_data)(T*)=nullptr) {
     if (is_equivalent) do_recombination();
     qsort(A.begin, A.size(), sizeof(beam_element<T>), compare_on_cost); // TODO: quick select
 
@@ -233,12 +233,12 @@ inline int compare_on_hash_then_cost(const void *void_a, const void *void_b) {
     best_cost_data = A[0].data;
   }
 
-  void maybe_compact(void (*free_data)(T*)=NULL) {
+  void maybe_compact(void (*free_data)(T*)=nullptr) {
     if (count >= beam_size * 10)
       compact(free_data);
   }
 
-  void erase(void (*free_data)(T*)=NULL) {
+  void erase(void (*free_data)(T*)=nullptr) {
     if (free_data)
       for (beam_element<T> * be = A.begin; be != A.end; ++be)
         free_data(be->data);
@@ -247,7 +247,7 @@ inline int compare_on_hash_then_cost(const void *void_a, const void *void_b) {
     worst_cost  = -FLT_MAX;
     best_cost   =  FLT_MAX;
     prune_if_gt =  FLT_MAX;
-    best_cost_data = NULL;
+    best_cost_data = nullptr;
   }
 
   ~beam() {
@@ -264,14 +264,14 @@ inline int compare_on_hash_then_cost(const void *void_a, const void *void_b) {
  private:
   // void add_recomb_friend(beam_element<T> *better, beam_element<T> *worse) {
   //   assert( better->cost <= worse->cost );
-  //   if (better->recomb_friends == NULL) {
-  //     if (worse->recomb_friends != NULL) {
+  //   if (better->recomb_friends == nullptr) {
+  //     if (worse->recomb_friends != nullptr) {
   //       better->recomb_friends = worse->recomb_friends;
-  //       worse->recomb_friends = NULL;
+  //       worse->recomb_friends = nullptr;
   //     } else
   //       better->recomb_friends = new vector<beam_element<T>*>;
   //   } else {
-  //     assert(worse->recomb_friends == NULL);
+  //     assert(worse->recomb_friends == nullptr);
   //   }
   // }
 };

--- a/vowpalwabbit/best_constant.cc
+++ b/vowpalwabbit/best_constant.cc
@@ -7,7 +7,7 @@ float second_observed_label = FLT_MAX;
 bool get_best_constant(vw& all, float& best_constant, float& best_constant_loss)
 {
     if (    first_observed_label == FLT_MAX || // no non-test labels observed or function was never called
-            (all.loss == NULL) || (all.sd == NULL)) return false;
+            (all.loss == nullptr) || (all.sd == nullptr)) return false;
 
     float label1 = first_observed_label; // observed labels might be inside [sd->Min_label, sd->Max_label], so can't use Min/Max
     float label2 = (second_observed_label == FLT_MAX)?0:second_observed_label; // if only one label observed, second might be 0

--- a/vowpalwabbit/bfgs.cc
+++ b/vowpalwabbit/bfgs.cc
@@ -210,7 +210,7 @@ double regularizer_direction_magnitude(vw& all, bfgs& b, float regularizer)
   uint32_t length = 1 << all.num_bits;
   size_t stride_shift = all.reg.stride_shift;
   weight* weights = all.reg.weight_vector;
-  if (b.regularizers == NULL)
+  if (b.regularizers == nullptr)
     for(uint32_t i = 0; i < length; i++)
       ret += regularizer*weights[(i << stride_shift)+W_DIR]*weights[(i << stride_shift)+W_DIR];
   else
@@ -414,7 +414,7 @@ double add_regularization(vw& all, bfgs& b, float regularization)
   uint32_t length = 1 << all.num_bits;
   size_t stride_shift = all.reg.stride_shift;
   weight* weights = all.reg.weight_vector;
-  if (b.regularizers == NULL)
+  if (b.regularizers == nullptr)
     {
       for(uint32_t i = 0; i < length; i++) {
 	weights[(i << stride_shift)+W_GT] += regularization*weights[i << stride_shift];
@@ -440,7 +440,7 @@ void finalize_preconditioner(vw& all, bfgs& b, float regularization)
   weight* weights = all.reg.weight_vector;
   float max_hessian = 0.f;
 
-  if (b.regularizers == NULL)
+  if (b.regularizers == nullptr)
     for(uint32_t i = 0; i < length; i++) {
       weights[stride*i+W_COND] += regularization;
 	  if (weights[stride*i+W_COND] > max_hessian)
@@ -470,11 +470,11 @@ void preconditioner_to_regularizer(vw& all, bfgs& b, float regularization)
   uint32_t length = 1 << all.num_bits;
   size_t stride = 1 << all.reg.stride_shift;
   weight* weights = all.reg.weight_vector;
-  if (b.regularizers == NULL)
+  if (b.regularizers == nullptr)
     {
       b.regularizers = calloc_or_die<weight>(2*length);
       
-      if (b.regularizers == NULL)
+      if (b.regularizers == nullptr)
 	{
 	  cerr << all.program_name << ": Failed to allocate weight array: try decreasing -b <bits>" << endl;
 	  throw exception();
@@ -903,7 +903,7 @@ void save_load(bfgs& b, io_buf& model_file, bool read, bool text)
       if (all->per_feature_regularizer_input != "")
 	{
 	  b.regularizers = calloc_or_die<weight>(2*length);
-	  if (b.regularizers == NULL)
+	  if (b.regularizers == nullptr)
 	    {
 	      cerr << all->program_name << ": Failed to allocate regularizers array: try decreasing -b <bits>" << endl;
 	      throw exception();
@@ -932,7 +932,7 @@ void save_load(bfgs& b, io_buf& model_file, bool read, bool text)
 	  cerr.precision(5);
 	}
       
-      if (b.regularizers != NULL)
+      if (b.regularizers != nullptr)
 	all->l2_lambda = 1; // To make sure we are adding the regularization
       b.output_regularizer =  (all->per_feature_regularizer_output != "" || all->per_feature_regularizer_text != "");
       reset_state(*all, b, false);
@@ -965,7 +965,7 @@ base_learner* bfgs_setup(vw& all)
 {
   if (missing_option(all, false, "bfgs", "use bfgs optimization") &&
       missing_option(all, false, "conjugate_gradient", "use conjugate gradient based optimization"))
-    return NULL;
+    return nullptr;
   new_options(all, "LBFGS options")
     ("hessian_on", "use second derivative in line search")
     ("mem", po::value<uint32_t>()->default_value(15), "memory in bfgs")

--- a/vowpalwabbit/binary.cc
+++ b/vowpalwabbit/binary.cc
@@ -28,10 +28,10 @@ void predict_or_learn(char&, LEARNER::base_learner& base, example& ec) {
 LEARNER::base_learner* binary_setup(vw& all)
 {
   if (missing_option(all, false, "binary", "report loss as binary classification on -1,1"))
-    return NULL;
+    return nullptr;
   
   LEARNER::learner<char>& ret = 
-    LEARNER::init_learner<char>(NULL, setup_base(all), 
+    LEARNER::init_learner<char>(nullptr, setup_base(all), 
 				predict_or_learn<true>, predict_or_learn<false>);
   return make_base(ret);
 }

--- a/vowpalwabbit/bs.cc
+++ b/vowpalwabbit/bs.cc
@@ -220,7 +220,7 @@ using namespace LEARNER;
 base_learner* bs_setup(vw& all)
 {
   if (missing_option<size_t, true>(all, "bootstrap", "k-way bootstrap by online importance resampling"))
-    return NULL;
+    return nullptr;
   new_options(all, "Bootstrap options")("bs_type", po::value<string>(), 
 					"prediction type {mean,vote}");    
   add_options(all);

--- a/vowpalwabbit/cb_algs.cc
+++ b/vowpalwabbit/cb_algs.cc
@@ -57,7 +57,7 @@ using namespace CB;
   inline bool observed_cost(cb_class* cl)
   {
     //cost observed for this action if it has non zero probability and cost != FLT_MAX
-    return (cl != NULL && cl->cost != FLT_MAX && cl->probability > .0);
+    return (cl != nullptr && cl->cost != FLT_MAX && cl->probability > .0);
   }
   
   cb_class* get_observed_cost(CB::label& ld)
@@ -65,7 +65,7 @@ using namespace CB;
     for (cb_class *cl = ld.costs.begin; cl != ld.costs.end; cl++)
       if( observed_cost(cl) ) 
         return cl;
-    return NULL;
+    return nullptr;
   }
 
   void gen_cs_example_ips(cb& c, example& ec, CB::label& ld, COST_SENSITIVE::label& cs_ld)
@@ -82,7 +82,7 @@ using namespace CB;
         wc.class_index = i;
         wc.partial_prediction = 0.;
         wc.wap_value = 0.;
-        if( c.known_cost != NULL && i == c.known_cost->action )
+        if( c.known_cost != nullptr && i == c.known_cost->action )
         {
           wc.x = c.known_cost->cost / c.known_cost->probability; //use importance weighted cost for observed action, 0 otherwise 
           //ips can be thought as the doubly robust method with a fixed regressor that predicts 0 costs for everything
@@ -106,7 +106,7 @@ using namespace CB;
         wc.class_index = cl->action;
         wc.partial_prediction = 0.;
         wc.wap_value = 0.;
-        if( c.known_cost != NULL && cl->action == c.known_cost->action )
+        if( c.known_cost != nullptr && cl->action == c.known_cost->action )
         {
           wc.x = c.known_cost->cost / c.known_cost->probability; //use importance weighted cost for observed action, 0 otherwise 
 
@@ -153,7 +153,7 @@ using namespace CB;
         wc.partial_prediction = 0.;
         wc.wap_value = 0.;
 
-        if( c.known_cost != NULL && c.known_cost->action == i ) {
+        if( c.known_cost != nullptr && c.known_cost->action == i ) {
           c.nb_ex_regressors++;
           c.avg_loss_regressors += (1.0f/c.nb_ex_regressors)*( (c.known_cost->cost - wc.x)*(c.known_cost->cost - wc.x) - c.avg_loss_regressors );
           c.last_pred_reg = wc.x;
@@ -182,7 +182,7 @@ using namespace CB;
         wc.partial_prediction = 0.;
         wc.wap_value = 0.;
 
-        if( c.known_cost != NULL && c.known_cost->action == cl->action ) {
+        if( c.known_cost != nullptr && c.known_cost->action == cl->action ) {
           c.nb_ex_regressors++;
           c.avg_loss_regressors += (1.0f/c.nb_ex_regressors)*( (c.known_cost->cost - wc.x)*(c.known_cost->cost - wc.x) - c.avg_loss_regressors );
           c.last_pred_reg = wc.x;
@@ -209,7 +209,7 @@ using namespace CB;
     wc.wap_value = 0.;
     
     //add correction if we observed cost for this action and regressor is wrong
-    if( c.known_cost != NULL && c.known_cost->action == label ) {
+    if( c.known_cost != nullptr && c.known_cost->action == label ) {
       c.nb_ex_regressors++;
       c.avg_loss_regressors += (1.0f/c.nb_ex_regressors)*( (c.known_cost->cost - wc.x)*(c.known_cost->cost - wc.x) - c.avg_loss_regressors );
       c.last_pred_reg = wc.x;
@@ -244,7 +244,7 @@ using namespace CB;
     CB::label ld = ec.l.cb;
 
     c.known_cost = get_observed_cost(ld);
-    if (c.known_cost != NULL && (c.known_cost->action < 1 || c.known_cost->action > c.num_actions))
+    if (c.known_cost != nullptr && (c.known_cost->action < 1 || c.known_cost->action > c.num_actions))
       cerr << "invalid action: " << c.known_cost->action << endl;
     //generate a cost-sensitive example to update classifiers
     switch(c.cb_type)
@@ -367,7 +367,7 @@ using namespace CB;
   base_learner* cb_algs_setup(vw& all)
   {
     if (missing_option<size_t, true>(all, "cb", "Use contextual bandit learning with <k> costs"))
-      return NULL;
+      return nullptr;
     new_options(all, "CB options")
       ("cb_type", po::value<string>(), "contextual bandit method to use in {ips,dm,dr}")
       ("eval", "Evaluate a policy rather than optimizing.");

--- a/vowpalwabbit/cb_algs.h
+++ b/vowpalwabbit/cb_algs.h
@@ -15,7 +15,7 @@ namespace CB_ALGS {
 
     label_data simple_temp;
     simple_temp.initial = 0.;
-    if (known_cost != NULL && index == known_cost->action)
+    if (known_cost != nullptr && index == known_cost->action)
       {
 	simple_temp.label = known_cost->cost;
 	simple_temp.weight = 1.;

--- a/vowpalwabbit/cbify.cc
+++ b/vowpalwabbit/cbify.cc
@@ -335,7 +335,7 @@ void predict_or_learn_bag(cbify& data, base_learner& base, example& ec)
    ec.l.multi = ld;
  }
   
-template<class T> inline void delete_it(T* p) { if (p != NULL) delete p; } 
+template<class T> inline void delete_it(T* p) { if (p != nullptr) delete p; } 
 
   void finish(cbify& data)
   { CB::cb_label.delete_label(&data.cb_label);
@@ -348,7 +348,7 @@ template<class T> inline void delete_it(T* p) { if (p != NULL) delete p; }
     delete_it(data.generic_explorer);
     delete_it(data.mwt_explorer);
     delete_it(data.recorder);
-    if (data.cover != NULL)
+    if (data.cover != nullptr)
       {
 	data.cover->predictions.delete_v();
 	data.cover->probabilities.delete_v();
@@ -361,7 +361,7 @@ template<class T> inline void delete_it(T* p) { if (p != NULL) delete p; }
   base_learner* cbify_setup(vw& all)
   {//parse and set arguments
     if (missing_option<size_t, true>(all, "cbify", "Convert multiclass on <k> classes into a contextual bandit problem"))
-      return NULL;
+      return nullptr;
     new_options(all, "CBIFY options")
       ("first", po::value<size_t>(), "tau-first exploration")
       ("epsilon",po::value<float>() ,"epsilon-greedy exploration")

--- a/vowpalwabbit/comp_io.h
+++ b/vowpalwabbit/comp_io.h
@@ -15,7 +15,7 @@ public:
   vector<gzFile> gz_files;
 
   virtual int open_file(const char* name, bool stdin_off, int flag=READ){
-    gzFile fil=NULL;
+    gzFile fil=nullptr;
     int ret = -1;
     switch(flag){
     case READ:
@@ -27,7 +27,7 @@ public:
 #else
        fil = gzdopen(fileno(stdin), "rb");
 #endif
-       if(fil!=NULL){
+       if(fil!=nullptr){
 	 gz_files.push_back(fil);
 	 ret = (int)gz_files.size()-1;
 	 files.push_back(ret);
@@ -36,7 +36,7 @@ public:
 
     case WRITE:
       fil = gzopen(name, "wb");
-      if(fil!=NULL){
+      if(fil!=nullptr){
         gz_files.push_back(fil);
         ret = (int)gz_files.size()-1;
 	files.push_back(ret);

--- a/vowpalwabbit/cost_sensitive.cc
+++ b/vowpalwabbit/cost_sensitive.cc
@@ -177,7 +177,7 @@ namespace COST_SENSITIVE {
         size_t num_current_features = ec.num_features;
         // for csoaa_ldf we want features from the whole (multiline example),
         // not only from one line (the first one) represented by ec
-        if (ec_seq != NULL)
+        if (ec_seq != nullptr)
 	  {
           num_current_features = 0;
           // If the first example is "shared", don't include its features.
@@ -242,7 +242,7 @@ namespace COST_SENSITIVE {
       all.print_text(all.raw_prediction, outputStringStream.str(), ec.tag);
     }
 
-    print_update(all, is_test_label(ec.l.cs), ec, NULL);
+    print_update(all, is_test_label(ec.l.cs), ec, nullptr);
   }
 
   bool example_is_test(example& ec)

--- a/vowpalwabbit/csoaa.cc
+++ b/vowpalwabbit/csoaa.cc
@@ -68,7 +68,7 @@ void finish_example(vw& all, csoaa&, example& ec)
 base_learner* csoaa_setup(vw& all)
 {
   if (missing_option<size_t, true>(all, "csoaa", "One-against-all multiclass with <k> costs"))
-    return NULL;
+    return nullptr;
   
   csoaa& c = calloc_or_die<csoaa>();
   c.num_classes = (uint32_t)all.vm["csoaa"].as<size_t>();
@@ -223,7 +223,7 @@ namespace LabelDict {
 
   void free_label_features(ldf& data) {
     void* label_iter = data.label_features.iterator();
-    while (label_iter != NULL) {
+    while (label_iter != nullptr) {
       v_array<feature> *features = data.label_features.iterator_get_value(label_iter);
       features->erase();
       features->delete_v();
@@ -585,7 +585,7 @@ namespace LabelDict {
       all.sd->example_number++;
     }
     bool hit_loss = false;
-    output_example(all, ec, hit_loss, NULL);
+    output_example(all, ec, hit_loss, nullptr);
     VW::finish_example(all, &ec);
   }
 
@@ -654,7 +654,7 @@ namespace LabelDict {
   {
     if (missing_option<string, true>(all, "csoaa_ldf", "Use one-against-all multiclass learning with label dependent features.  Specify singleline or multiline.")
 	&& missing_option<string, true>(all, "wap_ldf", "Use weighted all-pairs multiclass learning with label dependent features.  Specify singleline or multiline."))
-      return NULL;
+      return nullptr;
     new_options(all, "LDF Options")
       ("ldf_override", po::value<string>(), "Override singleline or multiline from csoaa_ldf or wap_ldf, eg if stored in file");
     add_options(all);

--- a/vowpalwabbit/ect.cc
+++ b/vowpalwabbit/ect.cc
@@ -352,7 +352,7 @@ size_t create_circuit(ect& e, uint32_t max_label, uint32_t eliminations)
 base_learner* ect_setup(vw& all)
 {
   if (missing_option<size_t, true>(all, "ect", "Error correcting tournament with <k> labels"))
-    return NULL;
+    return nullptr;
   new_options(all, "Error Correcting Tournament options")
     ("error", po::value<size_t>()->default_value(0), "error in ECT");
   add_options(all);

--- a/vowpalwabbit/example.cc
+++ b/vowpalwabbit/example.cc
@@ -122,7 +122,7 @@ namespace VW {
 
 void return_features(feature* f)
 {
-	if (f != NULL)
+	if (f != nullptr)
 		free(f);
 }
 }
@@ -171,7 +171,7 @@ void free_flatten_example(flat_example* fec)
 example *alloc_examples(size_t label_size, size_t count=1)
 {
   example* ec = calloc_or_die<example>(count);
-  if (ec == NULL) return NULL;
+  if (ec == nullptr) return nullptr;
   for (size_t i=0; i<count; i++) {
     ec[i].in_use = true;
     ec[i].ft_offset = 0;

--- a/vowpalwabbit/example.h
+++ b/vowpalwabbit/example.h
@@ -106,7 +106,7 @@ flat_example* flatten_sort_example(vw& all, example *ec);
 void free_flatten_example(flat_example* fec);
 
 example *alloc_examples(size_t,size_t);
-void dealloc_example(void(*delete_label)(void*), example&ec, void(*delete_prediction)(void*) = NULL);
+void dealloc_example(void(*delete_label)(void*), example&ec, void(*delete_prediction)(void*) = nullptr);
 
 inline int example_is_newline(example& ec)
 {

--- a/vowpalwabbit/ezexample.h
+++ b/vowpalwabbit/ezexample.h
@@ -42,7 +42,7 @@ class ezexample {
 
   void setup_new_ezexample(vw*this_vw, bool multiline, vw*this_vw_parser) {
     vw_ref = this_vw;
-    vw_par_ref = (this_vw_parser == NULL) ? this_vw : this_vw_parser;
+    vw_par_ref = (this_vw_parser == nullptr) ? this_vw : this_vw_parser;
     is_multiline = multiline;
 
     str[0] = 0; str[1] = 0;
@@ -59,7 +59,7 @@ class ezexample {
 
   
   void setup_for_predict() {
-    static example* empty_example = is_multiline ? VW::read_example(*vw_par_ref, (char*)"") : NULL;
+    static example* empty_example = is_multiline ? VW::read_example(*vw_par_ref, (char*)"") : nullptr;
     if (example_changed_since_prediction) {
       mini_setup_example();
       vw_ref->learn(ec);
@@ -72,7 +72,7 @@ class ezexample {
 
   // REAL FUNCTIONALITY
   // create a new ezexample by asking the vw parser for an example
-  ezexample(vw*this_vw, bool multiline=false, vw*this_vw_parser=NULL) {
+  ezexample(vw*this_vw, bool multiline=false, vw*this_vw_parser=nullptr) {
     setup_new_ezexample(this_vw, multiline, this_vw_parser);
     example_copies = v_init<example*>();    
     ec = get_new_example();
@@ -85,7 +85,7 @@ class ezexample {
   // create a new ezexample by wrapping around an already existing example
   // we do NOT copy your data, therefore, WARNING:
   //   do NOT touch the underlying example unless you really know what you're done)
-  ezexample(vw*this_vw, example*this_ec, bool multiline=false, vw*this_vw_parser=NULL) {
+  ezexample(vw*this_vw, example*this_ec, bool multiline=false, vw*this_vw_parser=nullptr) {
     setup_new_ezexample(this_vw, multiline, this_vw_parser);
 
     ec = this_ec;
@@ -257,7 +257,7 @@ class ezexample {
   }
 
   void finish() {
-    static example* empty_example = is_multiline ? VW::read_example(*vw_par_ref, (char*)"") : NULL;
+    static example* empty_example = is_multiline ? VW::read_example(*vw_par_ref, (char*)"") : nullptr;
     if (is_multiline) {
       vw_ref->learn(empty_example);
       for (example**ecc=example_copies.begin; ecc!=example_copies.end; ecc++)

--- a/vowpalwabbit/ftrl_proximal.cc
+++ b/vowpalwabbit/ftrl_proximal.cc
@@ -102,7 +102,7 @@ void save_load(ftrl& b, io_buf& model_file, bool read, bool text)
 base_learner* ftrl_setup(vw& all) 
 {
   if (missing_option(all, false, "ftrl", "Follow the Regularized Leader")) 
-    return NULL;
+    return nullptr;
   new_options(all, "FTRL options")
     ("ftrl_alpha", po::value<float>()->default_value(0.005f), "Learning rate for FTRL-proximal optimization")
     ("ftrl_beta", po::value<float>()->default_value(0.1f), "FTRL beta");

--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -182,13 +182,13 @@ bool operator<(const string_value& first, const string_value& second)
   
   string tmp = "";
   
-  if (a != NULL){
+  if (a != nullptr){
     tmp += a->space;
     tmp += '^';
     tmp += a->feature; 
   }
  
-  if (a != NULL && all.audit){
+  if (a != nullptr && all.audit){
     tempstream << tmp << ':';
   }
   else 	if ( index == ((( (constant << stride_shift) * all.wpp + offset)&all.reg.weight_mask)) && all.audit){
@@ -223,7 +223,7 @@ bool operator<(const string_value& first, const string_value& second)
     if (as.begin != as.end)
       audit_feature(all, & fs[j], & as[j], results, prepend, ns_pre, offset, mult);
     else
-      audit_feature(all, & fs[j], NULL, results, prepend, ns_pre, offset, mult);
+      audit_feature(all, & fs[j], nullptr, results, prepend, ns_pre, offset, mult);
 }
 
 void audit_quad(vw& all, feature& left_feature, audit_data* left_audit, v_array<feature> &right_features, v_array<audit_data> &audit_right, vector<string_value>& results, string& ns_pre, uint32_t offset = 0)
@@ -298,7 +298,7 @@ void print_features(vw& all, example& ec)
 	  unsigned char snd = (*i)[1];
 	  for (size_t j = 0; j < ec.atomics[fst].size(); j++)
 	    {
-	      audit_data* a = NULL;
+	      audit_data* a = nullptr;
 	      if (ec.audit_features[fst].size() > 0)
 		a = & ec.audit_features[fst][j];
 	      audit_quad(all, ec.atomics[fst][j], a, ec.atomics[snd], ec.audit_features[snd], features, ns_pre);
@@ -312,12 +312,12 @@ void print_features(vw& all, example& ec)
 	  unsigned char trd = (*i)[2];
 	  for (size_t j = 0; j < ec.atomics[fst].size(); j++)
 	    {
-	      audit_data* a1 = NULL;
+	      audit_data* a1 = nullptr;
 	      if (ec.audit_features[fst].size() > 0)
 		a1 = & ec.audit_features[fst][j];
 	      for (size_t k = 0; k < ec.atomics[snd].size(); k++)
 		{
-		  audit_data* a2 = NULL;
+		  audit_data* a2 = nullptr;
 		  if (ec.audit_features[snd].size() > 0)
 		    a2 = & ec.audit_features[snd][k];
 		  audit_triple(all, ec.atomics[fst][j], a1, ec.atomics[snd][k], a2, ec.atomics[trd], ec.audit_features[trd], features, ns_pre);
@@ -710,12 +710,12 @@ void save_load_online_state(vw& all, io_buf& model_file, bool read, bool text, g
 
       // fix average loss
       double total_weight = 0.; //value holder as g* may be null
-      if (!read && g != NULL) total_weight = g->total_weight;
+      if (!read && g != nullptr) total_weight = g->total_weight;
       text_len = sprintf(buff, "gd::total_weight %f\n", total_weight);
       bin_text_read_write_fixed(model_file,(char*)&total_weight, sizeof(total_weight),
                                 "", read,
                                 buff, text_len, text);
-      if (read && g != NULL) g->total_weight = total_weight;
+      if (read && g != nullptr) g->total_weight = total_weight;
 
       // fix "loss since last" for first printed out example details
       text_len = sprintf(buff, "sd::old_weighted_examples %f\n", all.sd->old_weighted_examples);

--- a/vowpalwabbit/gd.h
+++ b/vowpalwabbit/gd.h
@@ -19,7 +19,7 @@ namespace GD{
   float finalize_prediction(shared_data* sd, float ret);
   void print_audit_features(vw&, example& ec);
   void save_load_regressor(vw& all, io_buf& model_file, bool read, bool text);
-  void save_load_online_state(vw& all, io_buf& model_file, bool read, bool text, GD::gd *g = NULL);
+  void save_load_online_state(vw& all, io_buf& model_file, bool read, bool text, GD::gd *g = nullptr);
 
   // iterate through one namespace (or its part), callback function T(some_data_R, feature_value_x, feature_weight)
   template <class R, void (*T)(R&, const float, float&)>

--- a/vowpalwabbit/gd_mf.cc
+++ b/vowpalwabbit/gd_mf.cc
@@ -305,7 +305,7 @@ void sd_offset_update(weight* weights, size_t mask, feature* begin, feature* end
 base_learner* gd_mf_setup(vw& all)
 {
   if (missing_option<uint32_t, true>(all, "rank", "rank for matrix factorization."))
-    return NULL;
+    return nullptr;
   
   gdmf& data = calloc_or_die<gdmf>(); 
   data.all = &all;

--- a/vowpalwabbit/global_data.cc
+++ b/vowpalwabbit/global_data.cc
@@ -301,7 +301,7 @@ vw::vw()
   eta = 0.5; //default learning rate for normalized adaptive updates, this is switched to 10 by default for the other updates (see parse_args.cc)
   numpasses = 1;
 
-  final_prediction_sink.begin = final_prediction_sink.end=final_prediction_sink.end_array = NULL;
+  final_prediction_sink.begin = final_prediction_sink.end=final_prediction_sink.end_array = nullptr;
   raw_prediction = -1;
   print = print_result;
   print_text = print_raw_text;
@@ -317,7 +317,7 @@ vw::vw()
   stdout_fileno = fileno(stdout);
   #endif
 
-  searchstr = NULL;
+  searchstr = nullptr;
 
   nonormalize = false;
   l1_lambda = 0.0;
@@ -349,7 +349,7 @@ vw::vw()
 
   add_constant = true;
   audit = false;
-  reg.weight_vector = NULL;
+  reg.weight_vector = nullptr;
   pass_length = (size_t)-1;
   passes_complete = 0;
 

--- a/vowpalwabbit/kernel_svm.cc
+++ b/vowpalwabbit/kernel_svm.cc
@@ -780,7 +780,7 @@ struct svm_params{
   }
 
 LEARNER::base_learner* kernel_svm_setup(vw &all) {
-  if (missing_option(all, true, "ksvm", "kernel svm")) return NULL;
+  if (missing_option(all, true, "ksvm", "kernel svm")) return nullptr;
   new_options(all, "KSVM options")
     ("reprocess", po::value<size_t>(), "number of reprocess steps for LASVM")
     //      ("active", "do active learning")

--- a/vowpalwabbit/label_parser.h
+++ b/vowpalwabbit/label_parser.h
@@ -14,6 +14,6 @@ struct label_parser {
   size_t (*read_cached_label)(shared_data*, void*, io_buf& cache);
   void (*delete_label)(void*);
   float (*get_weight)(void*);
-  void (*copy_label)(void*,void*); // copy_label(dst,src) performs a DEEP copy of src into dst (dst is allocated correctly).  if this function is NULL, then we assume that a memcpy of size label_size is sufficient, so you need only specify this function if your label constains, for instance, pointers (otherwise you'll get double-free errors)
+  void (*copy_label)(void*,void*); // copy_label(dst,src) performs a DEEP copy of src into dst (dst is allocated correctly).  if this function is nullptr, then we assume that a memcpy of size label_size is sufficient, so you need only specify this function if your label constains, for instance, pointers (otherwise you'll get double-free errors)
   size_t label_size;
 };

--- a/vowpalwabbit/lda_core.cc
+++ b/vowpalwabbit/lda_core.cc
@@ -582,7 +582,7 @@ void save_load(lda& l, io_buf& model_file, bool read, bool text)
       // the for loops down there. Since it seems that there's not much to
       // do in this case, we just return.
       for (size_t d = 0; d < l.examples.size(); d++)
-	return_simple_example(*l.all, NULL, *l.examples[d]);
+	return_simple_example(*l.all, nullptr, *l.examples[d]);
       l.examples.erase();
       return;
     }
@@ -653,7 +653,7 @@ void save_load(lda& l, io_buf& model_file, bool read, bool text)
 	  l.all->sd->sum_loss -= score;
 	  l.all->sd->sum_loss_since_last_dump -= score;
 	}
-	return_simple_example(*l.all, NULL, *l.examples[d]);
+	return_simple_example(*l.all, nullptr, *l.examples[d]);
       }
     
     for (index_feature* s = &l.sorted_features[0]; s <= &l.sorted_features.back();)
@@ -749,7 +749,7 @@ void end_examples(lda& l)
 base_learner* lda_setup(vw&all)
 {
   if (missing_option<uint32_t, true>(all, "lda", "Run lda with <int> topics")) 
-    return NULL;
+    return nullptr;
   new_options(all, "Lda options")
     ("lda_alpha", po::value<float>()->default_value(0.1f), "Prior on sparsity of per-document topic weights")
     ("lda_rho", po::value<float>()->default_value(0.1f), "Prior on sparsity of topic distributions")

--- a/vowpalwabbit/learner.cc
+++ b/vowpalwabbit/learner.cc
@@ -15,12 +15,12 @@ namespace LEARNER
 {
   void generic_driver(vw& all)
   {
-    example* ec = NULL;
+    example* ec = nullptr;
 
     all.l->init_driver();
     while ( all.early_terminate == false )
       {
-	if ((ec = VW::get_example(all.p)) != NULL)//semiblocking operation.
+	if ((ec = VW::get_example(all.p)) != nullptr)//semiblocking operation.
 	  {
 	    if (ec->indices.size() > 1) // 1+ nonconstant feature. (most common case first)
 	      dispatch_example(all, *ec);
@@ -55,7 +55,7 @@ namespace LEARNER
     if (all.early_terminate) //drain any extra examples from parser and call end_examples
       while ( all.early_terminate == false )
 	{
-	  if ((ec = VW::get_example(all.p)) != NULL)//semiblocking operation.
+	  if ((ec = VW::get_example(all.p)) != nullptr)//semiblocking operation.
 	    VW::finish_example(all, ec);
 	  else if (parser_done(all.p))
 	    {

--- a/vowpalwabbit/log_multi.cc
+++ b/vowpalwabbit/log_multi.cc
@@ -482,7 +482,7 @@ using namespace LEARNER;
 base_learner* log_multi_setup(vw& all)	//learner setup
 {
   if (missing_option<size_t, true>(all, "log_multi", "Use online tree for multiclass"))
-    return NULL;
+    return nullptr;
   new_options(all, "Logarithmic Time Multiclass options")
     ("no_progress", "disable progressive validation")
     ("swap_resistance", po::value<uint32_t>(), "higher = more resistance to swap, default=4");

--- a/vowpalwabbit/loss_functions.cc
+++ b/vowpalwabbit/loss_functions.cc
@@ -147,7 +147,7 @@ public:
   }
 
   float getSquareGrad(float prediction, float label) {
-    float d = first_derivative(NULL, prediction,label);
+    float d = first_derivative(nullptr, prediction,label);
     return d*d;
   }
 
@@ -218,7 +218,7 @@ public:
   }
 
   float getSquareGrad(float prediction, float label) {
-    float d = first_derivative(NULL, prediction,label);
+    float d = first_derivative(nullptr, prediction,label);
     return d*d;
   }
 
@@ -283,7 +283,7 @@ public:
   }
 
   float getSquareGrad(float prediction, float label) {
-    float fd = first_derivative(NULL, prediction,label);
+    float fd = first_derivative(nullptr, prediction,label);
     return fd*fd;
   }
 

--- a/vowpalwabbit/lrq.cc
+++ b/vowpalwabbit/lrq.cc
@@ -196,13 +196,13 @@ void predict_or_learn(LRQstate& lrq, base_learner& base, example& ec)
   base_learner* lrq_setup(vw& all)
   {//parse and set arguments
     if (missing_option<vector<string>>(all, "lrq", "use low rank quadratic features"))
-      return NULL;
+      return nullptr;
     new_options(all, "Lrq options")
       ("lrqdropout", "use dropout training for low rank quadratic features");
     add_options(all);
 
     if(!all.vm.count("lrq"))
-      return NULL;
+      return nullptr;
 
     LRQstate& lrq = calloc_or_die<LRQstate>();
     size_t maxk = 0;

--- a/vowpalwabbit/memory.h
+++ b/vowpalwabbit/memory.h
@@ -6,10 +6,10 @@ template<class T>
 T* calloc_or_die(size_t nmemb)
 {
   if (nmemb == 0)
-    return NULL;
+    return nullptr;
   
   void* data = calloc(nmemb, sizeof(T));
-  if (data == NULL) {
+  if (data == nullptr) {
     std::cerr << "internal error: memory allocation failed; dying!" << std::endl;
     throw std::exception();
   }
@@ -19,4 +19,4 @@ T* calloc_or_die(size_t nmemb)
 template<class T> T& calloc_or_die()
 { return *calloc_or_die<T>(1); }
 
-inline void free_it(void* ptr) { if (ptr != NULL) free(ptr); }
+inline void free_it(void* ptr) { if (ptr != nullptr) free(ptr); }

--- a/vowpalwabbit/mf.cc
+++ b/vowpalwabbit/mf.cc
@@ -186,7 +186,7 @@ void finish(mf& o) {
 
   base_learner* mf_setup(vw& all) {
     if (missing_option<size_t, true>(all, "new_mf", "rank for reduction-based matrix factorization")) 
-      return NULL;
+      return nullptr;
     
     mf& data = calloc_or_die<mf>();
     data.all = &all;

--- a/vowpalwabbit/multiclass.cc
+++ b/vowpalwabbit/multiclass.cc
@@ -87,7 +87,7 @@ namespace MULTICLASS {
   label_parser mc_label = {default_label, parse_label, 
 				  cache_label, read_cached_label, 
 				  delete_label, weight, 
-				  NULL,
+				  nullptr,
 				  sizeof(label_t)};
   
   void print_update(vw& all, example &ec)

--- a/vowpalwabbit/multilabel.cc
+++ b/vowpalwabbit/multilabel.cc
@@ -105,7 +105,7 @@ namespace MULTILABEL {
 	
 	for (size_t i = 0; i < p->parse_name.size(); i++)
 	  {
-	    p->parse_name[i].end = '\0';
+	    p->parse_name[i].end = nullptr;
 	    uint32_t n = atoi(p->parse_name[i].begin);
 	    ld->label_v.push_back(n);
 	  }

--- a/vowpalwabbit/multilabel_oaa.cc
+++ b/vowpalwabbit/multilabel_oaa.cc
@@ -51,7 +51,7 @@ void predict_or_learn(oaa& o, LEARNER::base_learner& base, example& ec) {
 LEARNER::base_learner* multilabel_oaa_setup(vw& all)
 {
   if (missing_option<size_t, true>(all, "multilabel_oaa", "One-against-all multilabel with <k> labels")) 
-    return NULL;
+    return nullptr;
   
   oaa& data = calloc_or_die<oaa>();
   data.k = all.vm["multilabel_oaa"].as<size_t>();

--- a/vowpalwabbit/network.cc
+++ b/vowpalwabbit/network.cc
@@ -34,7 +34,7 @@ int open_socket(const char* host)
 #endif
   short unsigned int port = 26542;
   hostent* he;
-  if (colon != NULL)
+  if (colon != nullptr)
     {
       port = atoi(colon+1);
       string hostname(host,colon-host);
@@ -43,7 +43,7 @@ int open_socket(const char* host)
   else
     he = gethostbyname(host);
 
-  if (he == NULL)
+  if (he == nullptr)
     {
       cerr << "gethostbyname(" << host << "): " << strerror(errno) << endl;
       throw exception();

--- a/vowpalwabbit/nn.cc
+++ b/vowpalwabbit/nn.cc
@@ -346,22 +346,22 @@ CONVERSE: // That's right, I'm using goto.  So sue me.
   {
     int save_raw_prediction = all.raw_prediction;
     all.raw_prediction = -1;
-    return_simple_example(all, NULL, ec);
+    return_simple_example(all, nullptr, ec);
     all.raw_prediction = save_raw_prediction;
   }
 
   void finish(nn& n)
   {
     delete n.squared_loss;
-    dealloc_example (NULL, n.output_layer);
-    dealloc_example (NULL, n.hiddenbias);
-    dealloc_example (NULL, n.outputweight);
+    dealloc_example (nullptr, n.output_layer);
+    dealloc_example (nullptr, n.hiddenbias);
+    dealloc_example (nullptr, n.outputweight);
   }
 
   base_learner* nn_setup(vw& all)
   {
     if (missing_option<size_t, true>(all, "nn", "Sigmoidal feedforward network with <k> hidden units"))
-      return NULL;
+      return nullptr;
     new_options(all, "Neural Network options")
       ("inpass", "Train or test sigmoidal feedforward network with input passthrough.")
       ("multitask", "Share hidden layer across all reduced tasks.")

--- a/vowpalwabbit/noop.cc
+++ b/vowpalwabbit/noop.cc
@@ -11,7 +11,7 @@ void learn(char&, LEARNER::base_learner&, example&) {}
 
 LEARNER::base_learner* noop_setup(vw& all)
 {
-  if (missing_option(all, true, "noop", "do no learning")) return NULL;
+  if (missing_option(all, true, "noop", "do no learning")) return nullptr;
   
-  return &LEARNER::init_learner<char>(NULL, learn, 1); 
+  return &LEARNER::init_learner<char>(nullptr, learn, 1); 
 }

--- a/vowpalwabbit/oaa.cc
+++ b/vowpalwabbit/oaa.cc
@@ -51,7 +51,7 @@ void predict_or_learn(oaa& o, LEARNER::base_learner& base, example& ec) {
 LEARNER::base_learner* oaa_setup(vw& all)
 {
   if (missing_option<size_t, true>(all, "oaa", "One-against-all multiclass with <k> labels")) 
-    return NULL;
+    return nullptr;
   
   oaa& data = calloc_or_die<oaa>();
   data.k = all.vm["oaa"].as<size_t>();

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -87,7 +87,7 @@ void parse_dictionary_argument(vw&all, string str) {
       return;
     }
 
-  feature_dict* map = new feature_dict(1023, NULL, substring_equal);
+  feature_dict* map = new feature_dict(1023, nullptr, substring_equal);
   
   // TODO: handle gzipped dictionaries
   example *ec = alloc_examples(all.p->lp.label_size, 1);
@@ -104,7 +104,7 @@ void parse_dictionary_argument(vw&all, string str) {
     memcpy(word, c, d-c);
     substring ss = { word, word + (d - c) };
     uint32_t hash = uniform_hash( ss.begin, ss.end-ss.begin, quadratic_constant);
-    if (map->get(ss, hash) != NULL) { // don't overwrite old values!
+    if (map->get(ss, hash) != nullptr) { // don't overwrite old values!
       free(word);
       continue;
     }
@@ -170,7 +170,7 @@ void parse_affix_argument(vw&all, string str) {
     all.affix_features[ns] <<= 4;
     all.affix_features[ns] |=  afx;
 
-    p = strtok(NULL, ",");
+    p = strtok(nullptr, ",");
   }
 
   free(cstr);
@@ -801,7 +801,7 @@ void load_input_model(vw& all, io_buf& io_temp)
 LEARNER::base_learner* setup_base(vw& all)
 {
   LEARNER::base_learner* ret = all.reduction_stack.pop()(all);
-  if (ret == NULL)
+  if (ret == nullptr)
     return setup_base(all);
   else 
     return ret;
@@ -1041,7 +1041,7 @@ namespace VW {
     finalize_regressor(all, all.final_regressor_name);
     all.l->finish();
     free_it(all.l);
-    if (all.reg.weight_vector != NULL)
+    if (all.reg.weight_vector != nullptr)
       free(all.reg.weight_vector);
     free_parser(all);
     finalize_source(all.p);

--- a/vowpalwabbit/parse_example.cc
+++ b/vowpalwabbit/parse_example.cc
@@ -55,7 +55,7 @@ public:
     else if(*reading_head == ':'){
       // featureValue --> ':' 'Float'
       ++reading_head;
-      char *end_read = NULL;
+      char *end_read = nullptr;
       v = parseFloat(reading_head,&end_read);
       if(end_read == reading_head){
 	cout << "malformed example !\nFloat expected after : \"" << std::string(beginLine, reading_head - beginLine).c_str()<< "\"" << endl;
@@ -173,7 +173,7 @@ public:
           feature_dict* map = namespace_dictionaries[index][dict];
           uint32_t hash = uniform_hash(feature_name.begin, feature_name.end-feature_name.begin, quadratic_constant);
           v_array<feature>* feats = map->get(feature_name, hash);
-          if ((feats != NULL) && (feats->size() > 0)) {
+          if ((feats != nullptr) && (feats->size() > 0)) {
             if (ae->atomics[dictionary_namespace].size() == 0)
               ae->indices.push_back(dictionary_namespace);
             push_many(ae->atomics[dictionary_namespace], feats->begin, feats->size());
@@ -206,7 +206,7 @@ public:
     }else if(*reading_head == ':'){
       // nameSpaceInfoValue --> ':' 'Float'
       ++reading_head;
-      char *end_read = NULL;
+      char *end_read = nullptr;
       cur_channel_v = parseFloat(reading_head,&end_read);
       if(end_read == reading_head){
 	cout << "malformed example !\nFloat expected after : \"" << std::string(beginLine, reading_head - beginLine).c_str()<< "\"" << endl;
@@ -237,7 +237,7 @@ public:
 	v_array<char> base_v_array = v_init<char>();
 	push_many(base_v_array, name.begin, name.end - name.begin);
 	base_v_array.push_back('\0');
-	if (base != NULL)
+	if (base != nullptr)
 	  free(base);
 	base = base_v_array.begin;
       }
@@ -270,7 +270,7 @@ public:
 	new_index = true;
       if(audit)
 	{
-	  if (base != NULL)
+	  if (base != nullptr)
 	    free(base);
 	  base = calloc_or_die<char>(2);
 	  base[0] = ' ';
@@ -316,9 +316,9 @@ public:
 	this->affix_features = all.affix_features;
 	this->spelling_features = all.spelling_features;
 	this->namespace_dictionaries = all.namespace_dictionaries;
-	this->base = NULL;
+	this->base = nullptr;
 	listNameSpace();
-	if (base != NULL)
+	if (base != nullptr)
 	  free(base);
       }
   }
@@ -363,7 +363,7 @@ int read_features(void* in, example* ex)
 {
   vw* all = (vw*)in;
   example* ae = (example*)ex;
-  char *line=NULL;
+  char *line=nullptr;
   size_t num_chars_initial = readto(*(all->p->input), line, '\n');
   if (num_chars_initial < 1)
     return (int)num_chars_initial;

--- a/vowpalwabbit/parse_regressor.cc
+++ b/vowpalwabbit/parse_regressor.cc
@@ -25,14 +25,14 @@ using namespace std;
 void initialize_regressor(vw& all)
 {
   // Regressor is already initialized.
-  if (all.reg.weight_vector != NULL) {
+  if (all.reg.weight_vector != nullptr) {
     return;
   }
 
   size_t length = ((size_t)1) << all.num_bits;
   all.reg.weight_mask = (length << all.reg.stride_shift) - 1;
   all.reg.weight_vector = calloc_or_die<weight>(length << all.reg.stride_shift);
-  if (all.reg.weight_vector == NULL)
+  if (all.reg.weight_vector == nullptr)
     {
       cerr << all.program_name << ": Failed to allocate weight array with " << all.num_bits << " bits: try decreasing -b <bits>" << endl;
       throw exception();

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -56,7 +56,7 @@ using namespace std;
 void initialize_mutex(MUTEX * pm)
 {
 #ifndef _WIN32
-  pthread_mutex_init(pm, NULL);
+  pthread_mutex_init(pm, nullptr);
 #else
 	::InitializeCriticalSection(pm);
 #endif
@@ -74,7 +74,7 @@ void delete_mutex(MUTEX * pm)
 void initialize_condition_variable(CV * pcv)
 {
 #ifndef _WIN32
-  pthread_cond_init(pcv, NULL);
+  pthread_cond_init(pcv, nullptr);
 #else
 	::InitializeConditionVariable(pcv);
 #endif
@@ -526,7 +526,7 @@ void enable_sources(vw& all, bool quiet, size_t passes)
 	    // waitid will be interrupted by SIGTERM with handler installed
 	    memset(&sa, 0, sizeof(sa));
 	    sa.sa_handler = handle_sigterm;
-	    sigaction(SIGTERM, &sa, NULL);
+	    sigaction(SIGTERM, &sa, nullptr);
 	  }
 
 	  while (true)
@@ -668,7 +668,7 @@ void addgrams(vw& all, size_t ngram, size_t skip_gram, v_array<feature>& atomics
 		}
 	      string feature_space = string(audits[i].space);
 	      
-	      audit_data a_feature = {NULL,NULL,new_index, 1., true};
+	      audit_data a_feature = {nullptr,nullptr,new_index, 1., true};
 	      a_feature.space = (char*)malloc(feature_space.length()+1);
 	      strcpy(a_feature.space, feature_space.c_str());
 	      a_feature.feature = (char*)malloc(feature_name.length()+1);
@@ -1069,7 +1069,7 @@ void *main_parse_loop(void *in)
 	   condition_variable_signal_all(&all->p->example_available);
 	   mutex_unlock(&all->p->examples_lock);
 	  }  
-	return NULL;
+	return nullptr;
 }
 
 namespace VW{
@@ -1094,7 +1094,7 @@ example* get_example(parser* p)
       }
     else {
       mutex_unlock(&p->examples_lock);
-      return NULL;
+      return nullptr;
     }
   }
 }
@@ -1182,9 +1182,9 @@ void start_parser(vw& all, bool init_structures)
   if (init_structures)
 	initialize_parser_datastructures(all);
   #ifndef _WIN32
-  pthread_create(&all.parse_thread, NULL, main_parse_loop, &all);
+  pthread_create(&all.parse_thread, nullptr, main_parse_loop, &all);
   #else
-  all.parse_thread = ::CreateThread(NULL, 0, static_cast<LPTHREAD_START_ROUTINE>(main_parse_loop), &all, NULL, NULL);
+  all.parse_thread = ::CreateThread(nullptr, 0, static_cast<LPTHREAD_START_ROUTINE>(main_parse_loop), &all, nullptr, nullptr);
   #endif
 }
 }
@@ -1206,7 +1206,7 @@ void free_parser(vw& all)
   free(all.p->examples);
   
   io_buf* output = all.p->output;
-  if (output != NULL)
+  if (output != nullptr)
     {
       output->finalname.delete_v();
       output->currentname.delete_v();
@@ -1225,7 +1225,7 @@ namespace VW {
 void end_parser(vw& all)
 {
   #ifndef _WIN32
-  pthread_join(all.parse_thread, NULL);
+  pthread_join(all.parse_thread, nullptr);
   #else
   ::WaitForSingleObject(all.parse_thread, INFINITE);
   ::CloseHandle(all.parse_thread);

--- a/vowpalwabbit/print.cc
+++ b/vowpalwabbit/print.cc
@@ -39,7 +39,7 @@ void learn(print& p, LEARNER::base_learner& base, example& ec)
 
 LEARNER::base_learner* print_setup(vw& all)
 {
-  if (missing_option(all, true, "print", "print examples")) return NULL;
+  if (missing_option(all, true, "print", "print examples")) return nullptr;
   
   print& p = calloc_or_die<print>();
   p.all = &all;

--- a/vowpalwabbit/search.cc
+++ b/vowpalwabbit/search.cc
@@ -35,7 +35,7 @@ namespace Search {
                                &EntityRelationTask::task,
                                &HookTask::task,
                                &GraphTask::task,
-                               NULL };   // must NULL terminate!
+                               nullptr };   // must nullptr terminate!
 
   const bool PRINT_UPDATE_EVERY_EXAMPLE =0;
   const bool PRINT_UPDATE_EVERY_PASS =1;
@@ -384,7 +384,7 @@ namespace Search {
     priv.dat_new_feature_ec->atomics[priv.dat_new_feature_namespace].push_back(f);
     priv.dat_new_feature_ec->sum_feat_sq[priv.dat_new_feature_namespace] += f.x * f.x;
     if (priv.all->audit) {
-      audit_data a = { NULL, NULL, f.weight_index, f.x, true };
+      audit_data a = { nullptr, nullptr, f.weight_index, f.x, true };
       a.space   = calloc_or_die<char>(priv.dat_new_feature_feature_space->length()+1);
       a.feature = calloc_or_die<char>(priv.dat_new_feature_audit_ss.str().length() + 32);
       strcpy(a.space, priv.dat_new_feature_feature_space->c_str());
@@ -516,7 +516,7 @@ namespace Search {
   
   size_t random(size_t max) { return (size_t)(frand48() * (float)max); }
   template<class T> bool array_contains(T target, const T*A, size_t n) {
-    if (A == NULL) return false;
+    if (A == nullptr) return false;
     for (size_t i=0; i<n; i++)
       if (A[i] == target) return true;
     return false;
@@ -672,7 +672,7 @@ namespace Search {
           cs_cost_push_back(isCB, ld, k, FLT_MAX);
       
     } else { // non-LDF version
-      if ((allowed_actions == NULL) || (allowed_actions_cnt == 0)) { // any action is allowed
+      if ((allowed_actions == nullptr) || (allowed_actions_cnt == 0)) { // any action is allowed
         if (num_costs != priv.A) {  // if there are already A-many actions, they must be the right ones, unless the user did something stupid like putting duplicate allowed_actions...
           cs_costs_erase(isCB, ld);
           for (action k = 0; k < priv.A; k++)
@@ -693,7 +693,7 @@ namespace Search {
       for (action k=0; k<ec_cnt; k++)
         losses.push_back( array_contains<action>(k, oracle_actions, oracle_actions_cnt) ? 0.f : 1.f );
     else { // non-LDF
-      if ((allowed_actions == NULL) || (allowed_actions_cnt == 0))  // any action is allowed
+      if ((allowed_actions == nullptr) || (allowed_actions_cnt == 0))  // any action is allowed
         for (action k=1; k<=priv.A; k++)
           losses.push_back( array_contains<action>(k, oracle_actions, oracle_actions_cnt) ? 0.f : 1.f );
       else
@@ -955,7 +955,7 @@ namespace Search {
       // since we're not LDF, it should be the case that ec_ref_cnt == 1
       // and learn_ec_ref[0] is a pointer to a single example
       assert(priv.learn_ec_ref_cnt == 1);
-      assert(priv.learn_ec_ref != NULL);
+      assert(priv.learn_ec_ref != nullptr);
 
       polylabel labels = allowed_actions_to_ld(priv, priv.learn_ec_ref_cnt, priv.learn_allowed_actions.begin, priv.learn_allowed_actions.size());
       cdbg_print_array("learn_allowed_actions", priv.learn_allowed_actions);
@@ -1052,9 +1052,9 @@ namespace Search {
     priv.t++;
 
     // make sure parameters come in pairs correctly
-    assert((oracle_actions  == NULL) == (oracle_actions_cnt  == 0));
-    assert((condition_on    == NULL) == (condition_on_names  == NULL));
-    assert((allowed_actions == NULL) == (allowed_actions_cnt == 0));
+    assert((oracle_actions  == nullptr) == (oracle_actions_cnt  == 0));
+    assert((condition_on    == nullptr) == (condition_on_names  == nullptr));
+    assert((allowed_actions == nullptr) == (allowed_actions_cnt == 0));
     
     // if we're just after the string, choose an oracle action
     if (priv.state == GET_TRUTH_STRING)
@@ -1098,7 +1098,7 @@ namespace Search {
           priv.learn_ec_ref = ecs;
         else {
           size_t label_size = priv.is_ldf ? sizeof(CS::label) : sizeof(MC::label_t);
-          void (*label_copy_fn)(void*,void*) = priv.is_ldf ? CS::cs_label.copy_label : NULL;
+          void (*label_copy_fn)(void*,void*) = priv.is_ldf ? CS::cs_label.copy_label : nullptr;
           
           ensure_size(priv.learn_ec_copy, ec_cnt);
           for (size_t i=0; i<ec_cnt; i++) 
@@ -1119,7 +1119,7 @@ namespace Search {
           for (size_t i=0; i<condition_on_cnt; i++)
             push_at(priv.learn_condition_on_act, ((1 <= condition_on[i]) && (condition_on[i] < priv.ptag_to_action.size())) ? priv.ptag_to_action[condition_on[i]] : 0, i);
 
-          if (condition_on_names == NULL) {
+          if (condition_on_names == nullptr) {
             ensure_size(priv.learn_condition_on_names, 1);
             priv.learn_condition_on_names[0] = 0;
           } else {
@@ -1343,7 +1343,7 @@ namespace Search {
       cdbg << "beam_run=" << beam_run << endl;
       priv.beam->compact(free_action_prefix);
       Beam::beam_element<action_prefix>* item = priv.beam->pop_best_item();
-      if (item != NULL) {
+      if (item != nullptr) {
         reset_search_structure(priv);
         priv.beam_actions.erase();
         priv.state = state;
@@ -1402,7 +1402,7 @@ namespace Search {
     bool ran_test = false;  // we must keep track so that even if we skip test, we still update # of examples seen
 
     clear_cache_hash_map(priv);
-    Beam::beam< pair<action_prefix*, string> >* final_beam = NULL;
+    Beam::beam< pair<action_prefix*, string> >* final_beam = nullptr;
     
     // do an initial test pass to compute output (and loss)
     if (must_run_test(all, priv.ec_seq, is_test_ex)) {
@@ -1447,7 +1447,7 @@ namespace Search {
     // do a pass over the data allowing oracle
     cdbg << "======================================== INIT TRAIN (" << priv.current_policy << "," << priv.read_example_last_pass << ") ========================================" << endl;
     //cerr << "training" << endl;
-    final_beam = NULL;
+    final_beam = nullptr;
     if (priv.beam)
       final_beam = beam_predict(sch, INIT_TRAIN);
 
@@ -1656,9 +1656,9 @@ namespace Search {
 
     priv.t = 0;
     priv.T = 0;
-    priv.learn_ec_ref = NULL;
+    priv.learn_ec_ref = nullptr;
     priv.learn_ec_ref_cnt = 0;
-    //priv.allowed_actions_cache = NULL;
+    //priv.allowed_actions_cache = nullptr;
     
     priv.loss_declared_cnt = 0;
     priv.learn_t = 0;
@@ -1710,8 +1710,8 @@ namespace Search {
     priv.cache_hash_map.set_default_value((action)-1);
     priv.cache_hash_map.set_equivalent(cached_item_equivalent);
     
-    priv.task = NULL;
-    sch.task_data = NULL;
+    priv.task = nullptr;
+    sch.task_data = nullptr;
 
     priv.empty_example = alloc_examples(sizeof(CS::label), 1);
     CS::cs_label.default_label(&priv.empty_example->l.cs);
@@ -1767,7 +1767,7 @@ namespace Search {
     priv.learn_condition_on.delete_v();
     priv.learn_condition_on_act.delete_v();
     
-    if (priv.task->finish != NULL) {
+    if (priv.task->finish != nullptr) {
       priv.task->finish(sch);
     }
 
@@ -1828,7 +1828,7 @@ namespace Search {
 
   v_array<CS::label> read_allowed_transitions(action A, const char* filename) {
     FILE *f = fopen(filename, "r");
-    if (f == NULL) {
+    if (f == nullptr) {
       std::cerr << "error: could not read file " << filename << " (" << strerror(errno) << "); assuming all transitions are valid" << endl;
       throw exception();
     }
@@ -1895,7 +1895,7 @@ namespace Search {
       int32_t enc = (posn << 24) | (ns & 0xFF);
       priv.neighbor_features.push_back(enc);
 
-      p = strtok(NULL, ",");
+      p = strtok(nullptr, ",");
     }
     cmd.delete_v();
 
@@ -1904,7 +1904,7 @@ namespace Search {
 
   base_learner* setup(vw&all) {
     if (missing_option<size_t, false>(all, "search", "Use learning to search, argument=maximum action id or 0 for LDF"))
-      return NULL;
+      return nullptr;
     new_options(all, "Search Options")
       ("search_task",              po::value<string>(), "the search task (use \"--search_task list\" to get a list of available tasks)")
       ("search_interpolation",     po::value<string>(), "at what level should interpolation happen? [*data|policy]")
@@ -1973,7 +1973,7 @@ namespace Search {
     if (vm.count("search_beam"))
       priv.beam = new Beam::beam<action_prefix>(vm["search_beam"].as<size_t>());  // TODO: pruning, kbest, equivalence testing
     else
-      priv.beam = NULL;
+      priv.beam = nullptr;
 
     priv.kbest = 1;
     if (vm.count("search_kbest")) {
@@ -2077,18 +2077,18 @@ namespace Search {
 
     if (task_string.compare("list") == 0) {
       std::cerr << endl << "available search tasks:" << endl;
-      for (search_task** mytask = all_tasks; *mytask != NULL; mytask++)
+      for (search_task** mytask = all_tasks; *mytask != nullptr; mytask++)
         std::cerr << "  " << (*mytask)->task_name << endl;
       std::cerr << endl;
       exit(0);
     }
-    for (search_task** mytask = all_tasks; *mytask != NULL; mytask++)
+    for (search_task** mytask = all_tasks; *mytask != nullptr; mytask++)
       if (task_string.compare((*mytask)->task_name) == 0) {
         priv.task = *mytask;
         sch.task_name = (*mytask)->task_name;
         break;
       }
-    if (priv.task == NULL) {
+    if (priv.task == nullptr) {
       if (! vm.count("help")) {
         std::cerr << "fail: unknown task for --search_task '" << task_string << "'; use --search_task list to get a list" << endl;
         throw exception();
@@ -2168,7 +2168,7 @@ namespace Search {
   }
 
   action search::predictLDF(example* ecs, size_t ec_cnt, ptag mytag, const action* oracle_actions, size_t oracle_actions_cnt, const ptag* condition_on, const char* condition_on_names, size_t learner_id) {
-    action a = search_predict(*this->priv, ecs, ec_cnt, mytag, oracle_actions, oracle_actions_cnt, condition_on, condition_on_names, NULL, 0, learner_id);
+    action a = search_predict(*this->priv, ecs, ec_cnt, mytag, oracle_actions, oracle_actions_cnt, condition_on, condition_on_names, nullptr, 0, learner_id);
     if (priv->beam) priv->current_trajectory.push_back(a);
     if (priv->state == INIT_TEST) priv->test_action_sequence.push_back(a);
     if ((mytag != 0) && ecs[a].l.cs.costs.size() > 0)
@@ -2226,7 +2226,7 @@ namespace Search {
   vw& search::get_vw_pointer_unsafe() { return *this->priv->all; }
   
   // predictor implementation
-  predictor::predictor(search& sch, ptag my_tag) : is_ldf(false), my_tag(my_tag), ec(NULL), ec_cnt(0), ec_alloced(false), oracle_is_pointer(false), allowed_is_pointer(false), learner_id(0), sch(sch) { 
+  predictor::predictor(search& sch, ptag my_tag) : is_ldf(false), my_tag(my_tag), ec(nullptr), ec_cnt(0), ec_alloced(false), oracle_is_pointer(false), allowed_is_pointer(false), learner_id(0), sch(sch) { 
     oracle_actions = v_init<action>(); 
     condition_on_tags = v_init<ptag>();
     condition_on_names = v_init<char>();
@@ -2239,7 +2239,7 @@ namespace Search {
         for (size_t i=0; i<ec_cnt; i++)
           dealloc_example(CS::cs_label.delete_label, ec[i]);
       else
-        dealloc_example(NULL, *ec);
+        dealloc_example(nullptr, *ec);
       free(ec);
     }
   }
@@ -2373,14 +2373,14 @@ namespace Search {
   predictor& predictor::set_tag(ptag tag) { my_tag = tag; return *this; }
 
   action predictor::predict() {
-    const action* orA = oracle_actions.size() == 0 ? NULL : oracle_actions.begin;
-    const ptag*   cOn = condition_on_names.size() == 0 ? NULL : condition_on_tags.begin;
-    const char*   cNa = NULL;
+    const action* orA = oracle_actions.size() == 0 ? nullptr : oracle_actions.begin;
+    const ptag*   cOn = condition_on_names.size() == 0 ? nullptr : condition_on_tags.begin;
+    const char*   cNa = nullptr;
     if (condition_on_names.size() > 0) {
       condition_on_names.push_back((char)0);  // null terminate
       cNa = condition_on_names.begin;
     }
-    const action* alA = (allowed_actions.size() == 0) ? NULL : allowed_actions.begin;
+    const action* alA = (allowed_actions.size() == 0) ? nullptr : allowed_actions.begin;
     action p = is_ldf ? sch.predictLDF(ec, ec_cnt, my_tag, orA, oracle_actions.size(), cOn, cNa, learner_id)
                       : sch.predict(*ec, my_tag, orA, oracle_actions.size(), cOn, cNa, alA, allowed_actions.size(), learner_id);
 

--- a/vowpalwabbit/search.h
+++ b/vowpalwabbit/search.h
@@ -47,8 +47,8 @@ namespace Search {
     //                           state, for future predictions, which ones depend
     //                           explicitely or implicitly on this prediction
     //   oracle_actions        an array of actions that the oracle would take
-    //                           NULL => the oracle doesn't know (is random!)
-    //   oracle_actions_cnt    the length of the previous array, or 0 if it's NULL
+    //                           nullptr => the oracle doesn't know (is random!)
+    //   oracle_actions_cnt    the length of the previous array, or 0 if it's nullptr
     //   condition_on          an array of previous (or future) predictions on which
     //                           this prediction depends. the semantics of conditioning
     //                           is that IF the predictions for all the tags in
@@ -57,22 +57,22 @@ namespace Search {
     //                           features, etc. (also assuming same policy). if
     //                           AUTO_CONDITION_FEATURES is on, then we will automatically
     //                           add features to ec based on what you're conditioning on.
-    //                           NULL => independent prediction
+    //                           nullptr => independent prediction
     //   condition_on_names    a string containing the list of names of features you're
     //                           conditioning on. used explicitly for auditing, implicitly
     //                           for keeping tags separated. also, strlen(condition_on_names)
     //                           tells us how long condition_on is
     //   allowed_actions       an array of actions that are allowed at this step, or
-    //                           NULL if everything is allowed
+    //                           nullptr if everything is allowed
     //   allowed_actions_cnt   the length of allowed_actions
     //   learner_id            the id for the underlying learner to use (via set_num_learners)
     action predict(        example& ec
                    ,       ptag     my_tag
                    , const action*  oracle_actions
                    ,       size_t   oracle_actions_cnt   = 1
-                   , const ptag*    condition_on         = NULL
-                   , const char*    condition_on_names   = NULL   // strlen(condition_on_names) should == |condition_on|
-                   , const action*  allowed_actions      = NULL
+                   , const ptag*    condition_on         = nullptr
+                   , const char*    condition_on_names   = nullptr   // strlen(condition_on_names) should == |condition_on|
+                   , const action*  allowed_actions      = nullptr
                    ,       size_t   allowed_actions_cnt  = 0
                    ,       size_t   learner_id           = 0
                    );
@@ -88,8 +88,8 @@ namespace Search {
                       ,       ptag     my_tag
                       , const action*  oracle_actions
                       ,       size_t   oracle_actions_cnt   = 1
-                      , const ptag*    condition_on         = NULL
-                      , const char*    condition_on_names   = NULL
+                      , const ptag*    condition_on         = nullptr
+                      , const char*    condition_on_names   = nullptr
                       ,       size_t   learner_id           = 0
                       );
 

--- a/vowpalwabbit/search_dep_parser.cc
+++ b/vowpalwabbit/search_dep_parser.cc
@@ -14,7 +14,7 @@
 #define cubic_namespace 102 // namespace for cubic feature
 #define offset_const 344429
 
-namespace DepParserTask         {  Search::search_task task = { "dep_parser", run, initialize, finish, NULL, NULL};  }
+namespace DepParserTask         {  Search::search_task task = { "dep_parser", run, initialize, finish, nullptr, nullptr};  }
 
 struct task_data {
   example *ex;
@@ -263,7 +263,7 @@ namespace DepParserTask {
     add_feature(&ex, (uint32_t) constant, constant_namespace, mask, ss);
     // be careful: indices in ec starts from 0, but i is starts from 1
     size_t n = ec.size();
-    // use this buffer to c_vw()ect the examples, default value: NULL
+    // use this buffer to c_vw()ect the examples, default value: nullptr
     ec_buf.resize(12,true);
     for(size_t i=0; i<12; i++)
       ec_buf[i] = 0;

--- a/vowpalwabbit/search_entityrelationtask.cc
+++ b/vowpalwabbit/search_entityrelationtask.cc
@@ -9,7 +9,7 @@
 #define R_NONE 10 // label for NONE relation
 #define LABEL_SKIP 11 // label for SKIP
 
-namespace EntityRelationTask { Search::search_task task = { "entity_relation", run, initialize, finish, NULL, NULL };  }
+namespace EntityRelationTask { Search::search_task task = { "entity_relation", run, initialize, finish, nullptr, nullptr };  }
 
 
 namespace EntityRelationTask {

--- a/vowpalwabbit/search_hooktask.cc
+++ b/vowpalwabbit/search_hooktask.cc
@@ -12,14 +12,14 @@ namespace HookTask {
 
   void initialize(Search::search& sch, size_t& num_actions, po::variables_map& vm) {
     task_data *td = new task_data;
-    td->run_f = NULL;
-    td->run_setup_f = NULL;
-    td->run_takedown_f = NULL;
-    td->run_object = NULL;
-    td->setup_object = NULL;
-    td->takedown_object = NULL;
-    td->delete_run_object = NULL;
-    td->delete_extra_data = NULL;
+    td->run_f = nullptr;
+    td->run_setup_f = nullptr;
+    td->run_takedown_f = nullptr;
+    td->run_object = nullptr;
+    td->setup_object = nullptr;
+    td->takedown_object = nullptr;
+    td->delete_run_object = nullptr;
+    td->delete_extra_data = nullptr;
     td->var_map = new po::variables_map(vm);
     td->num_actions = num_actions;
     sch.set_task_data<task_data>(td);

--- a/vowpalwabbit/search_multiclasstask.cc
+++ b/vowpalwabbit/search_multiclasstask.cc
@@ -5,7 +5,7 @@ license as described in the file LICENSE.
  */
 #include "search_multiclasstask.h"
 
-namespace MulticlassTask { Search::search_task task = { "multiclasstask", run, initialize, finish, NULL, NULL };  }
+namespace MulticlassTask { Search::search_task task = { "multiclasstask", run, initialize, finish, nullptr, nullptr };  }
 
 namespace MulticlassTask {
 
@@ -42,7 +42,7 @@ namespace MulticlassTask {
 	  size_t mask = 1<<(my_task_data->num_level-i-1);
 	  size_t y_allowed_size = (label+mask +1 <= my_task_data->max_label)?2:1;
       action oracle = (((gold_label-1)&mask)>0)+1;
-      size_t prediction = sch.predict(*ec[0], 0, &oracle, 1, NULL, NULL, my_task_data->y_allowed.begin, y_allowed_size, learner_id); // TODO: do we really need y_allowed?
+      size_t prediction = sch.predict(*ec[0], 0, &oracle, 1, nullptr, nullptr, my_task_data->y_allowed.begin, y_allowed_size, learner_id); // TODO: do we really need y_allowed?
       learner_id= (learner_id << 1) + prediction;
 	  if(prediction == 2)
 	      label += mask;

--- a/vowpalwabbit/search_sequencetask.cc
+++ b/vowpalwabbit/search_sequencetask.cc
@@ -6,10 +6,10 @@ license as described in the file LICENSE.
 #include "search_sequencetask.h"
 #include "vw.h"
 
-namespace SequenceTask         { Search::search_task task = { "sequence",          run, initialize, NULL,   NULL,  NULL     }; }
+namespace SequenceTask         { Search::search_task task = { "sequence",          run, initialize, nullptr,   nullptr,  nullptr     }; }
 namespace SequenceSpanTask     { Search::search_task task = { "sequencespan",      run, initialize, finish, setup, takedown }; }
-namespace ArgmaxTask           { Search::search_task task = { "argmax",            run, initialize, NULL,   NULL,  NULL     }; }
-namespace SequenceTask_DemoLDF { Search::search_task task = { "sequence_demoldf",  run, initialize, finish, NULL,  NULL     }; }
+namespace ArgmaxTask           { Search::search_task task = { "argmax",            run, initialize, nullptr,   nullptr,  nullptr     }; }
+namespace SequenceTask_DemoLDF { Search::search_task task = { "sequence_demoldf",  run, initialize, finish, nullptr,  nullptr     }; }
 
 namespace SequenceTask {
   void initialize(Search::search& sch, size_t& num_actions, po::variables_map& vm) {

--- a/vowpalwabbit/sender.cc
+++ b/vowpalwabbit/sender.cc
@@ -59,7 +59,7 @@ void receive_result(sender& s)
   label_data& ld = ec.l.simple;
   ec.loss = s.all->loss->getLoss(s.all->sd, ec.pred.scalar, ld.label) * ld.weight;
   
-  return_simple_example(*(s.all), NULL, ec);  
+  return_simple_example(*(s.all), nullptr, ec);  
 }
 
 void learn(sender& s, LEARNER::base_learner& base, example& ec) 
@@ -94,7 +94,7 @@ void finish(sender& s)
 LEARNER::base_learner* sender_setup(vw& all)
 {
   if (missing_option<string, true>(all, "sendto", "send examples to <host>"))
-    return NULL;
+    return nullptr;
   
   sender& s = calloc_or_die<sender>();
   s.sd = -1;

--- a/vowpalwabbit/simple_label.cc
+++ b/vowpalwabbit/simple_label.cc
@@ -100,7 +100,7 @@ void parse_simple_label(parser* p, shared_data* sd, void* v, v_array<substring>&
 label_parser simple_label = {default_simple_label, parse_simple_label,
 				   cache_simple_label, read_cached_simple_label, 
 				   delete_simple_label, get_weight,  
-                                   NULL,
+                                   nullptr,
 				   sizeof(label_data)};
 
 void print_update(vw& all, example& ec)

--- a/vowpalwabbit/stagewise_poly.cc
+++ b/vowpalwabbit/stagewise_poly.cc
@@ -225,7 +225,7 @@ using namespace LEARNER;
 
   void sort_data_create(stagewise_poly &poly)
   {
-    poly.sd = NULL;
+    poly.sd = nullptr;
     poly.sd_len = 0;
   }
 
@@ -663,7 +663,7 @@ using namespace LEARNER;
   base_learner *stagewise_poly_setup(vw &all)
   {
     if (missing_option(all, true, "stage_poly", "use stagewise polynomial feature learning"))
-      return NULL;
+      return nullptr;
     
     new_options(all, "Stagewise poly options")
       ("sched_exponent", po::value<float>(), "exponent controlling quantity of included features")
@@ -697,7 +697,7 @@ using namespace LEARNER;
     poly.last_example_counter = -1;
     poly.numpasses = 1;
     poly.update_support = false;
-    poly.original_ec = NULL;
+    poly.original_ec = nullptr;
     poly.next_batch_sz = poly.batch_sz;
 
     learner<stagewise_poly>& l = init_learner(&poly, setup_base(all), learn, predict);

--- a/vowpalwabbit/topk.cc
+++ b/vowpalwabbit/topk.cc
@@ -101,7 +101,7 @@ void finish_example(vw& all, topk& d, example& ec)
 LEARNER::base_learner* topk_setup(vw& all)
 {
   if (missing_option<size_t, false>(all, "top", "top k recommendation"))
-    return NULL;
+    return nullptr;
   
   topk& data = calloc_or_die<topk>();
   data.B = (uint32_t)all.vm["top"].as<size_t>();

--- a/vowpalwabbit/v_array.h
+++ b/vowpalwabbit/v_array.h
@@ -38,7 +38,7 @@ template<class T> struct v_array{
 	{
 	  size_t old_len = end-begin;
 	  begin = (T *)realloc(begin, sizeof(T) * length);
-	  if ((begin == NULL) && ((sizeof(T)*length) > 0)) {
+	  if ((begin == nullptr) && ((sizeof(T)*length) > 0)) {
 	    std::cerr << "realloc of " << length << " failed in resize().  out of memory?" << std::endl;
 	    throw std::exception();
 	  }
@@ -59,9 +59,9 @@ template<class T> struct v_array{
   }
   void delete_v()
   {
-    if (begin != NULL)
+    if (begin != nullptr)
       free(begin);
-    begin = end = end_array = NULL;
+    begin = end = end_array = nullptr;
   }
   void push_back(const T &new_ele)
   {
@@ -144,7 +144,7 @@ inline size_t min(size_t a, size_t b)
 }
 
 template<class T> 
-inline v_array<T> v_init() { return {NULL, NULL, NULL, 0};}
+inline v_array<T> v_init() { return {nullptr, nullptr, nullptr, 0};}
 
 template<class T> void copy_array(v_array<T>& dst, v_array<T> src)
 {

--- a/vowpalwabbit/v_hashmap.h
+++ b/vowpalwabbit/v_hashmap.h
@@ -36,14 +36,14 @@ template<class K, class V> class v_hashmap{
 
   void set_default_value(V def) { default_value = def; }
   
-  void init_dat(size_t min_size, V def, bool (*eq)(void*,K&,K&), void*eq_dat=NULL) {
+  void init_dat(size_t min_size, V def, bool (*eq)(void*,K&,K&), void *eq_dat = nullptr) {
     dat = v_init<hash_elem>();
     if (min_size < 1023) min_size = 1023;
     dat.resize(min_size, true); // resize sets to 0 ==> occupied=false
 
     default_value = def;
     equivalent = eq;
-    equivalent_no_data = NULL;
+    equivalent_no_data = nullptr;
     eq_data = eq_dat;
 
     last_position = 0;
@@ -56,9 +56,9 @@ template<class K, class V> class v_hashmap{
     dat.resize(min_size, true); // resize sets to 0 ==> occupied=false
 
     default_value = def;
-    equivalent = NULL;
+    equivalent = nullptr;
     equivalent_no_data = eq;
-    eq_data = NULL;
+    eq_data = nullptr;
 
     last_position = 0;
     num_occupants = 0;
@@ -69,20 +69,20 @@ template<class K, class V> class v_hashmap{
     if (min_size < 1023) min_size = 1023;
     dat.resize(min_size, true); // resize sets to 0 ==> occupied=false
 
-    equivalent = NULL;
+    equivalent = nullptr;
     equivalent_no_data = eq;
-    eq_data = NULL;
+    eq_data = nullptr;
 
     last_position = 0;
     num_occupants = 0;
   }
   
-  v_hashmap(size_t min_size, V def, bool (*eq)(void*,K&,K&), void*eq_dat=NULL) { init_dat(min_size, def, eq, eq_dat); }
+  v_hashmap(size_t min_size, V def, bool (*eq)(void*,K&,K&), void*eq_dat=nullptr) { init_dat(min_size, def, eq, eq_dat); }
   v_hashmap(size_t min_size, V def, bool (*eq)(K&,K&))                         { init(min_size, def, eq); }
-  v_hashmap() { init(1023, NULL); }
+  v_hashmap() { init(1023, nullptr); }
   
-  void set_equivalent(bool (*eq)(void*,K&,K&), void*eq_dat=NULL) { equivalent = eq; eq_data = eq_dat; equivalent_no_data = NULL; }
-  void set_equivalent(bool (*eq)(K&,K&)) { equivalent_no_data = eq; eq_data = NULL; equivalent = NULL; }
+  void set_equivalent(bool (*eq)(void*,K&,K&), void*eq_dat=nullptr) { equivalent = eq; eq_data = eq_dat; equivalent_no_data = nullptr; }
+  void set_equivalent(bool (*eq)(K&,K&)) { equivalent_no_data = eq; eq_data = nullptr; equivalent = nullptr; }
 
   void delete_v() { dat.delete_v(); }
   
@@ -97,14 +97,14 @@ template<class K, class V> class v_hashmap{
 
   void* iterator_next(void* prev) {
     hash_elem* e = (hash_elem*)prev;
-    if (e == NULL) return NULL;
+    if (e == nullptr) return nullptr;
     e++;
     while (e != dat.end_array) {
       if (e->occupied)
         return e;
       e++;
     }
-    return NULL;
+    return nullptr;
   }
 
   void* iterator() {
@@ -114,7 +114,7 @@ template<class K, class V> class v_hashmap{
         return e;
       e++;
     }
-    return NULL;
+    return nullptr;
   }
 
   V* iterator_get_value(void* el) {
@@ -165,9 +165,9 @@ template<class K, class V> class v_hashmap{
   }
 
   bool is_equivalent(K& key, K& key2) {
-    if ((equivalent == NULL) && (equivalent_no_data == NULL))
+    if ((equivalent == nullptr) && (equivalent_no_data == nullptr))
       return true;
-    else if (equivalent != NULL)
+    else if (equivalent != nullptr)
       return equivalent(eq_data, key, key2);
     else
       return equivalent_no_data(key, key2);

--- a/vowpalwabbit/vwdll.h
+++ b/vowpalwabbit/vwdll.h
@@ -31,14 +31,21 @@ extern "C"
 {
 #endif
 
+#ifdef __cplusplus
+#define VW_TYPE_SAFE_NULL nullptr
+#else
+#define VW_TYPE_SAFE_NULL NULL
+#endif
+
 	typedef void * VW_HANDLE;
 	typedef void * VW_EXAMPLE;
 	typedef void * VW_LABEL;
 	typedef void * VW_FEATURE_SPACE;
 	typedef void * VW_FEATURE;
  
-	const VW_HANDLE INVALID_VW_HANDLE = nullptr;
-	const VW_HANDLE INVALID_VW_EXAMPLE = nullptr;
+	const VW_HANDLE INVALID_VW_HANDLE = VW_TYPE_SAFE_NULL;
+	const VW_HANDLE INVALID_VW_EXAMPLE = VW_TYPE_SAFE_NULL;
+
 #ifdef USE_CODECVT
 	VW_DLL_MEMBER VW_HANDLE VW_CALLING_CONV VW_Initialize(const char16_t * pstrArgs);
 #endif
@@ -93,3 +100,5 @@ extern "C"
 #ifdef __cplusplus
 }
 #endif
+
+#undef VW_TYPE_SAFE_NULL

--- a/vowpalwabbit/vwdll.h
+++ b/vowpalwabbit/vwdll.h
@@ -37,8 +37,8 @@ extern "C"
 	typedef void * VW_FEATURE_SPACE;
 	typedef void * VW_FEATURE;
  
-	const VW_HANDLE INVALID_VW_HANDLE = NULL;
-	const VW_HANDLE INVALID_VW_EXAMPLE = NULL;
+	const VW_HANDLE INVALID_VW_HANDLE = nullptr;
+	const VW_HANDLE INVALID_VW_EXAMPLE = nullptr;
 #ifdef USE_CODECVT
 	VW_DLL_MEMBER VW_HANDLE VW_CALLING_CONV VW_Initialize(const char16_t * pstrArgs);
 #endif


### PR DESCRIPTION
[Primarily stylistic]
Fix compile error in multilabel.cc: '\0' is not a pointer type. It is a character and shouldn't be used as a subsitute for NULL, even if that was previously valid in C. (clang++ 3.7 flagged this as an error.) (Note: it's also possible that the fix in multilabel.cc is incorrect and should have had a pointer dereference.)

Stylistic consistency: Prefer the 'nullptr' keyword over 'NULL' because it is more type safe than NULL (0). 'nullptr' was introduced as part of the C++0x standard; VW requires at least C++0x support to compile.