### PR TITLE
fix vw-hypersearch -e 'command argument'

### DIFF
--- a/utl/vw-hypersearch
+++ b/utl/vw-hypersearch
@@ -581,7 +581,8 @@ sub process_args {
         # Allow users to pass args to the eval script,
         # assume first non-space sequence is the command
         my ($first_word) = ($opt_e =~ /^\s*(\S+)/);
-        usage("-e $opt_e: $!") unless (-e $first_word && -x $first_word);
+        my $is_ex = (-e $first_word && -x $first_word) || qx{which $first_word};
+        usage("-e $opt_e: command not found") unless $is_ex;
         warn "Using external evaluation plug-in: '$opt_e'\n";
     }
 


### PR DESCRIPTION
Previously it did not work unless 'command' is found the current directory:

  master ~/work/vowpal_wabbit $ utl/vw-hypersearch -e 'cat utl/vw-hypersearch' 0 1 echo %
  -e cat utl/vw-hypersearch: No such file or directory
  Usage: vw-hypersearch [options] <lower_bound> <upper_bound> [tolerance] vw-command...
  ...

With this patch it works fine:

  master ~/work/vowpal_wabbit $ utl/vw-hypersearch -e 'cat utl/vw-hypersearch' 0 1 echo %
  Using external evaluation plug-in: 'cat utl/vw-hypersearch'
  trying 0.618033988749895 . 1 (best)
  ...