### PR TITLE
renamed --ftrl_proximal to --ftrl for consistence with documentation

### DIFF
--- a/test/RunTests
+++ b/test/RunTests
@@ -1079,7 +1079,7 @@ __DATA__
     train-sets/ref/0002.autolink.predict
 
 # Test 72: train FTRL-Proximal
-{VW} -k -d train-sets/0001.dat -f models/0001_ftrl.model --passes 1 --ftrl_proximal --ftrl_alpha 0.01 --ftrl_beta 0 --l1 2
+{VW} -k -d train-sets/0001.dat -f models/0001_ftrl.model --passes 1 --ftrl --ftrl_alpha 0.01 --ftrl_beta 0 --l1 2
     train-sets/ref/0001_ftrl.stderr
 
 # Test 73: test FTRL-Proximal

--- a/vowpalwabbit/ftrl.cc
+++ b/vowpalwabbit/ftrl.cc
@@ -137,7 +137,7 @@ void save_load(ftrl& b, io_buf& model_file, bool read, bool text) {
 }
 
 base_learner* ftrl_setup(vw& all) {
-  if (missing_option(all, false, "ftrl_proximal", "FTRL: Follow the Proximal Regularized Leader") &&
+  if (missing_option(all, false, "ftrl", "FTRL: Follow the Proximal Regularized Leader") &&
       missing_option(all, false, "pistol", "FTRL: Parameter-free Stochastic Learning"))
     return nullptr;
   
@@ -154,7 +154,7 @@ base_learner* ftrl_setup(vw& all) {
   void (*learn_ptr)(ftrl&, base_learner&, example&) = nullptr;
   
   string algorithm_name;
-  if (vm.count("ftrl_proximal")) {
+  if (vm.count("ftrl")) {
     algorithm_name = "Proximal-FTRL";
     learn_ptr=learn_proximal;
     if (vm.count("ftrl_alpha"))


### PR DESCRIPTION
The documentation suggests to use the `--ftrl` flag in order to use the FTRL-proximal update rule. I noticed that the flag that was actually supported is `--ftrl_proximal`. I also noticed that there have been a couple of name changes from *ftrl_proximal* to *ftrl* in the code base. So, assuming that you'd want to extend this to the actual command line arguments, I updated those as well. (Conversely, you might want to change `--ftrl` to `--ftrl_proximal` in the docs.)