### PR TITLE
size_t on 32bit systems cannot be so high

### DIFF
--- a/vowpalwabbit/interactions.cc
+++ b/vowpalwabbit/interactions.cc
@@ -297,7 +297,7 @@ void ft_cnt(eval_gen_data& dat, float fx, uint32_t )
 #endif
 
 // lookup table of factorials up tu 21!
-size_t fast_factorial[] = {1,1,2,6,24,120,720,5040,40320,362880,3628800,39916800,479001600,6227020800,87178291200,1307674368000,
+long long int fast_factorial[] = {1,1,2,6,24,120,720,5040,40320,362880,3628800,39916800,479001600,6227020800,87178291200,1307674368000,
                              20922789888000,355687428096000,6402373705728000,121645100408832000,2432902008176640000};
 const size_t size_fast_factorial = sizeof(fast_factorial)/sizeof(*fast_factorial);
 


### PR DESCRIPTION
Compilation on 32bit systems (and g++ 4.6.3) was broken:

    interactions.cc:301:116: error: narrowing conversion of ‘2432902008176640000ll’
    from ‘long long int’ to ‘size_t {aka unsigned int}’

According to C99, 7.18.4, limit of size_t is (at least) 65535.
Relying on anything bigger is implementation-specific.