### PR TITLE
fixing illegal memory access in generated features count evaluation func

### DIFF
--- a/vowpalwabbit/interactions.cc
+++ b/vowpalwabbit/interactions.cc
@@ -371,10 +371,10 @@ void eval_count_of_generated_ft(vw& all, example& ec, size_t& new_features_cnt, 
                 } else { // we are at beginning of a block made of same namespace (interaction is preliminary sorted)
 
                     // let's find out real length of this block
-                    size_t order_of_inter = 2;
+                    size_t order_of_inter = 2; // alredy compared ns == ns+1
 
-                    unsigned char* ns_end = ns + 1;
-                    while ((ns_end < inter->end) && (*ns == *(++ns_end))) ++order_of_inter;
+                    for (unsigned char* ns_end = ns + 2; ns_end < inter->end; ++ns_end)
+                        if (*ns == *ns_end) ++order_of_inter;
 
                     // namespace is same for whole block
                     v_array<feature>& features = ec.atomics[(const int)*ns];

--- a/vowpalwabbit/interactions.cc
+++ b/vowpalwabbit/interactions.cc
@@ -362,7 +362,7 @@ void eval_count_of_generated_ft(vw& all, example& ec, size_t& new_features_cnt, 
 
             for (unsigned char* ns = inter->begin; ns != inter->end; ++ns)
             {
-                if (*ns != *(ns + 1)) // neighbour namespaces are different
+                if ((ns == inter->end-1) || (*ns != *(ns + 1))) // neighbour namespaces are different
                 {   // just multiply precomputed values
                     const int nsc = *ns;
                     num_features_in_inter *= ec.atomics[nsc].size();
@@ -374,7 +374,7 @@ void eval_count_of_generated_ft(vw& all, example& ec, size_t& new_features_cnt, 
                     size_t order_of_inter = 2;
 
                     unsigned char* ns_end = ns + 1;
-                    while (*ns == *(++ns_end)) ++order_of_inter;
+                    while ((ns_end < inter->end) && (*ns == *(++ns_end))) ++order_of_inter;
 
                     // namespace is same for whole block
                     v_array<feature>& features = ec.atomics[(const int)*ns];


### PR DESCRIPTION
With help of valgrind and `-fmudflap` i've found a bug in my own module. It's in function that evaluates 
count of generated features and sum of their squared weights. It didn't affect its results.

It seems sometimes I can compare last element of v_array with v_array->end in a loop like
`for(i; i < arr->end;++i) compare(i, i+1)`
And accessing data of v_array->end is dangerous.
On practice that didn't cause any problems as (v_array->end-1 != v_array->end) with high probability. So I wouldn't notice it without valgrind.

Correctness of function output is checked by testing with enabled DEBUG_EVAL_COUNT_OF_GEN_FT