### PR TITLE
fix vw[<=7.8] model file compatibility

### DIFF
--- a/vowpalwabbit/parse_regressor.cc
+++ b/vowpalwabbit/parse_regressor.cc
@@ -21,6 +21,7 @@ using namespace std;
 /* Define the last version where files are backward compatible. */
 #define LAST_COMPATIBLE_VERSION "6.1.3"
 #define VERSION_FILE_WITH_CUBIC "6.1.3"
+#define VERSION_FILE_WITH_RANK_IN_HEADER "7.8.0"
 #define VERSION_FILE_WITH_INTERACTIONS "7.10.2"
 
 void initialize_regressor(vw& all)
@@ -198,6 +199,17 @@ void save_load_header(vw& all, io_buf& model_file, bool read, bool text)
           bin_text_read_write_fixed(model_file,buff,0,
                     "", read,
                     "\n",1, text);
+      }
+
+      if (all.model_file_ver <= VERSION_FILE_WITH_RANK_IN_HEADER)
+      { // to fix compatibility broken in 7.9
+          u_int32_t rank = 0;
+          text_len = sprintf(buff, "rank:%d\n", (int)rank);
+          bin_text_read_write_fixed(model_file,(char*)&rank, sizeof(rank),
+                                    "", read,
+                                    buff,text_len, text);
+          if (rank != 0) // rank was used
+              cerr << "WARNING: this model file version is outdated. Unfortunately 'rank: "<< rank << "' value stored in it can't be restored automatically. Please pass it via the command line.";
       }
       
       text_len = sprintf(buff, "lda:%d\n", (int)all.lda);

--- a/vowpalwabbit/parse_regressor.cc
+++ b/vowpalwabbit/parse_regressor.cc
@@ -202,8 +202,8 @@ void save_load_header(vw& all, io_buf& model_file, bool read, bool text)
       }
 
       if (all.model_file_ver <= VERSION_FILE_WITH_RANK_IN_HEADER)
-      { // to fix compatibility broken in 7.9
-          u_int32_t rank = 0;
+      { // to fix compatibility that was broken in 7.9
+          uint32_t rank = 0;
           text_len = sprintf(buff, "rank:%d\n", (int)rank);
           bin_text_read_write_fixed(model_file,(char*)&rank, sizeof(rank),
                                     "", read,


### PR DESCRIPTION
This commit should fix model files compatibility broken in 7.9. It was broken at [this](https://github.com/JohnLangford/vowpal_wabbit/commit/c316ebe62a2a428ab13841195bf7dc5420f5a1db) commit.
just before 7.8 got tag 7.9. The problem is that `all.rank` field was removed from `vw` class and was excluded from saving in model header.
If we read dummy `uint32` at this point - at least simple 7.8 model could be successfully read in 7.10.2

Current solution reads dummy 32bit at place where rank was stored in model files with version <= 7.8.
Note: in case read value != 0 the warning is displayed. The user is asked to pass this value manually via command line.