### PR TITLE
python pip installable vowpal wabbit package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,9 @@ VW.creator.user
 VW.files
 VW.includes
 
+# Python package
+build/**
+dist/**
+pyvw.egg-info/**
+python/pyvw.egg-info/**
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,14 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libboost-all-dev
   - sudo apt-get install maven
-  - sudo pip install cpp-coveralls
+  - sudo pip install cpp-coveralls wheel
 script:
   - make
   - make python
   - cd java; mvn test; cd ..
   - make test
   - make test_gcov --always-make
+  - python setup.py sdist
+  - python setup.py bdist_wheel
 after_success:
   - coveralls --exclude lib --exclude tests --gcov-options '\-lp'

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include Makefile Makefile.am configure.ac
+recursive-include vowpalwabbit *.cc *.h *.config Makefile Makefile.am
+recursive-include python *.cc Makefile
+recursive-include explore *.h *.config Makefile

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[metadata]
+description-file = README.md
+

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,17 @@ setup(
     url="https://github.com/JohnLangford/vowpal_wabbit",
     maintainer="trbs",
     maintainer_email="trbs@trbs.net",
-    description="test",
+    description="The Vowpal Wabbit (VW) project is a fast out-of-core learning system.",
+    long_description="""PIP Installable version of Vowpal Wabbit.
+
+You need to have boost (libboost-program-options-dev and libboost-python-dev) and python
+development packages installed on your system for it to build correctly. See the Vowpal Wabbit
+side for more information about building VW.
+
+Since the pyvw wrapper bundled with Vowpal Wabbit links statically to libvw.a this package will
+always build it's own library and (currently) cannot use the system installed libvw.so provided
+by distribution packages.
+""",
     package_dir={'': 'python'},
     py_modules=['pyvw'],
     ext_modules=[pylibvw],

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,56 @@
+import os
+import shutil
+import subprocess
+from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext as _build_ext
+from distutils.command.clean import clean as _clean
+
+VERSION = None
+with open("configure.ac") as f:
+    for line in f:
+        line = line.strip()
+        if 'AC_INIT(' in line:
+            VERSION = line.split(",")[1].replace("[", "").replace("]", "").strip()
+
+if not VERSION:
+    raise Exception("VowPal Wabbit version not found in '%s'" % CONFIG_H)
+
+
+class VWBuildExt(_build_ext):
+    def build_extension(self, ext):
+        subprocess.check_call(["make", "python"])
+        target_dir = os.path.dirname(self.get_ext_fullpath(ext.name))
+        if not os.path.isdir(target_dir):
+            os.makedirs(target_dir)
+        shutil.copy(os.path.join("python", "%s.so" % ext.name), self.get_ext_fullpath(ext.name))
+
+
+class VWClean(_clean):
+    def run(self):
+        _clean.run(self)
+        subprocess.check_call(["make", "clean"])
+
+
+pylibvw = Extension('pylibvw', sources=['python/pylibvw.cc'])
+
+setup(
+    name="pyvw",
+    version=VERSION,
+    url="https://github.com/JohnLangford/vowpal_wabbit",
+    maintainer="trbs",
+    maintainer_email="trbs@trbs.net",
+    description="test",
+    package_dir={'': 'python'},
+    py_modules=['pyvw'],
+    ext_modules=[pylibvw],
+    cmdclass={
+        'build_ext': VWBuildExt,
+        'clean': VWClean,
+    },
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: BSD License',
+        'Topic :: Scientific/Engineering',
+    ],
+)


### PR DESCRIPTION
Initial setup.py that creates a pip installable package for Vowpal Wabbit.

Currently the Python module is statically linked with Vowpal Wabbit.
It would be very nice if we would be able to build the Python module and have it link to the installed libvw.so as well in the future. (result being a ```pyvw``` package that works like the ```pyzmq``` package, using the system libvw.so if available otherwise building it from source)



