### PR TITLE
added missing variable to example

### DIFF
--- a/python/Learning_to_Search.ipynb
+++ b/python/Learning_to_Search.ipynb
@@ -125,8 +125,9 @@
       "        output = []\n",
       "        for n in range(len(sentence)):\n",
       "            pos,word = sentence[n]\n",
+      "            prevPred = output[n-1] if n > 0 else '<s>'\n",
       "            # use \"with...as...\" to guarantee that the example is finished properly\n",
-      "            with self.vw.example({'w': [word], 'p': [prev_word]}) as ex:\n",
+      "            with self.vw.example({'w': [word], 'p': [prevPred]}) as ex:\n",
       "                pred = self.sch.predict(examples=ex, my_tag=n+1, oracle=pos, condition=[(n,'p'), (n-1, 'q')])\n",
       "                output.append(pred)\n",
       "        return output\n"


### PR DESCRIPTION
The `prev_word` variable is missing from the `SequenceLabeler` example in the Learning_to_Search notebook. This causes a `NameError` when calling `learn()`.

I replaced it with `prevPred` based on the `SequenceLabeler2` example.