### PR TITLE
Add ezexample_predict & ezexample_train to library/Makefile.am so tests ...

### DIFF
--- a/library/Makefile.am
+++ b/library/Makefile.am
@@ -1,7 +1,14 @@
-bin_PROGRAMS = library_example
+bin_PROGRAMS = library_example ezexample_train ezexample_predict
+EXAMPLE_LIBS = ../vowpalwabbit/libvw.la ../vowpalwabbit/liballreduce.la
 
 library_example_SOURCES = library_example.cc
 library_example_LDADD = ../vowpalwabbit/libvw.la ../vowpalwabbit/liballreduce.la
+
+ezexample_train_SOURCES = ezexample_train.cc
+ezexample_train_LDADD = ${EXAMPLE_LIBS}
+
+ezexample_predict_SOURCES = ezexample_predict.cc
+ezexample_predict_LDADD = ${EXAMPLE_LIBS}
 
 ACLOCAL_AMFLAGS = -I acinclude.d
 


### PR DESCRIPTION
...don't fail after running 'autogen.sh'

Should fix the common failures in `make test` test #59 after `autogen.sh` overwrites original Makefiles. E.g: https://github.com/JohnLangford/vowpal_wabbit/issues/600