### PR TITLE
delete unused variable in example

### DIFF
--- a/python/Learning_to_Search.ipynb
+++ b/python/Learning_to_Search.ipynb
@@ -126,7 +126,7 @@
       "        for n in range(len(sentence)):\n",
       "            pos,word = sentence[n]\n",
       "            # use \"with...as...\" to guarantee that the example is finished properly\n",
-      "            with self.vw.example({'w': [word], 'p': [prev_word]}) as ex:\n",
+      "            with self.vw.example({'w': [word]}) as ex:\n",
       "                pred = self.sch.predict(examples=ex, my_tag=n+1, oracle=pos, condition=[(n,'p'), (n-1, 'q')])\n",
       "                output.append(pred)\n",
       "        return output\n"


### PR DESCRIPTION
Deleted unused variable in SequenceLabeler example in the Learning_to_Search
notebook. This variable causes the following NameError:

```
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
/Users/marcov/repos/vowpal_wabbit/python/pyvw.pyc in run()
     20         self._output = None
     21         self.bogus_example.set_test_only(isTest)
---> 22         def run(): self._output = self._run(my_example)
     23         setup = None
     24         takedown = None

<ipython-input-3-12f679e00325> in _run(self, sentence)
     13             pos,word = sentence[n]
     14             # use "with...as..." to guarantee that the example is finished properly
---> 15             with self.vw.example({'w': [word], 'p': [prev_word]}) as ex:
     16                 pred = self.sch.predict(examples=ex, my_tag=n+1, oracle=pos, condition=[(n,'p'), (n-1, 'q')])
     17                 output.append(pred)

NameError: global name 'prev_word' is not defined

---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-6-d4081d508caf> in <module>()
      1 for i in xrange(10):
----> 2     sequenceLabeler.learn(my_dataset)

/Users/marcov/repos/vowpal_wabbit/python/pyvw.pyc in learn(self, data_iterator)
     32     def learn(self, data_iterator):
     33         for my_example in data_iterator.__iter__():
---> 34             self._call_vw(my_example, isTest=False);
     35 
     36     def example(self, initStringOrDict=None, labelType=pylibvw.vw.lDefault):

/Users/marcov/repos/vowpal_wabbit/python/pyvw.pyc in _call_vw(self, my_example, isTest, useOracle)
     28         self.sch.set_force_oracle(useOracle)
     29         self.vw.learn(self.bogus_example)
---> 30         self.vw.learn(self.blank_line) # this will cause our ._run hook to get called
     31 
     32     def learn(self, data_iterator):

/Users/marcov/repos/vowpal_wabbit/python/pyvw.pyc in learn(self, ec)
     82             if hasattr(ec, 'setup_done') and not ec.setup_done:
     83                 ec.setup_example()
---> 84             pylibvw.vw.learn(self, ec)
     85 
     86     def finish(self):

RuntimeError: std::exception
```