### PR TITLE
multiple fixes for oaa

### DIFF
--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -280,7 +280,7 @@ void print_features(vw& all, example& ec)
         for (audit_data* a = ns.begin; a != ns.end; ++a)
         {
             audit_interaction(dat, a);
-            audit_feature(dat, a->x, a->weight_index);
+            audit_feature(dat, a->x, a->weight_index + ec.ft_offset);
             audit_interaction(dat, NULL);
         }
       }


### PR DESCRIPTION
First commit for:
```
1) For the non-interaction terms, the value of the first class's coefficient is repeated for each subsequent class. Using Martin's short example, "echo -e '3 |f a b c\n2 |f a b c' | vw --oaa 3 -q ff --invert_hash=model.invert", the invert_hash output and readable_model output for feature "c" are:

f^c:228992:-0.132257
f^c[1]:228992:-0.132257
f^c[2]:228992:-0.132257

228992:-0.132257
228993:0.014981
228994:-0.014981

The quadratic terms match between invert_hash and readable_model.
```

I forgot to add offset to feature weight in case of single feature audit.
Perhaps we'll need some make tests at least for audit/inv_hash after all bugs will be fixed.