### PR TITLE
faster C(n,k) for interactions number estimator

### DIFF
--- a/vowpalwabbit/interactions.cc
+++ b/vowpalwabbit/interactions.cc
@@ -437,19 +437,18 @@ void eval_count_of_generated_ft(vw& all, example& ec, size_t& new_features_cnt, 
 
 
                     size_t n;
-                    if (cnt_ft_weight_non_1 == 0) // number of generated simple combinations is C(n,k) = n!/(n-k)!/k!
+                    if (cnt_ft_weight_non_1 == 0) // number of generated simple combinations is C(n,k)
                     {
-                        n = factor(ft_size, ft_size-order_of_inter);
-                        n /= factor(order_of_inter); // k!
+                        n = choose(ft_size, order_of_inter);
                     } else {
                         n = 0.;
                         for (size_t l = 0; l <= order_of_inter; ++l)
                         {
                             //C(l+m-1, l) * C(n-m, k-l)
-                            size_t num = (l==0)?1:factor(l+cnt_ft_weight_non_1-1, cnt_ft_weight_non_1-1)/factor(l);
+                            size_t num = (l==0)?1:choose(l+cnt_ft_weight_non_1-1, l);
 
                             if (ft_size - cnt_ft_weight_non_1 >= order_of_inter-l)
-                                num *= factor(ft_size - cnt_ft_weight_non_1, ft_size - cnt_ft_weight_non_1 - order_of_inter + l)/factor(order_of_inter-l);
+                                num *= choose(ft_size - cnt_ft_weight_non_1, order_of_inter-l);
                             else num = 0;
 
                             n +=  num;

--- a/vowpalwabbit/interactions.h
+++ b/vowpalwabbit/interactions.h
@@ -419,6 +419,20 @@ inline void generate_interactions(vw& all, example& ec, R& dat)
     generate_interactions<R, S, T, feature, dummy_func<R> > (all, ec, dat, ec.atomics);
 }
 
-} // end of namespace
+// C(n,k) = n!/(k!(n-k)!)
 
+inline long long choose(long long n, long long k) {
+    if (k > n) return 0;
+    if (k<0) return 0;
+    if (k==n) return 1;
+    if (k==0 && n!=0) return 1;
+    long long r = 1;
+    for (long long d = 1; d <= k; ++d) {
+      r *= n--;
+      r /= d;
+    }
+    return r;
+}
+
+} // end of namespace
 


### PR DESCRIPTION
Switched to faster implementation of C(n,k) as proposed by Martin.
C(n,k) is used in estimation of number of generated features for interacting namespaces that called once for each example in parser.cc.
Resolves #703 