### PR TITLE
fix -q :: segfault for mac os

### DIFF
--- a/vowpalwabbit/interactions.cc
+++ b/vowpalwabbit/interactions.cc
@@ -152,7 +152,7 @@ bool comp_interaction (ordered_interaction a, ordered_interaction b)
     if (a.size != b.size)
         return a.size < b.size;
     else
-        return memcmp(a.data, b.data, a.size) <= 0;
+        return memcmp(a.data, b.data, a.size) < 0;
 }
 
 // comparision function for std::sort to sort interactions by their position (to restore original order)


### PR DESCRIPTION
Thanks to Stephen Hoover I've identified a bug in my duplicate interactions filtering code. That piece of code is executed by default and leads to segfault on Mac OS if there are more than 1 interaction specified (or wildcard is used). Unluckily, it wasn't lead to crash on Ubuntu, so I've missed it. Most probably Win isn't affected too.

The problem was caused by violation of [strict ordering rule](http://stackoverflow.com/questions/979759/operator-and-strict-weak-ordering/981299#981299) in custom function passed to `std::sort()`


