### PR TITLE
fixed bug in cached_action_store_or_find()

### DIFF
--- a/vowpalwabbit/search.cc
+++ b/vowpalwabbit/search.cc
@@ -1014,7 +1014,7 @@ namespace Search {
     if (priv.no_caching) return do_store;
     if (mytag == 0) return do_store; // don't attempt to cache when tag is zero
 
-    size_t sz  = sizeof(size_t) + sizeof(ptag) + sizeof(int) + sizeof(size_t) + sizeof(size_t) + condition_on_cnt * (sizeof(ptag) + sizeof(action) + sizeof(char));
+    size_t sz  = sizeof(size_t) + sizeof(ptag) + sizeof(int) + sizeof(size_t) + sizeof(size_t) + condition_on_cnt * (sizeof(ptag) + sizeof(action) + sizeof(uint32_t) + sizeof(char));
     for (size_t i=0; i<condition_on_cnt; i++)
       sz += sizeof(float) * condition_on_actions[i].pp.size();
     if (sz % 4 != 0) sz = 4 * (sz / 4 + 1); // make sure sz aligns to 4 so that uniform_hash does the right thing
@@ -1025,14 +1025,15 @@ namespace Search {
     *here = mytag;             here += sizeof(ptag);
     *here = policy;            here += sizeof(int);
     *here = (unsigned char)learner_id;        here += sizeof(size_t);
-    *here = (unsigned char)condition_on_cnt;  here += (unsigned char)sizeof(size_t);
+    *here = (unsigned char)condition_on_cnt;  here += sizeof(size_t);
     for (size_t i=0; i<condition_on_cnt; i++) {
       uint32_t nf = condition_on_actions[i].pp.size();
       *here = condition_on[i];           here += sizeof(ptag);
       *here = condition_on_actions[i].a; here += sizeof(action);
       *here = nf;                        here += sizeof(uint32_t);
-      for (uint32_t j=0; j<nf; j++)
+      for (uint32_t j=0; j<nf; j++) {
         *here = condition_on_actions[i].pp[j]; here += sizeof(float);
+      }
       *here = condition_on_names[i];     here += sizeof(char);  // SPEEDUP: should we align this at 4?
     }
     uint32_t hash = uniform_hash(item, sz, 3419);


### PR DESCRIPTION
fixed bug that caused the following error in macosx 10.9.5

```
Process:         Python [15981]
Path:            /usr/local/Cellar/python/2.7.10/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python
Identifier:      Python
Version:         2.7.10 (2.7.10)
Code Type:       X86-64 (Native)
Parent Process:  bash [13731]
Responsible:     iTerm [13726]
User ID:         502

Date/Time:       2015-06-25 22:57:08.365 -0700
OS Version:      Mac OS X 10.9.5 (13F34)
Report Version:  11
Anonymous UUID:  373B542D-52A6-CDE6-C399-AF9A7258BD83

Sleep/Wake UUID: 34A2697A-730F-474E-A5D4-50CDAD13240D

Crashed Thread:  0  Dispatch queue: com.apple.main-thread

Exception Type:  EXC_CRASH (SIGABRT)
Exception Codes: 0x0000000000000000, 0x0000000000000000

Application Specific Information:
abort() called
*** error for object 0x7fa6730002f0: incorrect checksum for freed object - object was probably modified after being freed.
 

Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib        	0x00007fff8ab68866 __pthread_kill + 10
1   libsystem_pthread.dylib       	0x00007fff868ad35c pthread_kill + 92
2   libsystem_c.dylib             	0x00007fff87012b1a abort + 125
3   libsystem_malloc.dylib        	0x00007fff83520690 szone_error + 587
4   libsystem_malloc.dylib        	0x00007fff8352219c tiny_free_list_remove_ptr + 294
5   libsystem_malloc.dylib        	0x00007fff8351df8d szone_free_definite_size + 1467
6   pylibvw.so                    	0x000000010287125c Search::cached_action_store_or_find(Search::search_private&, unsigned int, unsigned int const*, char const*, Search::actionpp*, unsigned long, int, unsigned long, unsigned int&, bool, float&) + 636
7   pylibvw.so                    	0x00000001028728a5 Search::search_predict(Search::search_private&, example*, unsigned long, unsigned int, unsigned int const*, unsigned long, unsigned int const*, char const*, unsigned int const*, unsigned long, unsigned long, float&, float) + 3765

Thread 0 crashed with X86 Thread State (64-bit):
  rax: 0x0000000000000000  rbx: 0x00007fff7373d310  rcx: 0x00007fff5d7a2608  rdx: 0x0000000000000000
  rdi: 0x0000000000000d07  rsi: 0x0000000000000006  rbp: 0x00007fff5d7a2630  rsp: 0x00007fff5d7a2608
   r8: 0x0000000000000010   r9: 0x00000000fffffff0  r10: 0x0000000008000000  r11: 0x0000000000000206
  r12: 0x000000010245f000  r13: 0x0000000102464000  r14: 0x0000000000000006  r15: 0x0000000000000000
  rip: 0x00007fff8ab68866  rfl: 0x0000000000000206  cr2: 0x00000001041da000
  
Logical CPU:     0
Error Code:      0x02000148
Trap Number:     133
```