### PR TITLE
Assume adaptive and normalized are off when g is NULL

### DIFF
--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -756,7 +756,7 @@ void save_load_online_state(vw& all, io_buf& model_file, bool read, bool text, g
 	    {
 	      assert (i< length);		
 	      v = &(all.reg.weight_vector[stride*i]);
-	      if (! g->adaptive && ! g->normalized)
+	      if (g == NULL || (! g->adaptive && ! g->normalized))
 		brw += bin_read_fixed(model_file, (char*)v, sizeof(*v), "");
 	      else if ((g->adaptive && !g->normalized) || (!g->adaptive && g->normalized))
 		brw += bin_read_fixed(model_file, (char*)v, sizeof(*v)*2, "");
@@ -776,7 +776,7 @@ void save_load_online_state(vw& all, io_buf& model_file, bool read, bool text, g
 	      int text_len = sprintf(buff, "%d", i);
 	      brw = bin_text_write_fixed(model_file,(char *)&i, sizeof (i),
 					 buff, text_len, text);
-	      if (! g->adaptive && ! g->normalized)
+	      if (g == NULL || (! g->adaptive && ! g->normalized))
 		{
 		  text_len = sprintf(buff, ":%f\n", *v);
 		  brw+= bin_text_write_fixed(model_file,(char *)v, sizeof (*v),


### PR DESCRIPTION
I noticed a segfault when using --ftrl/--pistol and --save_resume stemming from g being NULL in save_load_online_state.

I added a null check to enter the (!adaptive && !normalized) block when g is NULL, and `vw --ftrl -i 1000lines.model -f 1000lines.model --save_resume 1000lines` now doesn't segfault, and produces a lower average loss each time it is run, indicating that things are working.

I'm new to this codebase, so it's not clear to me whether this is the right fix. Would appreciate your feedback.