### PR TITLE
Fixing prediction bug in lda_core.cc and fixing visual studio dependency for ftrl

### DIFF
--- a/test/train-sets/ref/lda-2pass-hang.stderr
+++ b/test/train-sets/ref/lda-2pass-hang.stderr
@@ -8,20 +8,20 @@ Reading datafile = train-sets/lda-2pass-hang.dat
 num sources = 1
 average  since         example        example  current  current  current
 loss     last          counter         weight    label  predict features
-12.797063 12.797063            1            1.0  unknown   0.0000      201
-12.934166 13.071269            2            2.0  unknown   0.0000      220
-13.475956 14.017745            4            4.0  unknown   0.0000      136
-14.728296 15.980637            8            8.0  unknown   0.0000      371
-15.885354 17.042412           16           16.0  unknown   0.0000      138
-17.174063 18.462772           32           32.0  unknown   0.0000      276
-17.150452 17.126840           64           64.0  unknown   0.0000       55
-16.497884 15.845317          128          128.0  unknown   0.0000      131
-15.940502 15.383119          256          256.0  unknown   0.0000      433
-15.306954 14.673407          512          512.0  unknown   0.0000       61
+12.796945 12.796945            1            1.0  unknown   0.0000      201
+12.781804 12.766663            2            2.0  unknown   0.0000      220
+12.801055 12.820307            4            4.0  unknown   0.0000      136
+12.817311 12.833568            8            8.0  unknown   0.0000      371
+12.798675 12.780039           16           16.0  unknown   0.0000      138
+12.797310 12.795944           32           32.0  unknown   0.0000      276
+12.802420 12.807530           64           64.0  unknown   0.0000       55
+12.799834 12.797248          128          128.0  unknown   0.0000      131
+12.800295 12.800757          256          256.0  unknown   0.0000      433
+12.800773 12.801252          512          512.0  unknown   0.0000       61
 
 finished run
 number of examples = 1000
 weighted example sum = 1000.000000
 weighted label sum = 0.000000
-average loss = 14.332565
+average loss = 12.800770
 total feature number = 193156

--- a/test/train-sets/ref/wiki1K.stderr
+++ b/test/train-sets/ref/wiki1K.stderr
@@ -5,21 +5,21 @@ power_t = 0.5
 using no cache
 Reading datafile = train-sets/wiki256.dat
 num sources = 1
-average    since         example     example  current  current  current
-loss       last          counter      weight    label  predict features
-10.149311  10.149311           1         1.0  unknown   0.0000      732
-10.369825  10.590340           2         2.0  unknown   0.0000       27
-10.325934  10.282042           4         4.0  unknown   0.0000       53
-10.401774  10.477614           8         8.0  unknown   0.0000       60
-10.356269  10.310764          16        16.0  unknown   0.0000       26
-10.472941  10.589612          32        32.0  unknown   0.0000      125
-10.474854  10.476768          64        64.0  unknown   0.0000      313
-10.425314  10.375773         128       128.0  unknown   0.0000       50
-10.005564  9.585815          256       256.0  unknown   0.0000       33
+average  since         example        example  current  current  current
+loss     last          counter         weight    label  predict features
+10.149228 10.149228            1            1.0  unknown   0.0000      732
+10.369738 10.590248            2            2.0  unknown   0.0000       27
+10.325845 10.281952            4            4.0  unknown   0.0000       53
+10.401694 10.477542            8            8.0  unknown   0.0000       60
+10.356218 10.310743           16           16.0  unknown   0.0000       26
+10.472917 10.589616           32           32.0  unknown   0.0000      125
+10.474825 10.476733           64           64.0  unknown   0.0000      313
+10.425268 10.375712          128          128.0  unknown   0.0000       50
+10.440290 10.455312          256          256.0  unknown   0.0000       33
 
 finished run
 number of examples = 256
-weighted example sum = 256
-weighted label sum = 0
-average loss = 10.0056
+weighted example sum = 256.000000
+weighted label sum = 0.000000
+average loss = 10.440290
 total feature number = 22158

--- a/vowpalwabbit/lda_core.cc
+++ b/vowpalwabbit/lda_core.cc
@@ -905,6 +905,9 @@ LEARNER::base_learner *lda_setup(vw &all)
   ld.example_t = all.initial_t;
   ld.mmode = vm["math-mode"].as<lda_math_mode>();
 
+  // Add lda_alpha to options serialized as part of the regressor
+  *all.file_options << " --lda_alpha " << ld.lda_alpha;
+
   float temp = ceilf(logf((float)(all.lda * 2 + 1)) / logf(2.f));
   all.reg.stride_shift = (size_t)temp;
   all.random_weights = true;

