### PR TITLE
inv_hash fix for oaa

### DIFF
--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -236,9 +236,16 @@ namespace GD
 
       if(dat.all.current_pass == 0 && dat.all.hash_inv)
       { //for invert_hash
-        if(!dat.all.name_index_map.count(ns_pre)) {
-          dat.all.name_index_map.insert(std::map< std::string, size_t>::value_type(ns_pre, index >> stride_shift));
-        }
+
+          if (dat.offset != 0)
+          {   // otherwise --oaa output no features for class > 0.
+              ostringstream tempstream;
+              tempstream << '[' << (dat.offset >> stride_shift)+1 << ']';
+              ns_pre += tempstream.str();
+          }
+
+          if(!dat.all.name_index_map.count(ns_pre))
+              dat.all.name_index_map.insert(std::map< std::string, size_t>::value_type(ns_pre, index >> stride_shift));
       }
 
   }


### PR DESCRIPTION
This should resolve #648 
Currently `[n]` postfix is added to feature names in inv_hash mode if offset is > 0.
That means in oaa features for classes > 1 will get `[n]` postfix.

I couldn't think out a good way to distinguish cases when `offset` isn't used by learning algo (without additional global variables), thus postfix [1] isn't printed for oaa && `offset == 0`

Example output for `echo -e '3 |f a b c\n2 |f a b c' | vw --oaa 3 -q ff --invert_hash=model.invert`:

```
Constant:202096:-0.132257
Constant[2]:202096:-0.132257
Constant[3]:202096:-0.132257
f^a:57420:-0.132257
f^a*f^b:123444:-0.132257
f^a*f^b[2]:123445:0.014981
f^a*f^b[3]:123446:-0.014981
f^a*f^c:157988:-0.132257
f^a*f^c[2]:157989:0.014981
f^a*f^c[3]:157990:-0.014981
f^a[2]:57420:-0.132257
f^a[3]:57420:-0.132257
f^b:62864:-0.132257
f^b*f^c:126768:-0.132257
f^b*f^c[2]:126769:0.014981
f^b*f^c[3]:126770:-0.014981
f^b[2]:62864:-0.132257
f^b[3]:62864:-0.132257
f^c:228992:-0.132257
f^c[2]:228992:-0.132257
f^c[3]:228992:-0.132257
```