### PR TITLE
Try coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,12 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libboost-all-dev
   - sudo apt-get install maven
-install: 
+  - sudo pip install cpp-coveralls
+script:
   - make
   - make python
-  - cd java; mvn test
-script: make test
+  - cd java; mvn test; cd ..
+  - make test
+  - make test_gcov --always-make
+after_success:
+  - coveralls --exclude lib --exclude tests --gcov-options '\-lp'

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ license as described in the file LICENSE.
 
 [![Build Status](https://travis-ci.org/JohnLangford/vowpal_wabbit.png)](https://travis-ci.org/JohnLangford/vowpal_wabbit)
 [![Windows Build Status](https://ci.appveyor.com/api/projects/status/github/JohnLangford/vowpal_wabbit?branch=master&svg=true)](https://ci.appveyor.com/project/JohnLangford/vowpal-wabbit)
+[![Coverage Status](https://coveralls.io/repos/JohnLangford/vowpal_wabbit/badge.svg)](https://coveralls.io/r/JohnLangford/vowpal_wabbit)
 
 This is the *vowpal wabbit* fast online learning code.  For Windows, look at README.windows.txt
 


### PR DESCRIPTION
Added 3 new make targets:
vw_gcov, library_example_gcov, test_gcov which build vw and the examples with GCOV support, then run tests.  This allows coveralls to analyze test coverage in the source code, but slows the tests down signifigantly.  I also edited the travis .yml file to upload the results to coveralls.io and added the badge to the readme.

Someone will need to setup a coveralls account for the main VW project and point the badge in the readme to that badge.  Currently the coveralls badge points only to my fork.