### PR TITLE
default ns now a part of  wildcard

### DIFF
--- a/vowpalwabbit/interactions.h
+++ b/vowpalwabbit/interactions.h
@@ -16,7 +16,7 @@ namespace INTERACTIONS
  */
 
 
-const unsigned char printable_start = '!';
+const unsigned char printable_start = ' ';
 const unsigned char printable_end   = '~';
 const uint32_t valid_ns_size = printable_end - printable_start - 1; // -1 to skip characters ':' and '|' excluded in is_valid_ns()
 

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -585,10 +585,7 @@ void parse_feature_tweaks(vw& all)
                   else
                   { // wildcard found: redefine all except default and break
                       for (size_t i = 0; i < 256; i++)
-                      {
-                          if (i != ' ')
-                              all.redefine[i] = new_namespace;
-                      }
+                         all.redefine[i] = new_namespace;
                       break; //break processing S
                   }
               }


### PR DESCRIPTION
should resolve #649
Wildcard now includes default namespace.
--redefine functionality was adjusted to new interpretation of a wildcard.
Only one line was changed: in interactions.h
And 3 deleted from parse_args.cc

Changes reported in seed_vw_model are due to move of lines in parse.cc - no any changes in these functions were made.
