### PR TITLE
fix bug on Makefile for mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,12 +43,12 @@ ifeq ($(UNAME), Darwin)
   #	but /opt/local seems to be preferred by some users
   #	so we try them both
   ifneq (,$(wildcard /usr/local/include))
-    BOOST_INCLUDE += -I /usr/local/include
-    BOOST_LIBRARY += -L /usr/local/lib
+    BOOST_INCLUDE = -I /usr/local/include
+    BOOST_LIBRARY = -L /usr/local/lib
   endif
   ifneq (,$(wildcard /opt/local/include))
-    BOOST_INCLUDE += -I /opt/local/include
-    BOOST_LIBRARY += -L /opt/local/lib
+    BOOST_INCLUDE = -I /opt/local/include
+    BOOST_LIBRARY = -L /opt/local/lib
   endif
   NPROCS:=$(shell sysctl -n hw.ncpu)
 endif


### PR DESCRIPTION
Currently there is a bug in the makefile that prevents us from building pyvw correctly
on mac os.

The problem is that BOOST_LIBRARY is set to "-L /usr/lib -L /usr/local/lib"
which is a problem because there is a libpython in /usr/lib that is not the one used to
compile boost, and that libpython hides the one in /usr/local/lib, which is the one we want.

The solution is to set BOOST_LIBRARY to "-L /usr/local/lib" so that the correct
libpython can be found.