### PR TITLE
Persist lda_alpha, lda_rho along with the model.

### DIFF
--- a/vowpalwabbit/lda_core.cc
+++ b/vowpalwabbit/lda_core.cc
@@ -926,6 +926,9 @@ LEARNER::base_learner *lda_setup(vw &all)
     all.p->ring_size = all.p->ring_size > minibatch2 ? all.p->ring_size : minibatch2;
   }
 
+  *all.file_options << " --lda_alpha " << ld.lda_alpha;
+  *all.file_options << " --lda_rho " << ld.lda_rho;
+
   ld.v.resize(all.lda * ld.minibatch);
 
   ld.decay_levels.push_back(0.f);

--- a/vowpalwabbit/parse_regressor.cc
+++ b/vowpalwabbit/parse_regressor.cc
@@ -251,12 +251,6 @@ void save_load_header(vw& all, io_buf& model_file, bool read, bool text)
 				"", read, 
 			buff, text_len, text);
 
-		if (read && all.lda > 0)
-		{
-			all.args.push_back("--lda");
-			all.args.push_back(boost::lexical_cast<std::string>(all.lda));
-		}
-      
       uint32_t ngram_len = (uint32_t)all.ngram_strings.size();
       text_len = sprintf(buff, "%d ngram: ", (int)ngram_len);
 		bin_text_read_write_fixed(model_file, (char *)&ngram_len, sizeof(ngram_len),


### PR DESCRIPTION
Remove duplication specification of --lda in test model. It is already persisted as "lda:x" during serialization

Training predictions:
.\vw.exe -k -f lda.model -p predictions.wiki.train --initial_t 0 --power_t 0.5 -d ..\..\..\test\train-sets\wiki256.dat --lda 10 --lda_rho 1 --lda_alpha 10 --lda_D 256 --lda_epsilon 0.000100 -l 0.1 -b 8
https://gist.github.com/sharatsc/a88f60d6ed08479a5172

Testing predictions with master:
.\vw.exe -k -i lda.model -p predictions.wiki.test.wo.alpha.rho -d ..\..\..\test\train-sets\wiki256.dat --lda_epsilon 0.000100 -t
https://gist.github.com/sharatsc/73884a2dc4d2ea22ec25

Testing predictions with master where lda_alpha and lda_rho are explicitly specified:
.\vw.exe -k -i lda.model -p predictions.wiki.test -d ..\..\..\test\train-sets\wiki256.dat --lda_epsilon 0.000100 --lda_rho 1 --lda_alpha 10 -t
https://gist.github.com/sharatsc/e70288cac91c554d8c7d

Testing predictoins w/ fix (note absence of --lda_alpha --lda_rho in the command line)
.\vw.exe -k -i lda.model -p predictions.wiki.test -d ..\..\..\test\train-sets\wiki256.dat --lda_epsilon 0.000100  -t
https://gist.github.com/sharatsc/a876ec80d72257b24559

Background information:
During prediction, only the E step (initialization + lda_loop) is required. The following m-step is unecessary. Also evident from Matt hoffman's python reference code on which gensim package is based
https://github.com/piskvorky/gensim/blob/develop/gensim/models/ldamodel.py
We can effectively disable the M-step by setting eta=0

I attempted to fix this in and earlier attempt (JohnLangford@882f34f#diff-7b22d2fa788bfde9ca32ef49951e4131) and rolled in back in (JohnLangford@05d5b78#diff-7b22d2fa788bfde9ca32ef49951e4131)

The mistake was that rho is used as prior in the code where as rho is used as memory parameter in
https://www.cs.princeton.edu/~blei/papers/HoffmanBleiBach2010b.pdf
I was going by the notation in the paper.