### PR TITLE
minor fixes

### DIFF
--- a/vowpalwabbit/main.cc
+++ b/vowpalwabbit/main.cc
@@ -92,7 +92,7 @@ int main(int argc, char *argv[])
 
     VW::finish(all);
   } catch (VW::vw_exception& e) {
-	  cerr << "vw (" << e.Filename() << ":" << e.LineNumber() << "): " << e.what();
+	  cerr << "vw (" << e.Filename() << ":" << e.LineNumber() << "): " << e.what() << endl;
   } catch (exception& e) {
     // vw is implemented as a library, so we use 'throw runtime_error()'
     // error 'handling' everywhere.  To reduce stderr pollution

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -124,7 +124,7 @@ void parse_dictionary_argument(vw&all, string str) {
 
   char ns = ' ';
   const char*s  = str.c_str();
-  if ((str.length() > 3) && (str[1] == ':')) {
+  if ((str.length() > 2) && (str[1] == ':')) {
     ns = str[0];
     s  += 2;
   }

--- a/vowpalwabbit/vw_exception.cc
+++ b/vowpalwabbit/vw_exception.cc
@@ -2,32 +2,26 @@
 
 namespace VW {
 
-	vw_exception::vw_exception(const char* pfile, int plineNumber, std::string pmessage)
-	  : file(pfile), message(pmessage), lineNumber(plineNumber)
-	{
-	}
+  vw_exception::vw_exception(const char* pfile, int plineNumber, std::string pmessage)
+    : file(pfile), lineNumber(plineNumber), message(pmessage) {
+  }
 
-	vw_exception::vw_exception(const vw_exception& ex)
-	  : file(ex.file), message(ex.message), lineNumber(ex.lineNumber)
-	{
-	}
+  vw_exception::vw_exception(const vw_exception& ex)
+    : file(ex.file), lineNumber(ex.lineNumber), message(ex.message) {
+  }
 
-	vw_exception::~vw_exception() _NOEXCEPT
-	{
-	}
+  vw_exception::~vw_exception() _NOEXCEPT {
+  }
 
-	const char* vw_exception::what() const _NOEXCEPT
-	{
-		return message.c_str();
-	}
-	
-	const char* vw_exception::Filename() const
-	{
-		return file;
-	}
+  const char* vw_exception::what() const _NOEXCEPT {
+    return message.c_str();
+  }
 
-	int vw_exception::LineNumber() const
-	{
-		return lineNumber;
-	}
+  const char* vw_exception::Filename() const {
+    return file;
+  }
+
+  int vw_exception::LineNumber() const {
+    return lineNumber;
+  }
 }

--- a/vowpalwabbit/vw_exception.h
+++ b/vowpalwabbit/vw_exception.h
@@ -16,36 +16,35 @@ license as described in the file LICENSE.
 
 namespace VW {
 
-	class vw_exception : public std::exception
-	{
-	private:
-		// source file exception was thrown
-		const char* file;
+class vw_exception : public std::exception {
+  private:
+    // source file exception was thrown
+    const char* file;
+    // line number exception was thrown
+    int lineNumber;
 
-		std::string message;
+    std::string message;
 
-		// line number exception was thrown
-		int lineNumber;
-	public:
-		vw_exception(const char* file, int lineNumber, std::string message);
+  public:
+    vw_exception(const char* file, int lineNumber, std::string message);
 
-		vw_exception(const vw_exception& ex);
+    vw_exception(const vw_exception& ex);
 
-		~vw_exception() _NOEXCEPT;
+    ~vw_exception() _NOEXCEPT;
 
-		virtual const char* what() const _NOEXCEPT;
+    virtual const char* what() const _NOEXCEPT;
 
-		const char* Filename() const;
+    const char* Filename() const;
 
-		int LineNumber() const;
-	};
+    int LineNumber() const;
+};
 
 // ease error handling and also log filename and line number
 #define THROW(args) \
-	{ \
-		std::stringstream __msg; \
-		__msg << args << std::endl; \
-		throw VW::vw_exception(__FILE__, __LINE__, __msg.str()); \
-	}
+  { \
+    std::stringstream __msg; \
+    __msg << args << std::endl; \
+    throw VW::vw_exception(__FILE__, __LINE__, __msg.str()); \
+  }
 
 }

--- a/vowpalwabbit/vw_exception.h
+++ b/vowpalwabbit/vw_exception.h
@@ -43,7 +43,7 @@ class vw_exception : public std::exception {
 #define THROW(args) \
   { \
     std::stringstream __msg; \
-    __msg << args << std::endl; \
+    __msg << args; \
     throw VW::vw_exception(__FILE__, __LINE__, __msg.str()); \
   }
 

--- a/vowpalwabbit/vw_exception.h
+++ b/vowpalwabbit/vw_exception.h
@@ -44,7 +44,7 @@ namespace VW {
 #define THROW(args) \
 	{ \
 		std::stringstream __msg; \
-		__msg << args; \
+		__msg << args << std::endl; \
 		throw VW::vw_exception(__FILE__, __LINE__, __msg.str()); \
 	}
 


### PR DESCRIPTION
* print a newline after each fatal error
* fix compile-time warnings
* fix an edge case of one-char dictionary filenames (`--dictionary n:f`)