--- a/vowpalwabbit/vw_static.vcxproj
+++ b/vowpalwabbit/vw_static.vcxproj
@@ -249,7 +249,7 @@
     <ClInclude Include="ect.h" />
     <ClInclude Include="example.h" />
     <ClInclude Include="gd.h" />
-    <ClInclude Include="ftrl_proximal.h" />
+    <ClInclude Include="ftrl.h" />
     <ClInclude Include="memory.h" />
     <ClInclude Include="multiclass.h" />
     <ClInclude Include="cost_sensitive.h" />
@@ -310,7 +310,7 @@
     <ClCompile Include="ect.cc" />
     <ClCompile Include="example.cc" />
     <ClCompile Include="gd.cc" />
-    <ClCompile Include="ftrl_proximal.cc" />
+    <ClCompile Include="ftrl.cc" />
     <ClCompile Include="kernel_svm.cc" />
     <ClCompile Include="multiclass.cc" />
     <ClCompile Include="cost_sensitive.cc" />


### PR DESCRIPTION
Fixes a bug in lda where predictions from a saved model do not match with final predictions during training.  In its current state, the model was doing an M-step during prediction where as only an E-step is requried to get the per-document topic prediction.

During training
.\vw --lda 7 --lda_rho 0.1 --lda_alpha 10 --lda_D 1000 --minibatch 32 --initial_t 100 --power_t 0.5 --passes 10 -b 12 --cache_file lda.cache -f lda.model  -d .\ohsumed.train.vw -k --readable_model lda.readable.model -l 0.01 --lda_epsilon 0.0001 --predictions ohsu.train.raw.topics --ngram 1 ; head ohsu.train.raw.topics

40.903191 35.257618 50.694920 34.024460 27.533512 37.044369 38.541920
56.760464 57.623875 76.206131 55.454617 47.009640 78.992493 55.952812
63.427761 65.763588 115.049309 53.252602 39.610867 52.114376 49.781487
44.057774 36.470482 51.358360 42.869236 34.757214 39.267475 39.219437
31.366035 28.633204 48.045204 36.969185 29.234461 31.105886 38.646046
11.903680 11.334533 11.194602 11.196782 11.694318 11.372726 11.303359
13.832070 14.058607 15.984157 13.778826 13.658925 14.021471 13.665944
42.860920 57.120514 56.260365 62.226589 37.926601 38.908913 64.696045
11.326857 11.528241 11.531357 12.045147 11.769191 11.446932 11.352277
12.698087 12.995925 12.986085 13.195250 12.226443 12.326744 12.571466

Predictions from a serialized model (before fix)
.\vw -i .\lda.model --testonly -d .\ohsumed.train.vw --predictions ohsu.train.topics --lda_rho 1 --lda_alpha 10 --power_t 0.5 --lda_epsilon 0.0001 -l 0; head .\ohsu.train.topics
21.405937 19.527222 145.496857 19.247581 18.430899 20.015324 19.876202
21.516590 20.003817 300.971008 20.382809 21.122417 22.743935 21.259258
23.063681 23.750576 308.721954 20.114212 20.599609 21.494593 21.255234
20.766350 19.311123 167.999390 20.612745 20.269173 19.264744 19.776417
18.315060 17.027956 136.970276 18.626656 17.394779 17.279991 18.385307
11.707281 11.248147 11.832418 11.145329 11.561582 11.258864 11.246379
13.273078 13.472594 19.844521 13.058596 12.866076 13.458078 13.027058
19.794188 20.991304 238.105789 20.877796 20.075378 19.005211 21.150322
11.093449 11.292001 13.362093 11.552471 11.533117 11.125841 11.041027
12.014547 12.003003 17.417271 12.242542 11.771358 11.758262 11.793016

Predictions from a serialized model (after fix)
 .\vw -i .\lda.model --testonly -d ohsumed.train.vw --predictions ohsu.train.topics --lda_alpha 10 ; head ohsu.train.topics
41.282265 32.689079 60.416901 30.587208 27.177851 36.411636 35.435066
45.906059 49.801826 117.833542 43.677597 44.474266 78.435127 47.871529
58.222866 59.172306 165.714050 37.861160 35.882568 42.853050 39.293983
42.543571 34.001694 61.726471 39.835823 34.867638 39.104435 35.920353
31.713186 27.032183 57.966515 34.692886 27.925049 29.555490 35.114697
12.021159 11.331286 10.595111 11.238810 11.959653 11.528491 11.325491
14.140907 14.370205 14.122267 14.016156 13.980987 14.594425 13.775052
36.019691 48.411919 105.645279 47.995098 35.732025 32.243488 53.952488
11.343710 11.496933 11.502791 12.091148 11.891670 11.412170 11.261578
12.853864 13.015150 12.706420 13.152281 12.333153 12.409439 12.529694

ps: training data is from http://boston.lti.cs.cmu.edu/classes/95-865/HW/HW2/