### PR TITLE
add API to save model

### DIFF
--- a/cs_test/VowpalWabbitInterface.cs
+++ b/cs_test/VowpalWabbitInterface.cs
@@ -129,5 +129,8 @@ namespace Microsoft.Research.MachineLearning
 
         [DllImport(LIBVW, EntryPoint = "VW_Get_Stride")]
         public static extern SizeT Get_Stride(VwHandle vw);
+
+        [DllImport(LIBVW, EntryPoint = "VW_SaveModel")]
+        public static extern void SaveModel(VwHandle vw);
     }
 }

--- a/vowpalwabbit/parse_regressor.cc
+++ b/vowpalwabbit/parse_regressor.cc
@@ -344,4 +344,11 @@ void parse_mask_regressor_args(vw& all)
   }
 }
 
+namespace VW
+{
+	void save_predictor(vw& all, string reg_name)
+	{
+		dump_regressor(all, reg_name, false);
+	}
+}
 

--- a/vowpalwabbit/vw.h
+++ b/vowpalwabbit/vw.h
@@ -78,6 +78,8 @@ namespace VW {
   primitive_feature_space* export_example(vw& all, example* e, size_t& len);
   void releaseFeatureSpace(primitive_feature_space* features, size_t len);
 
+  void save_predictor(vw& all, string reg_name);
+
   // inlines
 
   //First create the hash of a namespace.

--- a/vowpalwabbit/vwdll.cpp
+++ b/vowpalwabbit/vwdll.cpp
@@ -255,4 +255,17 @@ extern "C"
 		vw* pointer = static_cast<vw*>(handle);
 		return VW::get_stride(*pointer);
 	}
+
+	VW_DLL_MEMBER void VW_CALLING_CONV VW_SaveModel(VW_HANDLE handle)
+	{
+		vw* pointer = static_cast<vw*>(handle);
+
+		string name = pointer->final_regressor_name;
+		if (name.empty())
+		{
+			return;
+		}
+
+		return VW::save_predictor(*pointer, name);
+	}
 }

--- a/vowpalwabbit/vwdll.h
+++ b/vowpalwabbit/vwdll.h
@@ -112,6 +112,8 @@ extern "C"
 	VW_DLL_MEMBER size_t VW_CALLING_CONV VW_Num_Weights(VW_HANDLE handle);
 	VW_DLL_MEMBER size_t VW_CALLING_CONV VW_Get_Stride(VW_HANDLE handle);
 
+	VW_DLL_MEMBER void VW_CALLING_CONV VW_SaveModel(VW_HANDLE handle);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Add a way for saving model at any moment. This is needed when the input
format method does not apply. The input method requires example goes
through generic_driver().