### PR TITLE
unused func args commented out to disable warnings

### DIFF
--- a/vowpalwabbit/allreduce.cc
+++ b/vowpalwabbit/allreduce.cc
@@ -241,7 +241,7 @@ void all_reduce_init(const string master_location, const size_t unique_id, const
 }
 
 
-void pass_down(char* buffer, const size_t parent_read_pos, size_t& children_sent_pos, const socket_t * child_sockets, const size_t n) {
+void pass_down(char* buffer, const size_t parent_read_pos, size_t& children_sent_pos, const socket_t * child_sockets, const size_t /*n*/) {
 
   size_t my_bufsize = min(ar_buf_size, (parent_read_pos - children_sent_pos));
 

--- a/vowpalwabbit/allreduce.h
+++ b/vowpalwabbit/allreduce.h
@@ -60,7 +60,7 @@ template <class T, void (*f)(T&, const T&)> void addbufs(T* buf1, const T* buf2,
 
 void all_reduce_init(const string master_location, const size_t unique_id, const size_t total, const size_t node, node_socks& socks);
 
-template <class T> void pass_up(char* buffer, size_t left_read_pos, size_t right_read_pos, size_t& parent_sent_pos, socket_t parent_sock, size_t n) {
+template <class T> void pass_up(char* buffer, size_t left_read_pos, size_t right_read_pos, size_t& parent_sent_pos, socket_t parent_sock, size_t /*n*/) {
   size_t my_bufsize = min(ar_buf_size, min(left_read_pos, right_read_pos) / sizeof(T) * sizeof(T) - parent_sent_pos);
 
   if(my_bufsize > 0) {

--- a/vowpalwabbit/bfgs.cc
+++ b/vowpalwabbit/bfgs.cc
@@ -514,7 +514,7 @@ double derivative_in_direction(vw& all, bfgs& b, float* mem, int &origin)
   return ret;
 }
   
-void update_weight(vw& all, float step_size, size_t current_pass)
+void update_weight(vw& all, float step_size, size_t /*current_pass*/)
   {
     uint32_t length = 1 << all.num_bits;
     size_t stride = 1 << all.reg.stride_shift;
@@ -814,7 +814,7 @@ void end_pass(bfgs& b)
 }
 
 // placeholder
-void predict(bfgs& b, base_learner& base, example& ec)
+void predict(bfgs& b, base_learner& /*base*/, example& ec)
 {
   vw* all = b.all;
   ec.pred.scalar = bfgs_predict(*all,ec);

--- a/vowpalwabbit/bs.cc
+++ b/vowpalwabbit/bs.cc
@@ -112,7 +112,7 @@ using namespace LEARNER;
     ec.loss = ((ec.pred.scalar == ec.l.simple.label) ? 0.f : 1.f) * ec.l.simple.weight;
   }
 
-  void print_result(int f, float res, float weight, v_array<char> tag, float lb, float ub)
+  void print_result(int f, float res, float /*weight*/, v_array<char> tag, float lb, float ub)
   {
     if (f >= 0)
     {

--- a/vowpalwabbit/cb.cc
+++ b/vowpalwabbit/cb.cc
@@ -47,7 +47,7 @@ namespace CB
     return total;
   }
 
-  float weight(void* v)
+  float weight(void* /*v*/)
   {
     return 1.;
   }
@@ -98,7 +98,7 @@ namespace CB
     return (strncmp(ss.begin, str, len_ss) == 0);
   }
 
-  void parse_label(parser* p, shared_data* sd, void* v, v_array<substring>& words)
+  void parse_label(parser* p, shared_data* /*sd*/, void* v, v_array<substring>& words)
   {
     CB::label* ld = (CB::label*)v;
 

--- a/vowpalwabbit/cb_algs.cc
+++ b/vowpalwabbit/cb_algs.cc
@@ -68,7 +68,7 @@ using namespace CB;
     return nullptr;
   }
 
-  void gen_cs_example_ips(cb& c, example& ec, CB::label& ld, COST_SENSITIVE::label& cs_ld)
+  void gen_cs_example_ips(cb& c, example& /*ec*/, CB::label& ld, COST_SENSITIVE::label& cs_ld)
   {//this implements the inverse propensity score method, where cost are importance weighted by the probability of the chosen action
     //generate cost-sensitive example
     cs_ld.costs.erase();
@@ -278,12 +278,12 @@ using namespace CB;
       }
   }
 
-  void predict_eval(cb& c, base_learner& base, example& ec) {
+  void predict_eval(cb& /*c*/, base_learner& /*base*/, example& /*ec*/) {
     cout << "can not use a test label for evaluation" << endl;
     throw exception();
   }
 
-  void learn_eval(cb& c, base_learner& base, example& ec) {
+  void learn_eval(cb& c, base_learner& /*base*/, example& ec) {
     CB_EVAL::label ld = ec.l.cb_eval;
     
     c.known_cost = get_observed_cost(ld.event);

--- a/vowpalwabbit/cbify.cc
+++ b/vowpalwabbit/cbify.cc
@@ -74,7 +74,7 @@ public:
 
 struct vw_recorder : public IRecorder<vw_context>
 {
-  void Record(vw_context& context, u32 a, float p, string unique_key)
+  void Record(vw_context& context, u32 a, float p, string /*unique_key*/)
   {
     action = a;
     probability = p;

--- a/vowpalwabbit/cost_sensitive.cc
+++ b/vowpalwabbit/cost_sensitive.cc
@@ -74,7 +74,7 @@ namespace COST_SENSITIVE {
     return total;
   }
 
-  float weight(void* v)
+  float weight(void* /*v*/)
   {
     return 1.;
   }
@@ -127,7 +127,7 @@ namespace COST_SENSITIVE {
     return (strncmp(ss.begin, str, len_ss) == 0);
   }
 
-  void parse_label(parser* p, shared_data* sd, void* v, v_array<substring>& words)
+  void parse_label(parser* p, shared_data* /*sd*/, void* v, v_array<substring>& words)
   {
     label* ld = (label*)v;
 

--- a/vowpalwabbit/csoaa.cc
+++ b/vowpalwabbit/csoaa.cc
@@ -180,7 +180,7 @@ void subtract_example(vw& all, example *ec, example *ecsub)
   ec->total_sum_feat_sq += ec->sum_feat_sq[wap_ldf_namespace];
 }
 
-void unsubtract_example(vw& all, example *ec)
+void unsubtract_example(vw& /*all*/, example *ec)
 {
   if (ec->indices.size() == 0) {
     cerr << "internal error (bug): trying to unsubtract_example, but there are no namespaces!" << endl;

--- a/vowpalwabbit/example.cc
+++ b/vowpalwabbit/example.cc
@@ -45,7 +45,7 @@ audit_data copy_audit_data(audit_data &src) {
 }
 
 namespace VW {
-void copy_example_label(example* dst, example* src, size_t label_size, void(*copy_label)(void*,void*)) {
+void copy_example_label(example* dst, example* src, size_t /*label_size*/, void(*copy_label)(void*,void*)) {
   if (copy_label)
     copy_label(&dst->l, &src->l);   // TODO: we really need to delete_label on dst :(
   else
@@ -168,7 +168,7 @@ void free_flatten_example(flat_example* fec)
     }
 }
 
-example *alloc_examples(size_t label_size, size_t count=1)
+example *alloc_examples(size_t /*label_size*/, size_t count = 1)
 {
   example* ec = calloc_or_die<example>(count);
   if (ec == nullptr) return nullptr;

--- a/vowpalwabbit/ftrl.cc
+++ b/vowpalwabbit/ftrl.cc
@@ -30,12 +30,12 @@ struct ftrl {
   struct update_data data;  
 };
   
-void predict(ftrl& b, base_learner& base, example& ec) {
+void predict(ftrl& b, base_learner& /*base*/, example& ec) {
   ec.partial_prediction = GD::inline_predict(*b.all, ec);
   ec.pred.scalar = GD::finalize_prediction(b.all->sd, ec.partial_prediction);
 }
 
-void multipredict(ftrl& b, base_learner& base, example& ec, size_t count, size_t step, polyprediction* pred, bool finalize_predictions) {
+void multipredict(ftrl& b, base_learner& /*base*/, example& ec, size_t count, size_t step, polyprediction* pred, bool finalize_predictions) {
   vw& all = *b.all;
   for (size_t c=0; c<count; c++)
     pred[c].scalar = ec.l.simple.initial;
@@ -93,7 +93,7 @@ void inner_update_pistol_post(update_data& d, float x, float& wref) {
   w[W_G2] += fabs(gradient);
 }
 
-void update_state_and_predict_pistol(ftrl& b, base_learner& base, example& ec) {
+void update_state_and_predict_pistol(ftrl& b, base_learner& /*base*/, example& ec) {
   b.data.predict = 0;
   
   GD::foreach_feature<update_data, inner_update_pistol_state_and_predict>(*b.all, ec, b.data);

--- a/vowpalwabbit/gd_mf.cc
+++ b/vowpalwabbit/gd_mf.cc
@@ -293,7 +293,7 @@ void sd_offset_update(weight* weights, size_t mask, feature* begin, feature* end
 
   void predict(gdmf& d, base_learner&, example& ec) { mf_predict(d,ec); }
 
-  void learn(gdmf& d, base_learner& base, example& ec)
+  void learn(gdmf& d, base_learner& /*base*/, example& ec)
   {
     vw& all = *d.all;
  

--- a/vowpalwabbit/global_data.cc
+++ b/vowpalwabbit/global_data.cc
@@ -74,7 +74,7 @@ void send_prediction(int sock, global_prediction p)
     }
 }
 
-void binary_print_result(int f, float res, float weight, v_array<char> tag)
+void binary_print_result(int f, float res, float weight, v_array<char> /*tag*/)
 {
   if (f >= 0)
     {
@@ -92,7 +92,7 @@ int print_tag(std::stringstream& ss, v_array<char> tag)
   return tag.begin != tag.end;
 }
 
-void print_result(int f, float res, float weight, v_array<char> tag)
+void print_result(int f, float res, float /*weight*/, v_array<char> tag)
 {
   if (f >= 0)
     {
@@ -128,7 +128,7 @@ void print_raw_text(int f, string s, v_array<char> tag)
     }
 }
 
-void print_lda_result(vw& all, int f, float* res, float weight, v_array<char> tag)
+void print_lda_result(vw& all, int f, float* res, float /*weight*/, v_array<char> tag)
 {
   if (f >= 0)
     {
@@ -156,7 +156,7 @@ void set_mm(shared_data* sd, float label)
     sd->max_label = max(sd->max_label, label);
 }
 
-void noop_mm(shared_data* sd, float label)
+void noop_mm(shared_data*, float)
 {}
 
 void vw::learn(example* ec)

--- a/vowpalwabbit/kernel_svm.cc
+++ b/vowpalwabbit/kernel_svm.cc
@@ -384,7 +384,7 @@ struct svm_params {
     }
   }
   
-  void predict(svm_params& params, base_learner &base, example& ec) {
+  void predict(svm_params& params, base_learner &/*base*/, example& ec) {
     flat_example* fec = flatten_sort_example(*(params.all),&ec);    
     if(fec) {
       svm_example* sec = &calloc_or_die<svm_example>(); 
@@ -724,7 +724,7 @@ struct svm_params {
     //cerr<<params.model->support_vec[0]->example_counter<<endl;
   }
 
-  void learn(svm_params& params, base_learner& base, example& ec) {
+  void learn(svm_params& params, base_learner& /*base*/, example& ec) {
     flat_example* fec = flatten_sort_example(*(params.all),&ec);
     // for(int i = 0;i < fec->feature_map_len;i++)
     //   cout<<i<<":"<<fec->feature_map[i].x<<" "<<fec->feature_map[i].weight_index<<" ";

--- a/vowpalwabbit/lda_core.cc
+++ b/vowpalwabbit/lda_core.cc
@@ -583,7 +583,7 @@ namespace
 // setting of lambda based on the document passed in. The value is
 // divided by the total number of words in the document This can be
 // used as a (possibly very noisy) estimate of held-out likelihood.
-float lda_loop(lda &l, v_array<float> &Elogtheta, float *v, weight *weights, example *ec, float power_t)
+float lda_loop(lda &l, v_array<float> &Elogtheta, float *v, weight *weights, example *ec, float /*power_t*/)
 {
   new_gamma.erase();
   old_gamma.erase();
@@ -815,7 +815,7 @@ void learn_batch(lda &l, bool do_m_step = true)
   l.doc_lengths.erase();
 }
 
-void learn(lda &l, LEARNER::base_learner &base, example &ec)
+void learn(lda &l, LEARNER::base_learner &/*base*/, example &ec)
 {
   size_t num_ex = l.examples.size();
   l.examples.push_back(&ec);
@@ -833,7 +833,7 @@ void learn(lda &l, LEARNER::base_learner &base, example &ec)
 }
 
 // placeholder
-void predict(lda &l, LEARNER::base_learner &base, example &ec)
+void predict(lda &l, LEARNER::base_learner &/*base*/, example &ec)
 {
 	size_t num_ex = l.examples.size();
 	l.examples.push_back(&ec);
@@ -867,7 +867,7 @@ void end_examples(lda &l)
   }
 }
 
-void finish_example(vw &all, lda &, example &ec) {}
+void finish_example(vw&, lda&, example &) {}
 
 void finish(lda &ld)
 {

--- a/vowpalwabbit/learner.h
+++ b/vowpalwabbit/learner.h
@@ -60,7 +60,7 @@ namespace LEARNER
   void generic_driver(vw& all);
   
   inline void noop_sl(void*, io_buf&, bool, bool) {}
-  inline void noop(void* data) {}
+  inline void noop(void*) {}
 
   typedef void (*tlearn)(void* d, base_learner& base, example& ec);
   typedef void (*tmultipredict)(void* d, base_learner& base, example& ec, size_t, size_t, polyprediction*, bool);

--- a/vowpalwabbit/log_multi.cc
+++ b/vowpalwabbit/log_multi.cc
@@ -377,7 +377,7 @@ using namespace LEARNER;
     fclose(fp);
   }	
   
-  void finish(log_multi& b)
+  void finish(log_multi& /*b*/)
   {
     //save_node_stats(b);
   }

--- a/vowpalwabbit/loss_functions.cc
+++ b/vowpalwabbit/loss_functions.cc
@@ -70,7 +70,7 @@ public:
       prediction = sd->max_label;
     return 2.f * (prediction-label);
   }
-  float second_derivative(shared_data* sd, float prediction, float label)
+  float second_derivative(shared_data* sd, float prediction, float /*label*/)
   {
     if (prediction <= sd->max_label && prediction >= sd->min_label)
       return 2.;
@@ -111,7 +111,7 @@ public:
   {
     return 2.f * (prediction-label);
   }
-  float second_derivative(shared_data*, float prediction, float label)
+  float second_derivative(shared_data*, float /*prediction*/, float /*label*/)
   {
     return 2.;
   }
@@ -156,7 +156,7 @@ public:
     return (label*prediction >= 1) ? 0 : -label;
   }
 
-  float second_derivative(shared_data*, float prediction, float label)
+  float second_derivative(shared_data*, float /*prediction*/, float /*label*/)
   {
     return 0.;
   }
@@ -287,7 +287,7 @@ public:
     return fd*fd;
   }
 
-  float second_derivative(shared_data*, float prediction, float label)
+  float second_derivative(shared_data*, float /*prediction*/, float /*label*/)
   {
     return 0.;
   }

--- a/vowpalwabbit/multiclass.cc
+++ b/vowpalwabbit/multiclass.cc
@@ -56,9 +56,9 @@ namespace MULTICLASS {
     ld->weight = 1.;
   }
 
-  void delete_label(void* v) {}
+  void delete_label(void* /*v*/) {}
 
-  void parse_label(parser* p, shared_data*, void* v, v_array<substring>& words)
+  void parse_label(parser* /*p*/, shared_data*, void* v, v_array<substring>& words)
   {
     label_t* ld = (label_t*)v;
 

--- a/vowpalwabbit/multilabel.cc
+++ b/vowpalwabbit/multilabel.cc
@@ -45,7 +45,7 @@ namespace MULTILABEL {
     return total;
   }
 
-  float weight(void* v)
+  float weight(void* /*v*/)
   {
     return 1.;
   }
@@ -91,7 +91,7 @@ namespace MULTILABEL {
     }
   }
 
-  void parse_label(parser* p, shared_data* sd, void* v, v_array<substring>& words)
+  void parse_label(parser* p, shared_data* /*sd*/, void* v, v_array<substring>& words)
   {
     labels* ld = (labels*)v;
 
@@ -146,7 +146,7 @@ label_parser multilabel = {default_label, parse_label,
       }
   }
 
-  void print_multilabel(int f, labels& mls, v_array<char>& tag)
+  void print_multilabel(int f, labels& mls, v_array<char>& /*tag*/)
   {
     if (f >= 0)
       {

--- a/vowpalwabbit/multilabel_oaa.cc
+++ b/vowpalwabbit/multilabel_oaa.cc
@@ -42,7 +42,7 @@ void predict_or_learn(oaa& o, LEARNER::base_learner& base, example& ec) {
   ec.l.multilabels = multilabels;
 }
 
-  void finish_example(vw& all, oaa& c, example& ec)
+  void finish_example(vw& all, oaa& /*c*/, example& ec)
   {
     MULTILABEL::output_example(all, ec);
     VW::finish_example(all, &ec);

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -1127,7 +1127,7 @@ float get_cost_sensitive_prediction(example* ec)
        return (float)ec->pred.multiclass;
 }
 
-uint32_t* get_multilabel_predictions(vw& all, example* ec, size_t& len)
+uint32_t* get_multilabel_predictions(vw& /*all*/, example* ec, size_t& len)
 {
     MULTILABEL::labels labels = ec->pred.multilabels;
     len = labels.label_v.size();

--- a/vowpalwabbit/print.cc
+++ b/vowpalwabbit/print.cc
@@ -14,7 +14,7 @@ void print_feature(vw& all, float value, float& weight)
   cout << " ";
 }
 
-void learn(print& p, LEARNER::base_learner& base, example& ec)
+void learn(print& p, LEARNER::base_learner& /*base*/, example& ec)
 {
   label_data& ld = ec.l.simple;
   if (ld.label != FLT_MAX)

--- a/vowpalwabbit/scorer.cc
+++ b/vowpalwabbit/scorer.cc
@@ -20,7 +20,7 @@ void predict_or_learn(scorer& s, LEARNER::base_learner& base, example& ec)
 }
 
 template <float (*link)(float in)>
-inline void multipredict(scorer& s, LEARNER::base_learner& base, example& ec, size_t count, size_t step, polyprediction*pred, bool finalize_predictions) {
+inline void multipredict(scorer& /*s*/, LEARNER::base_learner& base, example& ec, size_t count, size_t /*step*/, polyprediction*pred, bool finalize_predictions) {
   base.multipredict(ec, 0, count, pred, finalize_predictions); // TODO: need to thread step through???
   for (size_t c=0; c<count; c++)
     pred[c].scalar = link(pred[c].scalar);

--- a/vowpalwabbit/search.cc
+++ b/vowpalwabbit/search.cc
@@ -568,7 +568,7 @@ namespace Search {
     return false;
   }
 
-  void add_example_conditioning(search_private& priv, example& ec, const ptag* condition_on, size_t condition_on_cnt, const char* condition_on_names, const action* condition_on_actions) {
+  void add_example_conditioning(search_private& priv, example& ec, const ptag* /*condition_on*/, size_t condition_on_cnt, const char* condition_on_names, const action* condition_on_actions) {
     if (condition_on_cnt == 0) return;
 
     uint32_t extra_offset=0;
@@ -973,7 +973,7 @@ namespace Search {
     return memcmp(A, B, sz_A) == 0;
   }
 
-  void free_key(unsigned char* mem, scored_action a) { free(mem); }
+  void free_key(unsigned char* mem, scored_action /*a*/) { free(mem); }
   void clear_cache_hash_map(search_private& priv) {
     priv.cache_hash_map.iter(free_key);
     priv.cache_hash_map.clear();
@@ -1866,7 +1866,7 @@ namespace Search {
   bool uint32_equal(uint32_t a, uint32_t b) { return a==b; }
   bool size_equal(size_t a, size_t b) { return a==b; }
 
-  template<class T> void check_option(T& ret, vw&all, po::variables_map& vm, const char* opt_name, bool default_to_cmdline, bool(*equal)(T,T), const char* mismatch_error_string, const char* required_error_string) {
+  template<class T> void check_option(T& ret, vw&all, po::variables_map& vm, const char* opt_name, bool /*default_to_cmdline*/, bool(*/*equal*/)(T,T), const char* /*mismatch_error_string*/, const char* required_error_string) {
     if (vm.count(opt_name)) {
       ret = vm[opt_name].as<T>();
       *all.file_options << " --" << opt_name << " " << ret;
@@ -1877,7 +1877,7 @@ namespace Search {
     }
   }
 
-  void check_option(bool& ret, vw&all, po::variables_map& vm, const char* opt_name, bool default_to_cmdline, const char* mismatch_error_string) {
+  void check_option(bool& ret, vw&all, po::variables_map& vm, const char* opt_name, bool /*default_to_cmdline*/, const char* /*mismatch_error_string*/) {
     if (vm.count(opt_name)) {
       ret = true;
       *all.file_options << " --" << opt_name;
@@ -2302,7 +2302,7 @@ namespace Search {
 
 
   void search::set_num_learners(size_t num_learners) { this->priv->num_learners = num_learners; }
-  void search::add_program_options(po::variables_map& vw, po::options_description& opts) { add_options( *this->priv->all, opts ); }
+  void search::add_program_options(po::variables_map& /*vw*/, po::options_description& opts) { add_options( *this->priv->all, opts ); }
 
   size_t search::get_mask() { return this->priv->all->reg.weight_mask;}
   size_t search::get_stride_shift() { return this->priv->all->reg.stride_shift;}

--- a/vowpalwabbit/search_dep_parser.cc
+++ b/vowpalwabbit/search_dep_parser.cc
@@ -23,7 +23,7 @@ struct task_data {
 namespace DepParserTask {
   using namespace Search;
 
-  void initialize(Search::search& srn, size_t& num_actions, po::variables_map& vm) {
+  void initialize(Search::search& srn, size_t& /*num_actions*/, po::variables_map& vm) {
     task_data *data = new task_data();
     data->action_loss.resize(4,true);
     data->ex = NULL;

--- a/vowpalwabbit/search_entityrelationtask.cc
+++ b/vowpalwabbit/search_entityrelationtask.cc
@@ -34,7 +34,7 @@ namespace EntityRelationTask {
   };
 
 
-  void initialize(Search::search& sch, size_t& num_actions, po::variables_map& vm) {
+  void initialize(Search::search& sch, size_t& /*num_actions*/, po::variables_map& vm) {
     task_data * my_task_data = new task_data();
     po::options_description sspan_opts("entity relation options");
     sspan_opts.add_options()
@@ -119,7 +119,7 @@ namespace EntityRelationTask {
     id2 = atoi(s2.c_str());
   }
   
-  size_t predict_entity(Search::search&sch, example* ex, v_array<size_t>& predictions, ptag my_tag, bool isLdf=false){
+  size_t predict_entity(Search::search&sch, example* ex, v_array<size_t>& /*predictions*/, ptag my_tag, bool isLdf=false){
 	  	
     task_data* my_task_data = sch.get_task_data<task_data>();
     size_t prediction;

--- a/vowpalwabbit/search_graph.cc
+++ b/vowpalwabbit/search_graph.cc
@@ -180,7 +180,7 @@ namespace GraphTask {
       D.pred.push_back( D.K+1 );
   }
 
-  void takedown(Search::search& sch, vector<example*>& ec) {
+  void takedown(Search::search& sch, vector<example*>& /*ec*/) {
     task_data& D = *sch.get_task_data<task_data>();
     D.bfs.clear();
     D.pred.clear();
@@ -243,7 +243,7 @@ namespace GraphTask {
     ec[n]->num_features += ec[n]->atomics[neighbor_namespace].size();
   }
   
-  void del_edge_features(task_data&D, uint32_t n, vector<example*>&ec) {
+  void del_edge_features(task_data&/*D*/, uint32_t n, vector<example*>&ec) {
     ec[n]->indices.pop();
     ec[n]->total_sum_feat_sq -= ec[n]->sum_feat_sq[neighbor_namespace];
     ec[n]->num_features -= ec[n]->atomics[neighbor_namespace].size();

--- a/vowpalwabbit/search_hooktask.cc
+++ b/vowpalwabbit/search_hooktask.cc
@@ -37,7 +37,7 @@ namespace HookTask {
     delete td;
   }
 
-  void run(Search::search& sch, vector<example*>& ec) {
+  void run(Search::search& sch, vector<example*>& /*ec*/) {
     task_data *td = sch.get_task_data<task_data>();
     if (td->run_f)
       td->run_f(sch);
@@ -45,12 +45,12 @@ namespace HookTask {
       cerr << "warning: HookTask::structured_predict called before hook is set" << endl;
   }
 
-  void run_setup(Search::search& sch, vector<example*>& ec) {
+  void run_setup(Search::search& sch, vector<example*>& /*ec*/) {
     task_data *td = sch.get_task_data<task_data>();
     if (td->run_setup_f) td->run_setup_f(sch);
   }
 
-  void run_takedown(Search::search& sch, vector<example*>& ec) {
+  void run_takedown(Search::search& sch, vector<example*>& /*ec*/) {
     task_data *td = sch.get_task_data<task_data>();
     if (td->run_takedown_f) td->run_takedown_f(sch);
   }

--- a/vowpalwabbit/search_meta.cc
+++ b/vowpalwabbit/search_meta.cc
@@ -17,17 +17,17 @@ namespace DebugMT {
   void run(Search::search& sch, vector<example*>& ec) {
     sch.base_task(ec)
         .foreach_action(
-            [](Search::search& sch, size_t t, float min_cost, action a, bool taken, float a_cost) -> void {
+            [](Search::search& /*sch*/, size_t t, float min_cost, action a, bool taken, float a_cost) -> void {
               cerr << "==DebugMT== foreach_action(t=" << t << ", min_cost=" << min_cost << ", a=" << a << ", taken=" << taken << ", a_cost=" << a_cost << ")" << endl;
             })
 
         .post_prediction(
-            [](Search::search& sch, size_t t, action a, float a_cost) -> void {
+            [](Search::search& /*sch*/, size_t t, action a, float a_cost) -> void {
               cerr << "==DebugMT== post_prediction(t=" << t << ", a=" << a << ", a_cost=" << a_cost << ")" << endl;
             })
 
         .maybe_override_prediction(
-            [](Search::search& sch, size_t t, action& a, float& a_cost) -> bool {
+            [](Search::search& /*sch*/, size_t t, action& a, float& a_cost) -> bool {
               cerr << "==DebugMT== maybe_override_prediction(t=" << t << ", a=" << a << ", a_cost=" << a_cost << ")" << endl;
               return false;
             })
@@ -75,7 +75,7 @@ namespace SelectiveBranchingMT {
     }
   };
   
-  void initialize(Search::search& sch, size_t& num_actions, po::variables_map& vm) {
+  void initialize(Search::search& sch, size_t& /*num_actions*/, po::variables_map& vm) {
     size_t max_branches = 2;
     size_t kbest = 0;
     po::options_description opts("selective branching options");
@@ -115,7 +115,7 @@ namespace SelectiveBranchingMT {
               cdbg << "adding branch: " << delta << " -> " << branch << endl;
             })
         .post_prediction(
-            [](Search::search& sch, size_t t, action a, float a_cost) -> void {
+            [](Search::search& sch, size_t /*t*/, action a, float a_cost) -> void {
               task_data& d = *sch.get_metatask_data<task_data>();
               d.trajectory.push_back( make_pair(a,a_cost) );
               d.total_cost += a_cost;
@@ -149,7 +149,7 @@ namespace SelectiveBranchingMT {
       
       cdbg << "*** BRANCH " << i << " *** " << d.branches[i].first << " : " << d.branches[i].second << endl;
       sch.base_task(ec)
-          .foreach_action([](Search::search& sch, size_t t, float min_cost, action a, bool taken, float a_cost) -> void {})
+          .foreach_action([](Search::search& /*sch*/, size_t /*t*/, float /*min_cost*/, action /*a*/, bool /*taken*/, float /*a_cost*/) -> void {})
           .maybe_override_prediction(
               [](Search::search& sch, size_t t, action& a, float& a_cost) -> bool {
                 task_data& d = *sch.get_metatask_data<task_data>();
@@ -160,7 +160,7 @@ namespace SelectiveBranchingMT {
                 return true;
               })
           .post_prediction(
-              [](Search::search& sch, size_t t, action a, float a_cost) -> void {
+              [](Search::search& sch, size_t /*t*/, action a, float a_cost) -> void {
                 task_data& d = *sch.get_metatask_data<task_data>();
                 d.trajectory.push_back( make_pair(a,a_cost) );
                 d.total_cost += a_cost;
@@ -194,7 +194,7 @@ namespace SelectiveBranchingMT {
     d.cur_branch = 0;
     d.output_string = nullptr;
     sch.base_task(ec)
-        .foreach_action([](Search::search& sch, size_t t, float min_cost, action a, bool taken, float a_cost) -> void {})
+        .foreach_action([](Search::search& /*sch*/, size_t /*t*/, float /*min_cost*/, action /*a*/, bool /*taken*/, float /*a_cost*/) -> void {})
         .maybe_override_prediction(
             [](Search::search& sch, size_t t, action& a, float& a_cost) -> bool {
               task_data& d = *sch.get_metatask_data<task_data>();

--- a/vowpalwabbit/search_multiclasstask.cc
+++ b/vowpalwabbit/search_multiclasstask.cc
@@ -15,7 +15,7 @@ namespace MulticlassTask {
     v_array<uint32_t> y_allowed;
   };
 
-  void initialize(Search::search& sch, size_t& num_actions, po::variables_map& vm) {
+  void initialize(Search::search& sch, size_t& num_actions, po::variables_map& /*vm*/) {
     task_data * my_task_data = new task_data();
     sch.set_options( 0 );
     sch.set_num_learners(num_actions);

--- a/vowpalwabbit/search_sequencetask.cc
+++ b/vowpalwabbit/search_sequencetask.cc
@@ -12,7 +12,7 @@ namespace ArgmaxTask           { Search::search_task task = { "argmax",         
 namespace SequenceTask_DemoLDF { Search::search_task task = { "sequence_demoldf",  run, initialize, finish, nullptr,  nullptr     }; }
 
 namespace SequenceTask {
-  void initialize(Search::search& sch, size_t& num_actions, po::variables_map& vm) {
+  void initialize(Search::search& sch, size_t& /*num_actions*/, po::variables_map& /*vm*/) {
     sch.set_options( Search::AUTO_CONDITION_FEATURES  |    // automatically add history features to our examples, please
                      Search::AUTO_HAMMING_LOSS        |    // please just use hamming loss on individual predictions -- we won't declare loss
                      Search::EXAMPLES_DONT_CHANGE     |    // we don't do any internal example munging
@@ -204,7 +204,7 @@ namespace ArgmaxTask {
     bool predict_max;
   };
 
-  void initialize(Search::search& sch, size_t& num_actions, po::variables_map& vm) {
+  void initialize(Search::search& sch, size_t& /*num_actions*/, po::variables_map& vm) {
     task_data* D = new task_data();
     
     po::options_description argmax_opts("argmax options");
@@ -260,7 +260,7 @@ namespace SequenceTask_DemoLDF {  // this is just to debug/show off how to do LD
     size_t   num_actions;
   };
   
-  void initialize(Search::search& sch, size_t& num_actions, po::variables_map& vm) {
+  void initialize(Search::search& sch, size_t& num_actions, po::variables_map& /*vm*/) {
     CS::wclass default_wclass = { 0., 0, 0., 0. };
 
     example* ldf_examples = alloc_examples(sizeof(CS::label), num_actions);

--- a/vowpalwabbit/sender.cc
+++ b/vowpalwabbit/sender.cc
@@ -62,7 +62,7 @@ void receive_result(sender& s)
   return_simple_example(*(s.all), nullptr, ec);  
 }
 
-void learn(sender& s, LEARNER::base_learner& base, example& ec) 
+void learn(sender& s, LEARNER::base_learner& /*base*/, example& ec)
 { 
   if (s.received_index + s.all->p->ring_size / 2 - 1 == s.sent_index)
     receive_result(s);
@@ -74,7 +74,7 @@ void learn(sender& s, LEARNER::base_learner& base, example& ec)
   s.delay_ring[s.sent_index++ % s.all->p->ring_size] = &ec;
 }
 
-void finish_example(vw& all, sender&, example& ec){}
+void finish_example(vw&, sender&, example&){}
 
 void end_examples(sender& s)
 { //close our outputs to signal finishing.

--- a/vowpalwabbit/simple_label.cc
+++ b/vowpalwabbit/simple_label.cc
@@ -9,7 +9,7 @@
 
 using namespace std;
 
-char* bufread_simple_label(shared_data* sd, label_data* ld, char* c)
+char* bufread_simple_label(shared_data* /*sd*/, label_data* ld, char* c)
 {
   memcpy(&ld->label, c, sizeof(ld->label));
   c += sizeof(ld->label);
@@ -67,11 +67,11 @@ void default_simple_label(void* v)
   ld->initial = 0.;
 }
 
-void delete_simple_label(void* v)
+void delete_simple_label(void* /*v*/)
 {
 }
 
-void parse_simple_label(parser* p, shared_data* sd, void* v, v_array<substring>& words)
+void parse_simple_label(parser* /*p*/, shared_data* /*sd*/, void* v, v_array<substring>& words)
 {
   label_data* ld = (label_data*)v;
 

--- a/vowpalwabbit/svrg.cc
+++ b/vowpalwabbit/svrg.cc
@@ -50,7 +50,7 @@ float predict_stable(const svrg& s, example& ec)
   return GD::finalize_prediction(s.all->sd, inline_predict<W_STABLE>(*s.all, ec));
 }
 
-void predict(svrg& s, base_learner& base, example& ec)
+void predict(svrg& s, base_learner& /*base*/, example& ec)
 {
   ec.partial_prediction = inline_predict<W_INNER>(*s.all, ec);
   ec.pred.scalar = GD::finalize_prediction(s.all->sd, ec.partial_prediction);


### PR DESCRIPTION
Most of unused function arguments were commented out, few removed and one left as is.
This allows to decrease number of warnings generated by gcc with default parameters from 405 down to 38