### PR TITLE
Unified source code style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+# See http://EditorConfig.org
+# Please, either use an editor supporting editorconfig
+# or set up your editor style according to this file manually
+# or use `astyle --lineend=linux --indent=spaces=2 *.cc *.h`
+# (see http://astyle.sourceforge.net/).
+
+# This is the top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# C++ files
+[*.{cc,h}]
+indent_style = space
+indent_size = 2
+
+# Makefiles need tab indentation
+[Makefile]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false

--- a/vowpalwabbit/accumulate.cc
+++ b/vowpalwabbit/accumulate.cc
@@ -13,21 +13,23 @@ Alekh Agarwal and John Langford, with help Olivier Chapelle.
 #include <cmath>
 #include <stdint.h>
 #include "global_data.h"
-   
+
 using namespace std;
 
-void add_float(float& c1, const float& c2) { c1 += c2; }
+void add_float(float& c1, const float& c2) {
+  c1 += c2;
+}
 
 void accumulate(vw& all, string master_location, regressor& reg, size_t o) {
   uint32_t length = 1 << all.num_bits; //This is size of gradient
   size_t stride = 1 << all.reg.stride_shift;
   float* local_grad = new float[length];
   weight* weights = reg.weight_vector;
-  for(uint32_t i = 0;i < length;i++) 
+  for(uint32_t i = 0; i < length; i++)
     local_grad[i] = weights[stride*i+o];
 
   all_reduce<float, add_float>(local_grad, length, master_location, all.unique_id, all.total, all.node, all.socks);
-  for(uint32_t i = 0;i < length;i++) 
+  for(uint32_t i = 0; i < length; i++)
     weights[stride*i+o] = local_grad[i];
   delete[] local_grad;
 }
@@ -45,25 +47,25 @@ void accumulate_avg(vw& all, string master_location, regressor& reg, size_t o) {
   weight* weights = reg.weight_vector;
   float numnodes = (float)all.total;
 
-  for(uint32_t i = 0;i < length;i++) 
+  for(uint32_t i = 0; i < length; i++)
     local_grad[i] = weights[stride*i+o];
 
   all_reduce<float, add_float>(local_grad, length, master_location, all.unique_id, all.total, all.node, all.socks);
-  for(uint32_t i = 0;i < length;i++) 
+  for(uint32_t i = 0; i < length; i++)
     weights[stride*i+o] = local_grad[i]/numnodes;
   delete[] local_grad;
 }
 
 float max_elem(float* arr, int length) {
   float max = arr[0];
-  for(int i = 1;i < length;i++)
+  for(int i = 1; i < length; i++)
     if(arr[i] > max) max = arr[i];
   return max;
 }
 
 float min_elem(float* arr, int length) {
   float min = arr[0];
-  for(int i = 1;i < length;i++)
+  for(int i = 1; i < length; i++)
     if(arr[i] < min && arr[i] > 0.001) min = arr[i];
   return min;
 }
@@ -78,28 +80,28 @@ void accumulate_weighted_avg(vw& all, string master_location, regressor& reg) {
   weight* weights = reg.weight_vector;
   float* local_weights = new float[length];
 
-  for(uint32_t i = 0;i < length;i++) 
+  for(uint32_t i = 0; i < length; i++)
     local_weights[i] = weights[stride*i+1];
-  
+
   //First compute weights for averaging
   all_reduce<float, add_float>(local_weights, length, master_location, all.unique_id, all.total, all.node, all.socks);
-  
-  for(uint32_t i = 0;i < length;i++) //Compute weighted versions
+
+  for(uint32_t i = 0; i < length; i++) //Compute weighted versions
     if(local_weights[i] > 0) {
       float ratio = weights[stride*i+1]/local_weights[i];
-      local_weights[i] = weights[stride*i] * ratio;      
+      local_weights[i] = weights[stride*i] * ratio;
       weights[stride*i] *= ratio;
-      weights[stride*i+1] *= ratio; //A crude max      
-      if (all.normalized_updates)	
-	weights[stride*i+all.normalized_idx] *= ratio; //A crude max
+      weights[stride*i+1] *= ratio; //A crude max
+      if (all.normalized_updates)
+        weights[stride*i+all.normalized_idx] *= ratio; //A crude max
     }
     else {
       local_weights[i] = 0;
       weights[stride*i] = 0;
     }
-  
+
   all_reduce<float, add_float>(weights, length*stride, master_location, all.unique_id, all.total, all.node, all.socks);
-  
+
   delete[] local_weights;
 }
 

--- a/vowpalwabbit/accumulate.h
+++ b/vowpalwabbit/accumulate.h
@@ -3,7 +3,7 @@ Copyright (c) by respective owners including Yahoo!, Microsoft, and
 individual contributors. All rights reserved.  Released under a BSD
 license as described in the file LICENSE.
  */
-//This implements various accumulate functions building on top of allreduce.  
+//This implements various accumulate functions building on top of allreduce.
 #pragma once
 #include "global_data.h"
 

--- a/vowpalwabbit/active.cc
+++ b/vowpalwabbit/active.cc
@@ -14,151 +14,151 @@ float get_active_coin_bias(float k, float avg_loss, float g, float c0)
   b=(float)(c0*(log(k+1.)+0.0001)/(k+0.0001));
   sb=sqrt(b);
   avg_loss = min(1.f, max(0.f, avg_loss)); //loss should be in [0,1]
-  
+
   sl=sqrt(avg_loss)+sqrt(avg_loss+g);
   if (g<=sb*sl+b)
     return 1;
   rs = (sl+sqrt(sl*sl+4*g))/(2*g);
   return b*rs*rs;
 }
-  
-  float query_decision(active& a, float ec_revert_weight, float k)
-    {
-      float bias, avg_loss, weighted_queries;
-      if (k<=1.)
-	bias=1.;
-      else{
-	weighted_queries = (float)(a.all->initial_t + a.all->sd->weighted_examples - a.all->sd->weighted_unlabeled_examples);
-	avg_loss = (float)(a.all->sd->sum_loss/k + sqrt((1.+0.5*log(k))/(weighted_queries+0.0001)));
-	bias = get_active_coin_bias(k, avg_loss, ec_revert_weight/k, a.active_c0);
-      }
-      if(frand48() < bias)
-	return 1.f / bias;
-      else
-	return -1.;
-    }
 
-  template <bool is_learn>
-  void predict_or_learn_simulation(active& a, base_learner& base, example& ec) {
-    base.predict(ec);
-    
-    if (is_learn)
-      {
-	vw& all = *a.all;
-
-	float k = ec.example_t - ec.l.simple.weight;
-	ec.revert_weight = all.loss->getRevertingWeight(all.sd, ec.pred.scalar, all.eta/powf(k,all.power_t));
-	float importance = query_decision(a, ec.revert_weight, k);
-
-	if(importance > 0){
-	  all.sd->queries += 1;
-	  ec.l.simple.weight *= importance;
-	  base.learn(ec);
-	}
-	else
-	  ec.l.simple.label = FLT_MAX;
-      }
+float query_decision(active& a, float ec_revert_weight, float k)
+{
+  float bias, avg_loss, weighted_queries;
+  if (k<=1.)
+    bias=1.;
+  else {
+    weighted_queries = (float)(a.all->initial_t + a.all->sd->weighted_examples - a.all->sd->weighted_unlabeled_examples);
+    avg_loss = (float)(a.all->sd->sum_loss/k + sqrt((1.+0.5*log(k))/(weighted_queries+0.0001)));
+    bias = get_active_coin_bias(k, avg_loss, ec_revert_weight/k, a.active_c0);
   }
-  
-  template <bool is_learn>
-  void predict_or_learn_active(active& a, base_learner& base, example& ec) {
-    if (is_learn)
+  if(frand48() < bias)
+    return 1.f / bias;
+  else
+    return -1.;
+}
+
+template <bool is_learn>
+void predict_or_learn_simulation(active& a, base_learner& base, example& ec) {
+  base.predict(ec);
+
+  if (is_learn)
+  {
+    vw& all = *a.all;
+
+    float k = ec.example_t - ec.l.simple.weight;
+    ec.revert_weight = all.loss->getRevertingWeight(all.sd, ec.pred.scalar, all.eta/powf(k,all.power_t));
+    float importance = query_decision(a, ec.revert_weight, k);
+
+    if(importance > 0) {
+      all.sd->queries += 1;
+      ec.l.simple.weight *= importance;
       base.learn(ec);
-    else
-      base.predict(ec);
-
-    if (ec.l.simple.label == FLT_MAX) {
-      vw& all = *a.all;
-      float t = (float)(ec.example_t - all.sd->weighted_holdout_examples);
-      ec.revert_weight = all.loss->getRevertingWeight(all.sd, ec.pred.scalar, 
-						      all.eta/powf(t,all.power_t));
     }
+    else
+      ec.l.simple.label = FLT_MAX;
+  }
+}
+
+template <bool is_learn>
+void predict_or_learn_active(active& a, base_learner& base, example& ec) {
+  if (is_learn)
+    base.learn(ec);
+  else
+    base.predict(ec);
+
+  if (ec.l.simple.label == FLT_MAX) {
+    vw& all = *a.all;
+    float t = (float)(ec.example_t - all.sd->weighted_holdout_examples);
+    ec.revert_weight = all.loss->getRevertingWeight(all.sd, ec.pred.scalar,
+                       all.eta/powf(t,all.power_t));
+  }
+}
+
+void active_print_result(int f, float res, float weight, v_array<char> tag)
+{
+  if (f >= 0)
+  {
+    std::stringstream ss;
+    char temp[30];
+    sprintf(temp, "%f", res);
+    ss << temp;
+    if(!print_tag(ss, tag))
+      ss << ' ';
+    if(weight >= 0)
+    {
+      sprintf(temp, " %f", weight);
+      ss << temp;
+    }
+    ss << '\n';
+    ssize_t len = ss.str().size();
+    ssize_t t = io_buf::write_file_or_socket(f, ss.str().c_str(), (unsigned int)len);
+    if (t != len)
+      cerr << "write error: " << strerror(errno) << endl;
+  }
+}
+
+void output_and_account_example(vw& all, active& a, example& ec)
+{
+  label_data& ld = ec.l.simple;
+
+  all.sd->update(ec.test_only, ec.loss, ld.weight, ec.num_features);
+  if (ld.label != FLT_MAX && !ec.test_only)
+    all.sd->weighted_labels += ld.label * ld.weight;
+  all.sd->weighted_unlabeled_examples += ld.label == FLT_MAX ? ld.weight : 0;
+
+  float ai=-1;
+  if(ld.label == FLT_MAX)
+    ai=query_decision(a, ec.revert_weight, (float)all.sd->weighted_unlabeled_examples);
+
+  all.print(all.raw_prediction, ec.partial_prediction, -1, ec.tag);
+  for (size_t i = 0; i<all.final_prediction_sink.size(); i++)
+  {
+    int f = (int)all.final_prediction_sink[i];
+    active_print_result(f, ec.pred.scalar, ai, ec.tag);
   }
 
-  void active_print_result(int f, float res, float weight, v_array<char> tag)
-  {
-    if (f >= 0)
-      {
-	std::stringstream ss;
-	char temp[30];
-	sprintf(temp, "%f", res);
-	ss << temp;
-	if(!print_tag(ss, tag))
-          ss << ' ';
-	if(weight >= 0)
-	  {
-	    sprintf(temp, " %f", weight);
-	    ss << temp;
-	  }
-	ss << '\n';
-	ssize_t len = ss.str().size();
-	ssize_t t = io_buf::write_file_or_socket(f, ss.str().c_str(), (unsigned int)len);
-	if (t != len)
-	  cerr << "write error: " << strerror(errno) << endl;
-      }
-  }
-  
-  void output_and_account_example(vw& all, active& a, example& ec)
-  {
-    label_data& ld = ec.l.simple;
-    
-    all.sd->update(ec.test_only, ec.loss, ld.weight, ec.num_features);
-    if (ld.label != FLT_MAX && !ec.test_only)
-      all.sd->weighted_labels += ld.label * ld.weight;
-    all.sd->weighted_unlabeled_examples += ld.label == FLT_MAX ? ld.weight : 0;
-    
-    float ai=-1; 
-    if(ld.label == FLT_MAX)
-      ai=query_decision(a, ec.revert_weight, (float)all.sd->weighted_unlabeled_examples);
+  print_update(all, ec);
+}
 
-    all.print(all.raw_prediction, ec.partial_prediction, -1, ec.tag);
-    for (size_t i = 0; i<all.final_prediction_sink.size(); i++)
-      {
-	int f = (int)all.final_prediction_sink[i];
-	active_print_result(f, ec.pred.scalar, ai, ec.tag);
-      }
-    
-    print_update(all, ec);
-  }
+void return_active_example(vw& all, active& a, example& ec)
+{
+  output_and_account_example(all, a, ec);
+  VW::finish_example(all,&ec);
+}
 
-  void return_active_example(vw& all, active& a, example& ec)
-  {
-    output_and_account_example(all, a, ec);
-    VW::finish_example(all,&ec);
-  }
-  
 base_learner* active_setup(vw& all)
-{//parse and set arguments
+{ //parse and set arguments
   if(missing_option(all, false, "active", "enable active learning")) return nullptr;
   new_options(all, "Active Learning options")
-    ("simulation", "active learning simulation mode")
-    ("mellowness", po::value<float>(), "active learning mellowness parameter c_0. Default 8");
+  ("simulation", "active learning simulation mode")
+  ("mellowness", po::value<float>(), "active learning mellowness parameter c_0. Default 8");
   add_options(all);
-  
+
   active& data = calloc_or_die<active>();
   data.active_c0 = 8;
   data.all=&all;
-  
+
   if (all.vm.count("mellowness"))
     data.active_c0 = all.vm["mellowness"].as<float>();
-  
+
   if (count(all.args.begin(), all.args.end(),"--lda") != 0)
     THROW("error: you can't combine lda and active learning");
 
   base_learner* base = setup_base(all);
-  
+
   //Create new learner
   learner<active>* l;
   if (all.vm.count("simulation"))
-    l = &init_learner(&data, base, predict_or_learn_simulation<true>, 
-		      predict_or_learn_simulation<false>);
+    l = &init_learner(&data, base, predict_or_learn_simulation<true>,
+                      predict_or_learn_simulation<false>);
   else
-    {
-      all.active = true;
-      l = &init_learner(&data, base, predict_or_learn_active<true>, 
-			predict_or_learn_active<false>);
-      l->set_finish_example(return_active_example);
-    }
-  
+  {
+    all.active = true;
+    l = &init_learner(&data, base, predict_or_learn_active<true>,
+                      predict_or_learn_active<false>);
+    l->set_finish_example(return_active_example);
+  }
+
   return make_base(*l);
 }

--- a/vowpalwabbit/active_interactor.cc
+++ b/vowpalwabbit/active_interactor.cc
@@ -29,124 +29,124 @@ int open_socket(const char* host, unsigned short port)
   he = gethostbyname(host);
 
   if (he == nullptr)
-    {
-      stringstream msg;
-      msg << "gethostbyname(" << host << "): " << strerror(errno);
-      cerr << msg.str() << endl;
-      throw runtime_error(msg.str().c_str());
-    }
+  {
+    stringstream msg;
+    msg << "gethostbyname(" << host << "): " << strerror(errno);
+    cerr << msg.str() << endl;
+    throw runtime_error(msg.str().c_str());
+  }
   int sd = socket(PF_INET, SOCK_STREAM, 0);
   if (sd == -1)
-    {
-      stringstream msg;
-      msg << "socket: " << strerror(errno);
-      cerr << msg.str() << endl;
-      throw runtime_error(msg.str().c_str());
-    }
+  {
+    stringstream msg;
+    msg << "socket: " << strerror(errno);
+    cerr << msg.str() << endl;
+    throw runtime_error(msg.str().c_str());
+  }
   sockaddr_in far_end;
   far_end.sin_family = AF_INET;
   far_end.sin_port = htons(port);
   far_end.sin_addr = *(in_addr*)(he->h_addr);
   memset(&far_end.sin_zero, '\0',8);
   if (connect(sd,(sockaddr*)&far_end, sizeof(far_end)) == -1)
-    {
-      stringstream msg;
-      msg << "connect(" << host << ':' << port << "): " << strerror(errno);
-      cerr << msg.str() << endl;
-      throw runtime_error(msg.str().c_str());
-    }
+  {
+    stringstream msg;
+    msg << "connect(" << host << ':' << port << "): " << strerror(errno);
+    cerr << msg.str() << endl;
+    throw runtime_error(msg.str().c_str());
+  }
   return sd;
 }
 
-int recvall(int s, char* buf, int n){
-    int total=0;
-    int ret=recv(s, buf, n, 0);
-    while(ret>0 && total<n){
-        total+=ret;
-        if(buf[total-1]=='\n')
-            break;
-        ret=recv(s, buf+total, n, 0);
-    }
-    return total;
+int recvall(int s, char* buf, int n) {
+  int total=0;
+  int ret=recv(s, buf, n, 0);
+  while(ret>0 && total<n) {
+    total+=ret;
+    if(buf[total-1]=='\n')
+      break;
+    ret=recv(s, buf+total, n, 0);
+  }
+  return total;
 }
 
-int main(int argc, char* argv[]){
-    char buf[256]; 
-    char* toks,*itok,*ttag;
-    string tag;
-    const char* host="localhost";
-    unsigned short port=~0;
-    ssize_t pos;
-    int s,ret,queries=0;
-    string line;
-    
-    if(argc>1){
-        host = argv[1];
-    }
-    if(argc>2){
-        port=atoi(argv[2]);
-    }
-    if(port <= 1024 || port==(unsigned short)(~0)){
-        port = 26542;
-    }
-    
-    s=open_socket(host, port);
-    size_t id=0;
-    ret=send(s,&id,sizeof(id),0);
-    if(ret<0){
-        const char* msg = "Could not perform handshake!";
-        cerr << msg << endl;
-        throw runtime_error(msg);
-    }
-    
-    while(getline(cin,line)){
-        line.append("\n");
-        int len=line.size();
-        const char* cstr = line.c_str();
-        const char* sp = strchr(cstr,' ');
-        ret=send(s,sp+1,len-(sp+1-cstr),0);
-        if(ret<0){
-            const char* msg = "Could not send unlabeled data!";
-            cerr << msg << endl;
-            throw runtime_error(msg);
-        }
-        ret=recvall(s, buf, 256);
-        if(ret<0){
-	    const char* msg = "Could not receive queries!";
-            cerr << msg << endl;
-            throw runtime_error(msg);
-        }
-        buf[ret]='\0';
-        toks=&buf[0];
-        strsep(&toks," ");
-        ttag=strsep(&toks," ");
-        tag=ttag?string(ttag):string("'empty");
-        itok=strsep(&toks,"\n");
-        if(itok==nullptr || itok[0]=='\0'){
-            continue;
-        }
+int main(int argc, char* argv[]) {
+  char buf[256];
+  char* toks,*itok,*ttag;
+  string tag;
+  const char* host="localhost";
+  unsigned short port=~0;
+  ssize_t pos;
+  int s,ret,queries=0;
+  string line;
 
-        queries+=1;
-        string imp=string(itok)+" "+tag+" |";
-        pos = line.find_first_of ("|");
-        line.replace(pos,1,imp); 
-        cstr = line.c_str();
-        len = line.size();
-        ret = send(s,cstr,len,0);
-        if(ret<0){
-	    const char* msg = "Could not send labeled data!";
-            cerr << msg << endl;
-            throw runtime_error(msg);
-        }
-        ret=recvall(s, buf, 256);
-        if(ret<0){
-	    const char* msg = "Could not receive predictions!";
-            cerr << msg << endl;
-            throw runtime_error(msg);
-        }
+  if(argc>1) {
+    host = argv[1];
+  }
+  if(argc>2) {
+    port=atoi(argv[2]);
+  }
+  if(port <= 1024 || port==(unsigned short)(~0)) {
+    port = 26542;
+  }
+
+  s=open_socket(host, port);
+  size_t id=0;
+  ret=send(s,&id,sizeof(id),0);
+  if(ret<0) {
+    const char* msg = "Could not perform handshake!";
+    cerr << msg << endl;
+    throw runtime_error(msg);
+  }
+
+  while(getline(cin,line)) {
+    line.append("\n");
+    int len=line.size();
+    const char* cstr = line.c_str();
+    const char* sp = strchr(cstr,' ');
+    ret=send(s,sp+1,len-(sp+1-cstr),0);
+    if(ret<0) {
+      const char* msg = "Could not send unlabeled data!";
+      cerr << msg << endl;
+      throw runtime_error(msg);
     }
-    close(s);
-    cout << "Went through the data by doing " << queries << " queries" << endl;
-    return 0;
+    ret=recvall(s, buf, 256);
+    if(ret<0) {
+      const char* msg = "Could not receive queries!";
+      cerr << msg << endl;
+      throw runtime_error(msg);
+    }
+    buf[ret]='\0';
+    toks=&buf[0];
+    strsep(&toks," ");
+    ttag=strsep(&toks," ");
+    tag=ttag?string(ttag):string("'empty");
+    itok=strsep(&toks,"\n");
+    if(itok==nullptr || itok[0]=='\0') {
+      continue;
+    }
+
+    queries+=1;
+    string imp=string(itok)+" "+tag+" |";
+    pos = line.find_first_of ("|");
+    line.replace(pos,1,imp);
+    cstr = line.c_str();
+    len = line.size();
+    ret = send(s,cstr,len,0);
+    if(ret<0) {
+      const char* msg = "Could not send labeled data!";
+      cerr << msg << endl;
+      throw runtime_error(msg);
+    }
+    ret=recvall(s, buf, 256);
+    if(ret<0) {
+      const char* msg = "Could not receive predictions!";
+      cerr << msg << endl;
+      throw runtime_error(msg);
+    }
+  }
+  close(s);
+  cout << "Went through the data by doing " << queries << " queries" << endl;
+  return 0;
 }
 

--- a/vowpalwabbit/allreduce.cc
+++ b/vowpalwabbit/allreduce.cc
@@ -60,17 +60,17 @@ socket_t sock_connect(const uint32_t ip, const int port) {
   size_t count = 0;
   int ret;
   while ( (ret =connect(sock,(sockaddr*)&far_end, sizeof(far_end))) == -1 && count < 100)
-    {
-      count++;
-      stringstream msg;
-      msg << "connect attempt " << count << " failed: " << strerror(errno);
-      cerr << msg.str() << endl;
+  {
+    count++;
+    stringstream msg;
+    msg << "connect attempt " << count << " failed: " << strerror(errno);
+    cerr << msg.str() << endl;
 #ifdef _WIN32
-      Sleep(1);
+    Sleep(1);
 #else
-      sleep(1);
+    sleep(1);
 #endif
-    }
+  }
   if (ret == -1)
     THROW("cannot connect");
   return sock;
@@ -85,9 +85,9 @@ socket_t getsock()
   // SO_REUSEADDR will allow port rebinding on Windows, causing multiple instances
   // of VW on the same machine to potentially contact the wrong tree node.
 #ifndef _WIN32
-    int on = 1;
-    if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (char*)&on, sizeof(on)) < 0)
-      cerr << "setsockopt SO_REUSEADDR: " << strerror(errno) << endl;
+  int on = 1;
+  if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (char*)&on, sizeof(on)) < 0)
+    cerr << "setsockopt SO_REUSEADDR: " << strerror(errno) << endl;
 #endif
 
   // Enable TCP Keep Alive to prevent socket leaks
@@ -132,7 +132,7 @@ void all_reduce_init(const string master_location, const size_t unique_id, const
   if (recv(master_sock, (char*)&ok, sizeof(ok), 0) < (int)sizeof(ok))
     cerr << "read ok failed!" << endl;
   else cerr << "read ok=" << ok << endl;
-  if (!ok) 
+  if (!ok)
     THROW("mapper already connected");
 
   uint16_t kid_count;
@@ -142,7 +142,7 @@ void all_reduce_init(const string master_location, const size_t unique_id, const
   if(recv(master_sock, (char*)&kid_count, sizeof(kid_count), 0) < (int)sizeof(kid_count))
     cerr << "read kid_count failed!" << endl;
   else cerr << "read kid_count=" << kid_count << endl;
-  
+
   socket_t sock = -1;
   short unsigned int netport = htons(26544);
   if(kid_count > 0) {
@@ -200,7 +200,7 @@ void all_reduce_init(const string master_location, const size_t unique_id, const
   if(recv(master_sock, (char*)&parent_port, sizeof(parent_port), 0) < (int)sizeof(parent_port))
     cerr << "read parent_port failed!" << endl;
   else cerr << "read parent_port=" << parent_port << endl;
-  
+
   CLOSESOCK(master_sock);
 
   if(parent_ip != (uint32_t)-1) {
@@ -209,7 +209,8 @@ void all_reduce_init(const string master_location, const size_t unique_id, const
   else
     socks.parent = -1;
 
-  socks.children[0] = -1; socks.children[1] = -1;
+  socks.children[0] = -1;
+  socks.children[1] = -1;
   for (int i = 0; i < kid_count; i++)
   {
     sockaddr_in child_address;
@@ -249,33 +250,33 @@ void pass_down(char* buffer, const size_t parent_read_pos, size_t& children_sent
 
 void broadcast(char* buffer, const size_t n, const socket_t parent_sock, const socket_t * child_sockets) {
 
-   size_t parent_read_pos = 0; //First unread float from parent
-   size_t children_sent_pos = 0; //First unsent float to children
+  size_t parent_read_pos = 0; //First unread float from parent
+  size_t children_sent_pos = 0; //First unsent float to children
   //parent_sent_pos <= left_read_pos
   //parent_sent_pos <= right_read_pos
 
-   if(parent_sock == -1) {
-     parent_read_pos = n;
-   }
-   if(child_sockets[0] == -1 && child_sockets[1] == -1)
-     children_sent_pos = n;
+  if(parent_sock == -1) {
+    parent_read_pos = n;
+  }
+  if(child_sockets[0] == -1 && child_sockets[1] == -1)
+    children_sent_pos = n;
 
-   while (parent_read_pos < n || children_sent_pos < n)
-    {
-      pass_down(buffer, parent_read_pos, children_sent_pos, child_sockets);
-      if(parent_read_pos >= n && children_sent_pos >= n) break;
+  while (parent_read_pos < n || children_sent_pos < n)
+  {
+    pass_down(buffer, parent_read_pos, children_sent_pos, child_sockets);
+    if(parent_read_pos >= n && children_sent_pos >= n) break;
 
-      if (parent_sock != -1) {
-	//there is data to be read from the parent
-	if(parent_read_pos == n) 
-	  THROW("I think parent has no data to send but he thinks he has");
+    if (parent_sock != -1) {
+      //there is data to be read from the parent
+      if(parent_read_pos == n)
+        THROW("I think parent has no data to send but he thinks he has");
 
-	size_t count = min(ar_buf_size,n-parent_read_pos);
-	int read_size = recv(parent_sock, buffer + parent_read_pos, (int)count, 0);
-	if(read_size == -1) {
-	  cerr <<" recv from parent: " << strerror(errno) << endl;
-	}
-	parent_read_pos += read_size;
+      size_t count = min(ar_buf_size,n-parent_read_pos);
+      int read_size = recv(parent_sock, buffer + parent_read_pos, (int)count, 0);
+      if(read_size == -1) {
+        cerr <<" recv from parent: " << strerror(errno) << endl;
       }
+      parent_read_pos += read_size;
     }
+  }
 }

--- a/vowpalwabbit/autolink.cc
+++ b/vowpalwabbit/autolink.cc
@@ -7,7 +7,7 @@ struct autolink {
   uint32_t stride_shift;
 };
 
-template <bool is_learn> 
+template <bool is_learn>
 void predict_or_learn(autolink& b, LEARNER::base_learner& base, example& ec)
 {
   base.predict(ec);
@@ -17,19 +17,19 @@ void predict_or_learn(autolink& b, LEARNER::base_learner& base, example& ec)
   float sum_sq = 0;
   for (size_t i = 0; i < b.d; i++)
     if (base_pred != 0.)
-      {
-	feature f = { base_pred, (uint32_t) (autoconstant + (i << b.stride_shift)) };
-	ec.atomics[autolink_namespace].push_back(f);
-	sum_sq += base_pred*base_pred;
-	base_pred *= ec.pred.scalar;
-      }
+    {
+      feature f = { base_pred, (uint32_t) (autoconstant + (i << b.stride_shift)) };
+      ec.atomics[autolink_namespace].push_back(f);
+      sum_sq += base_pred*base_pred;
+      base_pred *= ec.pred.scalar;
+    }
   ec.total_sum_feat_sq += sum_sq;
-  
+
   if (is_learn)
     base.learn(ec);
   else
     base.predict(ec);
-  
+
   ec.atomics[autolink_namespace].erase();
   ec.indices.pop();
   ec.total_sum_feat_sq -= sum_sq;
@@ -39,12 +39,12 @@ LEARNER::base_learner* autolink_setup(vw& all)
 {
   if (missing_option<size_t, true>(all, "autolink", "create link function with polynomial d"))
     return nullptr;
-  
+
   autolink& data = calloc_or_die<autolink>();
   data.d = (uint32_t)all.vm["autolink"].as<size_t>();
   data.stride_shift = all.reg.stride_shift;
-  
-  LEARNER::learner<autolink>& ret = 
+
+  LEARNER::learner<autolink>& ret =
     init_learner(&data, setup_base(all), predict_or_learn<true>, predict_or_learn<false>);
 
   return make_base(ret);

--- a/vowpalwabbit/beam.h
+++ b/vowpalwabbit/beam.h
@@ -54,8 +54,8 @@ inline int compare_on_hash_then_cost(const void *void_a, const void *void_b) {
   else return 0;
 }
 
- template<class T> class beam {
- private:
+template<class T> class beam {
+private:
   size_t beam_size;   // the beam size -- how many active elements can we have
   size_t count;       // how many elements do we have currently -- should be == to A.size()
   float  pruning_coefficient;  // prune anything with cost >= pruning_coefficient * best, set to FLT_MAX to not do coefficient-based pruning
@@ -68,15 +68,15 @@ inline int compare_on_hash_then_cost(const void *void_a, const void *void_b) {
   //  v_array<v_array<beam_element<T>*>> recomb_buckets;
 
   //  static size_t NUM_RECOMB_BUCKETS = 10231;
-  
+
   bool (*is_equivalent)(T*,T*);  // test if two items are equivalent; nullptr means don't do hypothesis recombination
-  
- public:
+
+public:
   beam(size_t beam_size, float prune_coeff=FLT_MAX, bool (*test_equiv)(T*,T*)=nullptr, bool kbest=false)
-      : beam_size(beam_size)
-      , pruning_coefficient(prune_coeff)
-      , do_kbest(kbest)
-      , is_equivalent(test_equiv)
+    : beam_size(beam_size)
+    , pruning_coefficient(prune_coeff)
+    , do_kbest(kbest)
+    , is_equivalent(test_equiv)
   {
     count = 0;
     worst_cost  = -FLT_MAX;
@@ -91,7 +91,9 @@ inline int compare_on_hash_then_cost(const void *void_a, const void *void_b) {
     if (beam_size == 1) do_kbest = false;  // automatically turn of kbest
   }
 
-  inline bool might_insert(float cost) { return (cost <= prune_if_gt) && ((count < beam_size) || (cost < worst_cost)); }
+  inline bool might_insert(float cost) {
+    return (cost <= prune_if_gt) && ((count < beam_size) || (cost < worst_cost));
+  }
 
   bool insert(T*data, float cost, uint32_t hash) { // returns TRUE iff element was actually added
     if (!might_insert(cost)) return false;
@@ -110,7 +112,7 @@ inline int compare_on_hash_then_cost(const void *void_a, const void *void_b) {
     //       add_recomb_friend(recomb_buckets[i][equiv_pos], be);
     //   }
     // }
-    
+
     if (beam_size < BEAM_CONSTANT_SIZE) {
       // find the worst item and directly replace it
       size_t worst_idx = 0;
@@ -124,7 +126,7 @@ inline int compare_on_hash_then_cost(const void *void_a, const void *void_b) {
         }
       if (cost >= worst_idx_cost)
         return false;
-      
+
       A[worst_idx].hash = hash;
       A[worst_idx].cost = cost;
       A[worst_idx].data = data;
@@ -144,7 +146,7 @@ inline int compare_on_hash_then_cost(const void *void_a, const void *void_b) {
       A.push_back(be);
       count++;
     }
-    
+
     if (cost < best_cost) {
       best_cost = cost;
       best_cost_data = data;
@@ -162,7 +164,7 @@ inline int compare_on_hash_then_cost(const void *void_a, const void *void_b) {
     while ((ret != A.end) && (!ret->active)) ++ret;
     return (ret == A.end) ? nullptr : ret;
   }
-   
+
   beam_element<T>* pop_best_item() {
     if (count == 0)
       return nullptr;
@@ -187,10 +189,10 @@ inline int compare_on_hash_then_cost(const void *void_a, const void *void_b) {
       prune_if_gt = FLT_MAX;
       best_cost_data = nullptr;
     }
-    
+
     return ret;
   }
-   
+
   void do_recombination() {
     qsort(A.begin, A.size(), sizeof(beam_element<T>), compare_on_hash_then_cost);
     size_t start = 0;
@@ -217,7 +219,7 @@ inline int compare_on_hash_then_cost(const void *void_a, const void *void_b) {
       start = end;
     }
   }
-  
+
   void compact(void (*free_data)(T*)=nullptr) {
     if (is_equivalent) do_recombination();
     qsort(A.begin, A.size(), sizeof(beam_element<T>), compare_on_cost); // TODO: quick select
@@ -261,14 +263,24 @@ inline int compare_on_hash_then_cost(const void *void_a, const void *void_b) {
     assert(A.size() == 0);
     A.delete_v();
   }
-  
-  beam_element<T> * begin() { return A.begin; }
-  beam_element<T> * end()   { return A.end; }
-  size_t         size()  { return count; }
-  bool           empty() { return A.empty(); }
-  size_t         get_beam_size() { return beam_size; }
-   
- private:
+
+  beam_element<T> * begin() {
+    return A.begin;
+  }
+  beam_element<T> * end()   {
+    return A.end;
+  }
+  size_t         size()  {
+    return count;
+  }
+  bool           empty() {
+    return A.empty();
+  }
+  size_t         get_beam_size() {
+    return beam_size;
+  }
+
+private:
   // void add_recomb_friend(beam_element<T> *better, beam_element<T> *worse) {
   //   assert( better->cost <= worse->cost );
   //   if (better->recomb_friends == nullptr) {

--- a/vowpalwabbit/best_constant.cc
+++ b/vowpalwabbit/best_constant.cc
@@ -6,77 +6,80 @@ float second_observed_label = FLT_MAX;
 
 bool get_best_constant(vw& all, float& best_constant, float& best_constant_loss)
 {
-    if (    first_observed_label == FLT_MAX || // no non-test labels observed or function was never called
-            (all.loss == nullptr) || (all.sd == nullptr)) return false;
+  if (    first_observed_label == FLT_MAX || // no non-test labels observed or function was never called
+          (all.loss == nullptr) || (all.sd == nullptr)) return false;
 
-    float label1 = first_observed_label; // observed labels might be inside [sd->Min_label, sd->Max_label], so can't use Min/Max
-    float label2 = (second_observed_label == FLT_MAX)?0:second_observed_label; // if only one label observed, second might be 0
-    if (label1 > label2) {float tmp = label1; label1 = label2; label2 = tmp;} // as don't use min/max - make sure label1 < label2
+  float label1 = first_observed_label; // observed labels might be inside [sd->Min_label, sd->Max_label], so can't use Min/Max
+  float label2 = (second_observed_label == FLT_MAX)?0:second_observed_label; // if only one label observed, second might be 0
+  if (label1 > label2) {
+    float tmp = label1;  // as don't use min/max - make sure label1 < label2
+    label1 = label2;
+    label2 = tmp;
+  }
 
-    float label1_cnt;
-    float label2_cnt;
+  float label1_cnt;
+  float label2_cnt;
 
-    if (label1 != label2)
-    {
-        float weighted_labeled_examples = (float)(all.sd->weighted_examples - all.sd->weighted_unlabeled_examples + all.initial_t);
-        label1_cnt = (float) (all.sd->weighted_labels - label2*weighted_labeled_examples)/(label1 - label2);
-        label2_cnt = weighted_labeled_examples - label1_cnt;
-    } else
-        return false;
+  if (label1 != label2)
+  {
+    float weighted_labeled_examples = (float)(all.sd->weighted_examples - all.sd->weighted_unlabeled_examples + all.initial_t);
+    label1_cnt = (float) (all.sd->weighted_labels - label2*weighted_labeled_examples)/(label1 - label2);
+    label2_cnt = weighted_labeled_examples - label1_cnt;
+  } else
+    return false;
 
-    if ( (label1_cnt + label2_cnt) <= 0.) return false;
+  if ( (label1_cnt + label2_cnt) <= 0.) return false;
 
 
-    po::variables_map& vm = all.vm;
+  po::variables_map& vm = all.vm;
 
-    string funcName;
-    if(vm.count("loss_function"))
-        funcName = vm["loss_function"].as<string>();
+  string funcName;
+  if(vm.count("loss_function"))
+    funcName = vm["loss_function"].as<string>();
+  else
+    funcName = "squared";
+
+  if(funcName.compare("squared") == 0 || funcName.compare("Huber") == 0 || funcName.compare("classic") == 0)
+  {
+    best_constant = (float) all.sd->weighted_labels / (float) (all.sd->weighted_examples - all.sd->weighted_unlabeled_examples + all.initial_t); //GENERIC. WAS: (label1*label1_cnt + label2*label2_cnt) / (label1_cnt + label2_cnt);
+
+  } else if (is_more_than_two_labels_observed) {
+    //loss functions below don't have generic formuas for constant yet.
+    return false;
+
+  } else if(funcName.compare("hinge") == 0) {
+
+    best_constant = label2_cnt <= label1_cnt ? -1.f: 1.f;
+
+  } else if(funcName.compare("logistic") == 0) {
+
+    label1 = -1.; //override {-50, 50} to get proper loss
+    label2 =  1.;
+
+    if (label1_cnt <= 0) best_constant = 1.;
+    else if (label2_cnt <= 0) best_constant = -1.;
     else
-        funcName = "squared";
+      best_constant = log(label2_cnt/label1_cnt);
 
-    if(funcName.compare("squared") == 0 || funcName.compare("Huber") == 0 || funcName.compare("classic") == 0)
-    {
-        best_constant = (float) all.sd->weighted_labels / (float) (all.sd->weighted_examples - all.sd->weighted_unlabeled_examples + all.initial_t); //GENERIC. WAS: (label1*label1_cnt + label2*label2_cnt) / (label1_cnt + label2_cnt);
+  } else if(funcName.compare("quantile") == 0 || funcName.compare("pinball") == 0 || funcName.compare("absolute") == 0) {
 
-    } else if (is_more_than_two_labels_observed) {
-        //loss functions below don't have generic formuas for constant yet.
-        return false;
+    float tau = 0.5;
+    if(vm.count("quantile_tau"))
+      tau = vm["quantile_tau"].as<float>();
 
-    } else if(funcName.compare("hinge") == 0) {
+    float q = tau*(label1_cnt + label2_cnt);
+    if (q < label2_cnt) best_constant = label2;
+    else best_constant = label1;
+  } else
+    return false;
 
-        best_constant = label2_cnt <= label1_cnt ? -1.f: 1.f;
+  if (!is_more_than_two_labels_observed)
+  {
+    best_constant_loss =  (label1_cnt>0)?all.loss->getLoss(all.sd, best_constant, label1) * label1_cnt:0.0;
+    best_constant_loss += (label2_cnt>0)?all.loss->getLoss(all.sd, best_constant, label2) * label2_cnt:0.0;
+    best_constant_loss /= label1_cnt + label2_cnt;
+  }
+  else best_constant_loss = FLT_MIN;
 
-    } else if(funcName.compare("logistic") == 0) {
-
-        label1 = -1.; //override {-50, 50} to get proper loss
-        label2 =  1.;
-
-        if (label1_cnt <= 0) best_constant = 1.;
-        else
-            if (label2_cnt <= 0) best_constant = -1.;
-            else
-                best_constant = log(label2_cnt/label1_cnt);
-
-    } else if(funcName.compare("quantile") == 0 || funcName.compare("pinball") == 0 || funcName.compare("absolute") == 0) {
-
-        float tau = 0.5;
-        if(vm.count("quantile_tau"))
-            tau = vm["quantile_tau"].as<float>();
-
-        float q = tau*(label1_cnt + label2_cnt);
-        if (q < label2_cnt) best_constant = label2;
-        else best_constant = label1;
-    } else
-        return false;
-
-    if (!is_more_than_two_labels_observed)
-    {
-      best_constant_loss =  (label1_cnt>0)?all.loss->getLoss(all.sd, best_constant, label1) * label1_cnt:0.0;
-      best_constant_loss += (label2_cnt>0)?all.loss->getLoss(all.sd, best_constant, label2) * label2_cnt:0.0;
-      best_constant_loss /= label1_cnt + label2_cnt;
-    }
-    else best_constant_loss = FLT_MIN;
-
-    return true;
+  return true;
 }

--- a/vowpalwabbit/best_constant.h
+++ b/vowpalwabbit/best_constant.h
@@ -8,22 +8,22 @@ extern float second_observed_label;
 
 inline void count_label(float l)
 {
-    if (is_more_than_two_labels_observed || l == FLT_MAX) return;
+  if (is_more_than_two_labels_observed || l == FLT_MAX) return;
 
-    if (first_observed_label != FLT_MAX)
+  if (first_observed_label != FLT_MAX)
+  {
+
+    if (first_observed_label != l)
     {
+      if (second_observed_label != FLT_MAX)
+      {
+        if (second_observed_label != l)
+          is_more_than_two_labels_observed = true;
 
-        if (first_observed_label != l)
-        {
-            if (second_observed_label != FLT_MAX)
-            {
-                if (second_observed_label != l)
-                    is_more_than_two_labels_observed = true;
+      } else second_observed_label = l;
+    }
 
-            } else second_observed_label = l;
-        }
-
-    } else first_observed_label = l;
+  } else first_observed_label = l;
 
 }
 

--- a/vowpalwabbit/bfgs.cc
+++ b/vowpalwabbit/bfgs.cc
@@ -43,7 +43,7 @@ class curv_exception: public exception {} curv_ex;
 
 /********************************************************************/
 /* mem & w definition ***********************************************/
-/********************************************************************/ 
+/********************************************************************/
 // mem[2*i] = y_t
 // mem[2*i+1] = s_t
 //
@@ -51,61 +51,61 @@ class curv_exception: public exception {} curv_ex;
 // w[1] = accumulated first derivative
 // w[2] = step direction
 // w[3] = preconditioner
-  
-  const float max_precond_ratio = 10000.f;
 
-  struct bfgs {
-    vw* all;//prediction, regressor
-    int m;
-    float rel_threshold; // termination threshold
+const float max_precond_ratio = 10000.f;
 
-    double wolfe1_bound;
-    
-    size_t final_pass;
-    struct timeb t_start, t_end;
-    double net_comm_time;
-    
-    struct timeb t_start_global, t_end_global;
-    double net_time;
-    
-    v_array<float> predictions;
-    size_t example_number;
-    size_t current_pass;
-    size_t no_win_counter;
-    size_t early_stop_thres;
-    
-    // default transition behavior
-    bool first_hessian_on;
-    bool backstep_on;
-    
-    // set by initializer
-    int mem_stride;
-    bool output_regularizer;
-    float* mem;
-    double* rho;
-    double* alpha;
-    
-    weight* regularizers;
-    // the below needs to be included when resetting, in addition to preconditioner and derivative
-    int lastj, origin;
-    double loss_sum, previous_loss_sum;
-    float step_size;
-    double importance_weight_sum;
-    double curvature;
-    
-    // first pass specification
-    bool first_pass;
-    bool gradient_pass;
-    bool preconditioner_pass;
-  };
+struct bfgs {
+  vw* all;//prediction, regressor
+  int m;
+  float rel_threshold; // termination threshold
+
+  double wolfe1_bound;
+
+  size_t final_pass;
+  struct timeb t_start, t_end;
+  double net_comm_time;
+
+  struct timeb t_start_global, t_end_global;
+  double net_time;
+
+  v_array<float> predictions;
+  size_t example_number;
+  size_t current_pass;
+  size_t no_win_counter;
+  size_t early_stop_thres;
+
+  // default transition behavior
+  bool first_hessian_on;
+  bool backstep_on;
+
+  // set by initializer
+  int mem_stride;
+  bool output_regularizer;
+  float* mem;
+  double* rho;
+  double* alpha;
+
+  weight* regularizers;
+  // the below needs to be included when resetting, in addition to preconditioner and derivative
+  int lastj, origin;
+  double loss_sum, previous_loss_sum;
+  float step_size;
+  double importance_weight_sum;
+  double curvature;
+
+  // first pass specification
+  bool first_pass;
+  bool gradient_pass;
+  bool preconditioner_pass;
+};
 
 const char* curv_message = "Zero or negative curvature detected.\n"
-      "To increase curvature you can increase regularization or rescale features.\n"
-      "It is also possible that you have reached numerical accuracy\n"
-      "and further decrease in the objective cannot be reliably detected.\n";
+                           "To increase curvature you can increase regularization or rescale features.\n"
+                           "It is also possible that you have reached numerical accuracy\n"
+                           "and further decrease in the objective cannot be reliably detected.\n";
 
 void zero_derivative(vw& all)
-{//set derivative to 0.
+{ //set derivative to 0.
   uint32_t length = 1 << all.num_bits;
   size_t stride_shift = all.reg.stride_shift;
   weight* weights = all.reg.weight_vector;
@@ -114,7 +114,7 @@ void zero_derivative(vw& all)
 }
 
 void zero_preconditioner(vw& all)
-{//set derivative to 0.
+{ //set derivative to 0.
   uint32_t length = 1 << all.num_bits;
   size_t stride_shift = all.reg.stride_shift;
   weight* weights = all.reg.weight_vector;
@@ -132,10 +132,10 @@ void reset_state(vw& all, bfgs& b, bool zero)
   b.gradient_pass = true;
   b.preconditioner_pass = true;
   if (zero)
-    {
-      zero_derivative(all);
-      zero_preconditioner(all);
-    }
+  {
+    zero_derivative(all);
+    zero_preconditioner(all);
+  }
 }
 
 // w[0] = weight
@@ -148,11 +148,11 @@ bool test_example(example& ec)
   return ec.l.simple.label == FLT_MAX;
 }
 
-  float bfgs_predict(vw& all, example& ec)
-  {
-    ec.partial_prediction = GD::inline_predict(all,ec);
-    return GD::finalize_prediction(all.sd, ec.partial_prediction);
-  }
+float bfgs_predict(vw& all, example& ec)
+{
+  ec.partial_prediction = GD::inline_predict(all,ec);
+  return GD::finalize_prediction(all.sd, ec.partial_prediction);
+}
 
 inline void add_grad(float& d, float f, float& fw)
 {
@@ -167,11 +167,11 @@ float predict_and_gradient(vw& all, example &ec)
   all.set_minmax(all.sd, ld.label);
 
   float loss_grad = all.loss->first_derivative(all.sd, fp,ld.label)*ld.weight;
-  
+
   ec.ft_offset += W_GT;
   GD::foreach_feature<float,add_grad>(all, ec, loss_grad);
   ec.ft_offset -= W_GT;
-  
+
   return fp;
 }
 
@@ -184,16 +184,16 @@ void update_preconditioner(vw& all, example& ec)
 {
   label_data& ld = ec.l.simple;
   float curvature = all.loss->second_derivative(all.sd, ec.pred.scalar, ld.label) * ld.weight;
-  
+
   ec.ft_offset += W_COND;
-  GD::foreach_feature<float,add_precond>(all, ec, curvature);  
+  GD::foreach_feature<float,add_precond>(all, ec, curvature);
   ec.ft_offset -= W_COND;
-}  
+}
 
 
 float dot_with_direction(vw& all, example& ec)
 {
-  ec.ft_offset+= W_DIR;  
+  ec.ft_offset+= W_DIR;
   float ret = GD::inline_predict(all, ec);
   ec.ft_offset-= W_DIR;
 
@@ -201,9 +201,9 @@ float dot_with_direction(vw& all, example& ec)
 }
 
 double regularizer_direction_magnitude(vw& all, bfgs& b, float regularizer)
-{//compute direction magnitude
+{ //compute direction magnitude
   double ret = 0.;
-  
+
   if (regularizer == 0.)
     return ret;
 
@@ -214,21 +214,21 @@ double regularizer_direction_magnitude(vw& all, bfgs& b, float regularizer)
     for(uint32_t i = 0; i < length; i++)
       ret += regularizer*weights[(i << stride_shift)+W_DIR]*weights[(i << stride_shift)+W_DIR];
   else
-    for(uint32_t i = 0; i < length; i++) 
+    for(uint32_t i = 0; i < length; i++)
       ret += b.regularizers[2*i]*weights[(i << stride_shift)+W_DIR]*weights[(i << stride_shift)+W_DIR];
 
   return ret;
 }
 
 float direction_magnitude(vw& all)
-{//compute direction magnitude
+{ //compute direction magnitude
   double ret = 0.;
   uint32_t length = 1 << all.num_bits;
   size_t stride_shift = all.reg.stride_shift;
   weight* weights = all.reg.weight_vector;
   for(uint32_t i = 0; i < length; i++)
     ret += weights[(i << stride_shift)+W_DIR]*weights[(i << stride_shift)+W_DIR];
-  
+
   return (float)ret;
 }
 
@@ -240,11 +240,11 @@ void bfgs_iter_start(vw& all, bfgs& b, float* mem, int& lastj, double importance
 
   double g1_Hg1 = 0.;
   double g1_g1 = 0.;
-  
+
   origin = 0;
   for(uint32_t i = 0; i < length; i++, mem+=b.mem_stride, w+=stride) {
     if (b.m>0)
-      mem[(MEM_XT+origin)%b.mem_stride] = w[W_XT]; 
+      mem[(MEM_XT+origin)%b.mem_stride] = w[W_XT];
     mem[(MEM_GT+origin)%b.mem_stride] = w[W_GT];
     g1_Hg1 += w[W_GT] * w[W_GT] * w[W_COND];
     g1_g1 += w[W_GT] * w[W_GT];
@@ -254,16 +254,16 @@ void bfgs_iter_start(vw& all, bfgs& b, float* mem, int& lastj, double importance
   lastj = 0;
   if (!all.quiet)
     fprintf(stderr, "%-10.5f\t%-10.5f\t%-10s\t%-10s\t%-10s\t",
-	    g1_g1/(importance_weight_sum*importance_weight_sum),
-	    g1_Hg1/importance_weight_sum, "", "", "");
+            g1_g1/(importance_weight_sum*importance_weight_sum),
+            g1_Hg1/importance_weight_sum, "", "", "");
 }
 
-void bfgs_iter_middle(vw& all, bfgs& b, float* mem, double* rho, double* alpha, int& lastj, int &origin) 
-{  
+void bfgs_iter_middle(vw& all, bfgs& b, float* mem, double* rho, double* alpha, int& lastj, int &origin)
+{
   uint32_t length = 1 << all.num_bits;
   size_t stride = 1 << all.reg.stride_shift;
   weight* w = all.reg.weight_vector;
-  
+
   float* mem0 = mem;
   float* w0 = w;
 
@@ -272,7 +272,7 @@ void bfgs_iter_middle(vw& all, bfgs& b, float* mem, double* rho, double* alpha, 
     double g_Hy = 0.;
     double g_Hg = 0.;
     double y = 0.;
-  
+
     for(uint32_t i = 0; i < length; i++, mem+=b.mem_stride, w+=stride) {
       y = w[W_GT]-mem[(MEM_GT+origin)%b.mem_stride];
       g_Hy += w[W_GT] * w[W_COND] * y;
@@ -283,7 +283,7 @@ void bfgs_iter_middle(vw& all, bfgs& b, float* mem, double* rho, double* alpha, 
 
     if (beta<0.f || nanpattern(beta))
       beta = 0.f;
-      
+
     mem = mem0;
     w = w0;
     for(uint32_t i = 0; i < length; i++, mem+=b.mem_stride, w+=stride) {
@@ -306,20 +306,20 @@ void bfgs_iter_middle(vw& all, bfgs& b, float* mem, double* rho, double* alpha, 
   double y_s = 0.;
   double y_Hy = 0.;
   double s_q = 0.;
-  
+
   for(uint32_t i = 0; i < length; i++, mem+=b.mem_stride, w+=stride) {
     mem[(MEM_YT+origin)%b.mem_stride] = w[W_GT] - mem[(MEM_GT+origin)%b.mem_stride];
     mem[(MEM_ST+origin)%b.mem_stride] = w[W_XT] - mem[(MEM_XT+origin)%b.mem_stride];
     w[W_DIR] = w[W_GT];
     y_s += mem[(MEM_YT+origin)%b.mem_stride]*mem[(MEM_ST+origin)%b.mem_stride];
     y_Hy += mem[(MEM_YT+origin)%b.mem_stride]*mem[(MEM_YT+origin)%b.mem_stride]*w[W_COND];
-    s_q += mem[(MEM_ST+origin)%b.mem_stride]*w[W_GT];  
+    s_q += mem[(MEM_ST+origin)%b.mem_stride]*w[W_GT];
   }
-  
+
   if (y_s <= 0. || y_Hy <= 0.)
     throw curv_ex;
   rho[0] = 1/y_s;
-  
+
   float gamma = (float) (y_s/y_Hy);
 
   for (int j=0; j<lastj; j++) {
@@ -334,7 +334,7 @@ void bfgs_iter_middle(vw& all, bfgs& b, float* mem, double* rho, double* alpha, 
   }
 
   alpha[lastj] = rho[lastj] * s_q;
-  double y_r = 0.;  
+  double y_r = 0.;
   mem = mem0;
   w = w0;
   for(uint32_t i = 0; i < length; i++, mem+=b.mem_stride, w+=stride) {
@@ -344,7 +344,7 @@ void bfgs_iter_middle(vw& all, bfgs& b, float* mem, double* rho, double* alpha, 
   }
 
   double coef_j;
-    
+
   for (int j=lastj; j>0; j--) {
     coef_j = alpha[j] - rho[j] * y_r;
     y_r = 0.;
@@ -363,9 +363,9 @@ void bfgs_iter_middle(vw& all, bfgs& b, float* mem, double* rho, double* alpha, 
   for(uint32_t i = 0; i < length; i++, mem+=b.mem_stride, w+=stride) {
     w[W_DIR] = -w[W_DIR]-(float)coef_j*mem[(MEM_ST+origin)%b.mem_stride];
   }
-  
+
   /*********************
-   ** shift 
+   ** shift
    ********************/
 
   mem = mem0;
@@ -381,23 +381,23 @@ void bfgs_iter_middle(vw& all, bfgs& b, float* mem, double* rho, double* alpha, 
     rho[j] = rho[j-1];
 }
 
-double wolfe_eval(vw& all, bfgs& b, float* mem, double loss_sum, double previous_loss_sum, double step_size, double importance_weight_sum, int &origin, double& wolfe1) { 
+double wolfe_eval(vw& all, bfgs& b, float* mem, double loss_sum, double previous_loss_sum, double step_size, double importance_weight_sum, int &origin, double& wolfe1) {
   uint32_t length = 1 << all.num_bits;
   size_t stride = 1 << all.reg.stride_shift;
   weight* w = all.reg.weight_vector;
-  
+
   double g0_d = 0.;
   double g1_d = 0.;
   double g1_Hg1 = 0.;
   double g1_g1 = 0.;
-  
+
   for(uint32_t i = 0; i < length; i++, mem+=b.mem_stride, w+=stride) {
     g0_d += mem[(MEM_GT+origin)%b.mem_stride] * w[W_DIR];
     g1_d += w[W_GT] * w[W_DIR];
     g1_Hg1 += w[W_GT] * w[W_GT] * w[W_COND];
     g1_g1 += w[W_GT] * w[W_GT];
   }
-  
+
   wolfe1 = (loss_sum-previous_loss_sum)/(step_size*g0_d);
   double wolfe2 = g1_d/g0_d;
   // double new_step_cross = (loss_sum-previous_loss_sum-g1_d*step)/(g0_d-g1_d);
@@ -409,26 +409,26 @@ double wolfe_eval(vw& all, bfgs& b, float* mem, double loss_sum, double previous
 
 
 double add_regularization(vw& all, bfgs& b, float regularization)
-{//compute the derivative difference
+{ //compute the derivative difference
   double ret = 0.;
   uint32_t length = 1 << all.num_bits;
   size_t stride_shift = all.reg.stride_shift;
   weight* weights = all.reg.weight_vector;
   if (b.regularizers == nullptr)
-    {
-      for(uint32_t i = 0; i < length; i++) {
-	weights[(i << stride_shift)+W_GT] += regularization*weights[i << stride_shift];
-	ret += 0.5*regularization*weights[i << stride_shift]*weights[i << stride_shift];
-      }
+  {
+    for(uint32_t i = 0; i < length; i++) {
+      weights[(i << stride_shift)+W_GT] += regularization*weights[i << stride_shift];
+      ret += 0.5*regularization*weights[i << stride_shift]*weights[i << stride_shift];
     }
+  }
   else
-    {
-      for(uint32_t i = 0; i < length; i++) {
-	weight delta_weight = weights[i << stride_shift] - b.regularizers[2*i+1];
-	weights[(i << stride_shift)+W_GT] += b.regularizers[2*i]*delta_weight;
-	ret += 0.5*b.regularizers[2*i]*delta_weight*delta_weight;
-      }
+  {
+    for(uint32_t i = 0; i < length; i++) {
+      weight delta_weight = weights[i << stride_shift] - b.regularizers[2*i+1];
+      weights[(i << stride_shift)+W_GT] += b.regularizers[2*i]*delta_weight;
+      ret += 0.5*b.regularizers[2*i]*delta_weight*delta_weight;
     }
+  }
 
   return ret;
 }
@@ -443,25 +443,25 @@ void finalize_preconditioner(vw& all, bfgs& b, float regularization)
   if (b.regularizers == nullptr)
     for(uint32_t i = 0; i < length; i++) {
       weights[stride*i+W_COND] += regularization;
-	  if (weights[stride*i+W_COND] > max_hessian)
-		  max_hessian = weights[stride*i+W_COND];
+      if (weights[stride*i+W_COND] > max_hessian)
+        max_hessian = weights[stride*i+W_COND];
       if (weights[stride*i+W_COND] > 0)
-	weights[stride*i+W_COND] = 1.f / weights[stride*i+W_COND];
+        weights[stride*i+W_COND] = 1.f / weights[stride*i+W_COND];
     }
   else
     for(uint32_t i = 0; i < length; i++) {
       weights[stride*i+W_COND] += b.regularizers[2*i];
-	  if (weights[stride*i+W_COND] > max_hessian)
-		  max_hessian = weights[stride*i+W_COND];
+      if (weights[stride*i+W_COND] > max_hessian)
+        max_hessian = weights[stride*i+W_COND];
       if (weights[stride*i+W_COND] > 0)
-	weights[stride*i+W_COND] = 1.f / weights[stride*i+W_COND];
+        weights[stride*i+W_COND] = 1.f / weights[stride*i+W_COND];
     }
 
   float max_precond = (max_hessian==0.f) ? 0.f : max_precond_ratio / max_hessian;
   weights = all.reg.weight_vector;
   for(uint32_t i = 0; i < length; i++) {
     if (infpattern(weights[stride*i+W_COND]) || weights[stride*i+W_COND]>max_precond)
-			weights[stride*i+W_COND] = max_precond;
+      weights[stride*i+W_COND] = max_precond;
   }
 }
 
@@ -471,20 +471,20 @@ void preconditioner_to_regularizer(vw& all, bfgs& b, float regularization)
   size_t stride = 1 << all.reg.stride_shift;
   weight* weights = all.reg.weight_vector;
   if (b.regularizers == nullptr)
-    {
-      b.regularizers = calloc_or_die<weight>(2*length);
-      
-      if (b.regularizers == nullptr)
-	THROW("Failed to allocate weight array: try decreasing -b <bits>");
+  {
+    b.regularizers = calloc_or_die<weight>(2*length);
 
-      for(uint32_t i = 0; i < length; i++) 
-	b.regularizers[2*i] = weights[stride*i+W_COND] + regularization;
-    }
+    if (b.regularizers == nullptr)
+      THROW("Failed to allocate weight array: try decreasing -b <bits>");
+
+    for(uint32_t i = 0; i < length; i++)
+      b.regularizers[2*i] = weights[stride*i+W_COND] + regularization;
+  }
   else
-    for(uint32_t i = 0; i < length; i++) 
+    for(uint32_t i = 0; i < length; i++)
       b.regularizers[2*i] = weights[stride*i+W_COND] + b.regularizers[2*i];
-  for(uint32_t i = 0; i < length; i++) 
-      b.regularizers[2*i+1] = weights[stride*i];
+  for(uint32_t i = 0; i < length; i++)
+    b.regularizers[2*i+1] = weights[stride*i];
 }
 
 void zero_state(vw& all)
@@ -492,322 +492,324 @@ void zero_state(vw& all)
   uint32_t length = 1 << all.num_bits;
   size_t stride = 1 << all.reg.stride_shift;
   weight* weights = all.reg.weight_vector;
-  for(uint32_t i = 0; i < length; i++) 
-    {
-      weights[stride*i+W_GT] = 0;
-      weights[stride*i+W_DIR] = 0;
-      weights[stride*i+W_COND] = 0;
-    }
+  for(uint32_t i = 0; i < length; i++)
+  {
+    weights[stride*i+W_GT] = 0;
+    weights[stride*i+W_DIR] = 0;
+    weights[stride*i+W_COND] = 0;
+  }
 }
 
 double derivative_in_direction(vw& all, bfgs& b, float* mem, int &origin)
-  {  
+{
   double ret = 0.;
   uint32_t length = 1 << all.num_bits;
   size_t stride = 1 << all.reg.stride_shift;
   weight* w = all.reg.weight_vector;
-  
+
   for(uint32_t i = 0; i < length; i++, w+=stride, mem+=b.mem_stride)
     ret += mem[(MEM_GT+origin)%b.mem_stride]*w[W_DIR];
   return ret;
 }
-  
+
 void update_weight(vw& all, float step_size)
-  {
-    uint32_t length = 1 << all.num_bits;
-    size_t stride = 1 << all.reg.stride_shift;
-    weight* w = all.reg.weight_vector;
-    
-    for(uint32_t i = 0; i < length; i++, w+=stride)
-      w[W_XT] += step_size * w[W_DIR];
-  }
+{
+  uint32_t length = 1 << all.num_bits;
+  size_t stride = 1 << all.reg.stride_shift;
+  weight* w = all.reg.weight_vector;
+
+  for(uint32_t i = 0; i < length; i++, w+=stride)
+    w[W_XT] += step_size * w[W_DIR];
+}
 
 int process_pass(vw& all, bfgs& b) {
   int status = LEARN_OK;
 
   /********************************************************************/
   /* A) FIRST PASS FINISHED: INITIALIZE FIRST LINE SEARCH *************/
-  /********************************************************************/ 
-    if (b.first_pass) {
-      if(all.span_server != "")
-	{
-	  accumulate(all, all.span_server, all.reg, W_COND); //Accumulate preconditioner
-	  float temp = (float)b.importance_weight_sum;
-	  b.importance_weight_sum = accumulate_scalar(all, all.span_server, temp);
-	}
-      finalize_preconditioner(all, b, all.l2_lambda);
+  /********************************************************************/
+  if (b.first_pass) {
+    if(all.span_server != "")
+    {
+      accumulate(all, all.span_server, all.reg, W_COND); //Accumulate preconditioner
+      float temp = (float)b.importance_weight_sum;
+      b.importance_weight_sum = accumulate_scalar(all, all.span_server, temp);
+    }
+    finalize_preconditioner(all, b, all.l2_lambda);
+    if(all.span_server != "") {
+      float temp = (float)b.loss_sum;
+      b.loss_sum = accumulate_scalar(all, all.span_server, temp);  //Accumulate loss_sums
+      accumulate(all, all.span_server, all.reg, 1); //Accumulate gradients from all nodes
+    }
+    if (all.l2_lambda > 0.)
+      b.loss_sum += add_regularization(all, b, all.l2_lambda);
+    if (!all.quiet)
+      fprintf(stderr, "%2lu %-10.5f\t", (long unsigned int)b.current_pass+1, b.loss_sum / b.importance_weight_sum);
+
+    b.previous_loss_sum = b.loss_sum;
+    b.loss_sum = 0.;
+    b.example_number = 0;
+    b.curvature = 0;
+    bfgs_iter_start(all, b, b.mem, b.lastj, b.importance_weight_sum, b.origin);
+    if (b.first_hessian_on) {
+      b.gradient_pass = false;//now start computing curvature
+    }
+    else {
+      b.step_size = 0.5;
+      float d_mag = direction_magnitude(all);
+      ftime(&b.t_end_global);
+      b.net_time = (int) (1000.0 * (b.t_end_global.time - b.t_start_global.time) + (b.t_end_global.millitm - b.t_start_global.millitm));
+      if (!all.quiet)
+        fprintf(stderr, "%-10s\t%-10.5f\t%-10.5f\n", "", d_mag, b.step_size);
+      b.predictions.erase();
+      update_weight(all, b.step_size);
+    }
+  }
+  else
+    /********************************************************************/
+    /* B) GRADIENT CALCULATED *******************************************/
+    /********************************************************************/
+    if (b.gradient_pass) // We just finished computing all gradients
+    {
       if(all.span_server != "") {
-	float temp = (float)b.loss_sum;
-	b.loss_sum = accumulate_scalar(all, all.span_server, temp);  //Accumulate loss_sums
-	accumulate(all, all.span_server, all.reg, 1); //Accumulate gradients from all nodes
+        float t = (float)b.loss_sum;
+        b.loss_sum = accumulate_scalar(all, all.span_server, t);  //Accumulate loss_sums
+        accumulate(all, all.span_server, all.reg, 1); //Accumulate gradients from all nodes
       }
       if (all.l2_lambda > 0.)
-	b.loss_sum += add_regularization(all, b, all.l2_lambda);
-      if (!all.quiet)
-	fprintf(stderr, "%2lu %-10.5f\t", (long unsigned int)b.current_pass+1, b.loss_sum / b.importance_weight_sum);
-      
-      b.previous_loss_sum = b.loss_sum;
-      b.loss_sum = 0.;
-      b.example_number = 0;
-      b.curvature = 0;
-      bfgs_iter_start(all, b, b.mem, b.lastj, b.importance_weight_sum, b.origin);
-      if (b.first_hessian_on) {
-	b.gradient_pass = false;//now start computing curvature
+        b.loss_sum += add_regularization(all, b, all.l2_lambda);
+      if (!all.quiet) {
+        if(!all.holdout_set_off && b.current_pass >= 1) {
+          if(all.sd->holdout_sum_loss_since_last_pass == 0. && all.sd->weighted_holdout_examples_since_last_pass == 0.) {
+            fprintf(stderr, "%2lu ", (long unsigned int)b.current_pass+1);
+            fprintf(stderr, "h unknown    ");
+          }
+          else
+            fprintf(stderr, "%2lu h%-10.5f\t", (long unsigned int)b.current_pass+1, all.sd->holdout_sum_loss_since_last_pass / all.sd->weighted_holdout_examples_since_last_pass);
+        }
+        else
+          fprintf(stderr, "%2lu %-10.5f\t", (long unsigned int)b.current_pass+1, b.loss_sum / b.importance_weight_sum);
       }
+      double wolfe1;
+      double new_step = wolfe_eval(all, b, b.mem, b.loss_sum, b.previous_loss_sum, b.step_size, b.importance_weight_sum, b.origin, wolfe1);
+
+      /********************************************************************/
+      /* B0) DERIVATIVE ZERO: MINIMUM FOUND *******************************/
+      /********************************************************************/
+      if (nanpattern((float)wolfe1))
+      {
+        fprintf(stderr, "\n");
+        fprintf(stdout, "Derivative 0 detected.\n");
+        b.step_size=0.0;
+        status = LEARN_CONV;
+      }
+      /********************************************************************/
+      /* B1) LINE SEARCH FAILED *******************************************/
+      /********************************************************************/
+      else if (b.backstep_on && (wolfe1<b.wolfe1_bound || b.loss_sum > b.previous_loss_sum))
+      { // curvature violated, or we stepped too far last time: step back
+        ftime(&b.t_end_global);
+        b.net_time = (int) (1000.0 * (b.t_end_global.time - b.t_start_global.time) + (b.t_end_global.millitm - b.t_start_global.millitm));
+        float ratio = (b.step_size==0.f) ? 0.f : (float)new_step/(float)b.step_size;
+        if (!all.quiet)
+          fprintf(stderr, "%-10s\t%-10s\t(revise x %.1f)\t%-10.5f\n",
+                  "","",ratio,
+                  new_step);
+        b.predictions.erase();
+        update_weight(all, (float)(-b.step_size+new_step));
+        b.step_size = (float)new_step;
+        zero_derivative(all);
+        b.loss_sum = 0.;
+      }
+
+      /********************************************************************/
+      /* B2) LINE SEARCH SUCCESSFUL OR DISABLED          ******************/
+      /*     DETERMINE NEXT SEARCH DIRECTION             ******************/
+      /********************************************************************/
       else {
-	b.step_size = 0.5;
-	float d_mag = direction_magnitude(all);
-	ftime(&b.t_end_global);
-	b.net_time = (int) (1000.0 * (b.t_end_global.time - b.t_start_global.time) + (b.t_end_global.millitm - b.t_start_global.millitm)); 
-	if (!all.quiet)
-	  fprintf(stderr, "%-10s\t%-10.5f\t%-10.5f\n", "", d_mag, b.step_size);
-	b.predictions.erase();
-	update_weight(all, b.step_size);		     		           }
+        double rel_decrease = (b.previous_loss_sum-b.loss_sum)/b.previous_loss_sum;
+        if (!nanpattern((float)rel_decrease) && b.backstep_on && fabs(rel_decrease)<b.rel_threshold) {
+          fprintf(stdout, "\nTermination condition reached in pass %ld: decrease in loss less than %.3f%%.\n"
+                  "If you want to optimize further, decrease termination threshold.\n", (long int)b.current_pass+1, b.rel_threshold*100.0);
+          status = LEARN_CONV;
+        }
+        b.previous_loss_sum = b.loss_sum;
+        b.loss_sum = 0.;
+        b.example_number = 0;
+        b.curvature = 0;
+        b.step_size = 1.0;
+
+        try {
+          bfgs_iter_middle(all, b, b.mem, b.rho, b.alpha, b.lastj, b.origin);
+        }
+        catch (curv_exception e) {
+          fprintf(stdout, "In bfgs_iter_middle: %s", curv_message);
+          b.step_size=0.0;
+          status = LEARN_CURV;
+        }
+
+        if (all.hessian_on) {
+          b.gradient_pass = false;//now start computing curvature
+        }
+        else {
+          float d_mag = direction_magnitude(all);
+          ftime(&b.t_end_global);
+          b.net_time = (int) (1000.0 * (b.t_end_global.time - b.t_start_global.time) + (b.t_end_global.millitm - b.t_start_global.millitm));
+          if (!all.quiet)
+            fprintf(stderr, "%-10s\t%-10.5f\t%-10.5f\n", "", d_mag, b.step_size);
+          b.predictions.erase();
+          update_weight(all, b.step_size);
+        }
+      }
     }
-    else
-  /********************************************************************/
-  /* B) GRADIENT CALCULATED *******************************************/
-  /********************************************************************/ 
-	      if (b.gradient_pass) // We just finished computing all gradients
-		{
-		  if(all.span_server != "") {
-		    float t = (float)b.loss_sum;
-		    b.loss_sum = accumulate_scalar(all, all.span_server, t);  //Accumulate loss_sums
-		    accumulate(all, all.span_server, all.reg, 1); //Accumulate gradients from all nodes
-		  }
-		  if (all.l2_lambda > 0.)
-		    b.loss_sum += add_regularization(all, b, all.l2_lambda);
-		  if (!all.quiet){
-                    if(!all.holdout_set_off && b.current_pass >= 1){
-                      if(all.sd->holdout_sum_loss_since_last_pass == 0. && all.sd->weighted_holdout_examples_since_last_pass == 0.){
-                        fprintf(stderr, "%2lu ", (long unsigned int)b.current_pass+1);
-                        fprintf(stderr, "h unknown    ");
-                      }                      
-                      else
-                        fprintf(stderr, "%2lu h%-10.5f\t", (long unsigned int)b.current_pass+1, all.sd->holdout_sum_loss_since_last_pass / all.sd->weighted_holdout_examples_since_last_pass);
-                    }
-                    else
-                      fprintf(stderr, "%2lu %-10.5f\t", (long unsigned int)b.current_pass+1, b.loss_sum / b.importance_weight_sum);
-                  }
-		  double wolfe1;
-		  double new_step = wolfe_eval(all, b, b.mem, b.loss_sum, b.previous_loss_sum, b.step_size, b.importance_weight_sum, b.origin, wolfe1);
-
-  /********************************************************************/
-  /* B0) DERIVATIVE ZERO: MINIMUM FOUND *******************************/
-  /********************************************************************/ 
-		  if (nanpattern((float)wolfe1))
-		    {
-		      fprintf(stderr, "\n");
-		      fprintf(stdout, "Derivative 0 detected.\n");
-		      b.step_size=0.0;
-		      status = LEARN_CONV;
-		    }
-  /********************************************************************/
-  /* B1) LINE SEARCH FAILED *******************************************/
-  /********************************************************************/ 
-		  else if (b.backstep_on && (wolfe1<b.wolfe1_bound || b.loss_sum > b.previous_loss_sum))
-		    {// curvature violated, or we stepped too far last time: step back
-		      ftime(&b.t_end_global);
-		      b.net_time = (int) (1000.0 * (b.t_end_global.time - b.t_start_global.time) + (b.t_end_global.millitm - b.t_start_global.millitm)); 
-		      float ratio = (b.step_size==0.f) ? 0.f : (float)new_step/(float)b.step_size;
-		      if (!all.quiet)
-			fprintf(stderr, "%-10s\t%-10s\t(revise x %.1f)\t%-10.5f\n",
-				"","",ratio,
-				new_step);
-			b.predictions.erase();
-			update_weight(all, (float)(-b.step_size+new_step));		     		      			
-			b.step_size = (float)new_step;
-			zero_derivative(all);
-			b.loss_sum = 0.;
-		    }
-
-  /********************************************************************/
-  /* B2) LINE SEARCH SUCCESSFUL OR DISABLED          ******************/
-  /*     DETERMINE NEXT SEARCH DIRECTION             ******************/
-  /********************************************************************/ 
-		  else {
-		      double rel_decrease = (b.previous_loss_sum-b.loss_sum)/b.previous_loss_sum;
-		      if (!nanpattern((float)rel_decrease) && b.backstep_on && fabs(rel_decrease)<b.rel_threshold) {
-			fprintf(stdout, "\nTermination condition reached in pass %ld: decrease in loss less than %.3f%%.\n"
-				"If you want to optimize further, decrease termination threshold.\n", (long int)b.current_pass+1, b.rel_threshold*100.0);
-			status = LEARN_CONV;
-		      }
-		      b.previous_loss_sum = b.loss_sum;
-		      b.loss_sum = 0.;
-		      b.example_number = 0;
-		      b.curvature = 0;
-		      b.step_size = 1.0;
-
-		      try {
-			bfgs_iter_middle(all, b, b.mem, b.rho, b.alpha, b.lastj, b.origin);
-		      }
-		      catch (curv_exception e) {
-			fprintf(stdout, "In bfgs_iter_middle: %s", curv_message);
-			b.step_size=0.0;
-			status = LEARN_CURV;
-		      }
-
-		      if (all.hessian_on) {
-			b.gradient_pass = false;//now start computing curvature
-		      }
-		      else {
-			float d_mag = direction_magnitude(all);
-			ftime(&b.t_end_global);
-			b.net_time = (int) (1000.0 * (b.t_end_global.time - b.t_start_global.time) + (b.t_end_global.millitm - b.t_start_global.millitm)); 
-			if (!all.quiet)
-			  fprintf(stderr, "%-10s\t%-10.5f\t%-10.5f\n", "", d_mag, b.step_size);
-			b.predictions.erase();
-			update_weight(all, b.step_size);		     		      
-		      }
-		    }
-		}
 
   /********************************************************************/
   /* C) NOT FIRST PASS, CURVATURE CALCULATED **************************/
-  /********************************************************************/ 
-	      else // just finished all second gradients
-		{
-		  if(all.span_server != "") {
-		    float t = (float)b.curvature;
-		    b.curvature = accumulate_scalar(all, all.span_server, t);  //Accumulate curvatures
-		  }
-		  if (all.l2_lambda > 0.)
-		    b.curvature += regularizer_direction_magnitude(all, b, all.l2_lambda);
-		  float dd = (float)derivative_in_direction(all, b, b.mem, b.origin);
-		  if (b.curvature == 0. && dd != 0.)
-		    {
-		      fprintf(stdout, "%s", curv_message);
-		      b.step_size=0.0;
-		      status = LEARN_CURV;
-		    }
-		  else if ( dd == 0.)
-		    {
-		      fprintf(stdout, "Derivative 0 detected.\n");
-		      b.step_size=0.0;
-		      status = LEARN_CONV;
-		    }
-		  else
-		    b.step_size = - dd/(float)b.curvature;
-		  
-		  float d_mag = direction_magnitude(all);
-
-		  b.predictions.erase();
-		  update_weight(all, b.step_size);
-		  ftime(&b.t_end_global);
-		  b.net_time = (int) (1000.0 * (b.t_end_global.time - b.t_start_global.time) + (b.t_end_global.millitm - b.t_start_global.millitm)); 
-		  if (!all.quiet)
-		    fprintf(stderr, "%-10.5f\t%-10.5f\t%-10.5f\n", b.curvature / b.importance_weight_sum, d_mag, b.step_size);
-		  b.gradient_pass = true;
-		}//now start computing derivatives.    
-    b.current_pass++;
-    b.first_pass = false;
-    b.preconditioner_pass = false;
-    
-    if (b.output_regularizer)//need to accumulate and place the regularizer.
-      {
-	if(all.span_server != "")
-	  accumulate(all, all.span_server, all.reg, W_COND); //Accumulate preconditioner
-	//preconditioner_to_regularizer(all, b, all.l2_lambda);
+  /********************************************************************/
+    else // just finished all second gradients
+    {
+      if(all.span_server != "") {
+        float t = (float)b.curvature;
+        b.curvature = accumulate_scalar(all, all.span_server, t);  //Accumulate curvatures
       }
-    ftime(&b.t_end_global);
-    b.net_time = (int) (1000.0 * (b.t_end_global.time - b.t_start_global.time) + (b.t_end_global.millitm - b.t_start_global.millitm)); 
+      if (all.l2_lambda > 0.)
+        b.curvature += regularizer_direction_magnitude(all, b, all.l2_lambda);
+      float dd = (float)derivative_in_direction(all, b, b.mem, b.origin);
+      if (b.curvature == 0. && dd != 0.)
+      {
+        fprintf(stdout, "%s", curv_message);
+        b.step_size=0.0;
+        status = LEARN_CURV;
+      }
+      else if ( dd == 0.)
+      {
+        fprintf(stdout, "Derivative 0 detected.\n");
+        b.step_size=0.0;
+        status = LEARN_CONV;
+      }
+      else
+        b.step_size = - dd/(float)b.curvature;
 
-    if (all.save_per_pass)
-      save_predictor(all, all.final_regressor_name, b.current_pass);
-    return status;
+      float d_mag = direction_magnitude(all);
+
+      b.predictions.erase();
+      update_weight(all, b.step_size);
+      ftime(&b.t_end_global);
+      b.net_time = (int) (1000.0 * (b.t_end_global.time - b.t_start_global.time) + (b.t_end_global.millitm - b.t_start_global.millitm));
+      if (!all.quiet)
+        fprintf(stderr, "%-10.5f\t%-10.5f\t%-10.5f\n", b.curvature / b.importance_weight_sum, d_mag, b.step_size);
+      b.gradient_pass = true;
+    }//now start computing derivatives.
+  b.current_pass++;
+  b.first_pass = false;
+  b.preconditioner_pass = false;
+
+  if (b.output_regularizer)//need to accumulate and place the regularizer.
+  {
+    if(all.span_server != "")
+      accumulate(all, all.span_server, all.reg, W_COND); //Accumulate preconditioner
+    //preconditioner_to_regularizer(all, b, all.l2_lambda);
+  }
+  ftime(&b.t_end_global);
+  b.net_time = (int) (1000.0 * (b.t_end_global.time - b.t_start_global.time) + (b.t_end_global.millitm - b.t_start_global.millitm));
+
+  if (all.save_per_pass)
+    save_predictor(all, all.final_regressor_name, b.current_pass);
+  return status;
 }
 
 void process_example(vw& all, bfgs& b, example& ec)
- {
+{
   label_data& ld = ec.l.simple;
   if (b.first_pass)
     b.importance_weight_sum += ld.weight;
-  
+
   /********************************************************************/
   /* I) GRADIENT CALCULATION ******************************************/
-  /********************************************************************/ 
+  /********************************************************************/
   if (b.gradient_pass)
-    {
-      ec.pred.scalar = predict_and_gradient(all, ec);//w[0] & w[1]
-      ec.loss = all.loss->getLoss(all.sd, ec.pred.scalar, ld.label) * ld.weight;
-      b.loss_sum += ec.loss;
-      b.predictions.push_back(ec.pred.scalar);
-    }
+  {
+    ec.pred.scalar = predict_and_gradient(all, ec);//w[0] & w[1]
+    ec.loss = all.loss->getLoss(all.sd, ec.pred.scalar, ld.label) * ld.weight;
+    b.loss_sum += ec.loss;
+    b.predictions.push_back(ec.pred.scalar);
+  }
   /********************************************************************/
   /* II) CURVATURE CALCULATION ****************************************/
-  /********************************************************************/ 
+  /********************************************************************/
   else //computing curvature
-    {
-      float d_dot_x = dot_with_direction(all, ec);//w[2]
-      if (b.example_number >= b.predictions.size())//Make things safe in case example source is strange.
-	b.example_number = b.predictions.size()-1;
-      ec.pred.scalar = b.predictions[b.example_number];
-      ec.partial_prediction = b.predictions[b.example_number];
-      ec.loss = all.loss->getLoss(all.sd, ec.pred.scalar, ld.label) * ld.weight;	      
-      float sd = all.loss->second_derivative(all.sd, b.predictions[b.example_number++],ld.label);
-      b.curvature += d_dot_x*d_dot_x*sd*ld.weight;
-    }
+  {
+    float d_dot_x = dot_with_direction(all, ec);//w[2]
+    if (b.example_number >= b.predictions.size())//Make things safe in case example source is strange.
+      b.example_number = b.predictions.size()-1;
+    ec.pred.scalar = b.predictions[b.example_number];
+    ec.partial_prediction = b.predictions[b.example_number];
+    ec.loss = all.loss->getLoss(all.sd, ec.pred.scalar, ld.label) * ld.weight;
+    float sd = all.loss->second_derivative(all.sd, b.predictions[b.example_number++],ld.label);
+    b.curvature += d_dot_x*d_dot_x*sd*ld.weight;
+  }
   ec.updated_prediction = ec.pred.scalar;
-  
+
   if (b.preconditioner_pass)
     update_preconditioner(all, ec);//w[3]
- }
+}
 
 void end_pass(bfgs& b)
 {
   vw* all = b.all;
-  
-  if (b.current_pass <= b.final_pass) 
+
+  if (b.current_pass <= b.final_pass)
   {
-       if(b.current_pass < b.final_pass)
-       { 
-          int status = process_pass(*all, b);
+    if(b.current_pass < b.final_pass)
+    {
+      int status = process_pass(*all, b);
 
-          //reaching the max number of passes regardless of convergence 
-          if(b.final_pass == b.current_pass)
-          {
-             cerr<<"Maximum number of passes reached. ";
-             if(!b.output_regularizer)
-                cerr<<"If you want to optimize further, increase the number of passes\n";
-             if(b.output_regularizer)
-             { 
-               cerr<<"\nRegular model file has been created. "; 
-               cerr<<"Output feature regularizer file is created only when the convergence is reached. Try increasing the number of passes for convergence\n";
-               b.output_regularizer = false;
-             }
+      //reaching the max number of passes regardless of convergence
+      if(b.final_pass == b.current_pass)
+      {
+        cerr<<"Maximum number of passes reached. ";
+        if(!b.output_regularizer)
+          cerr<<"If you want to optimize further, increase the number of passes\n";
+        if(b.output_regularizer)
+        {
+          cerr<<"\nRegular model file has been created. ";
+          cerr<<"Output feature regularizer file is created only when the convergence is reached. Try increasing the number of passes for convergence\n";
+          b.output_regularizer = false;
+        }
 
-          } 
-          
-          //attain convergence before reaching max iterations 
-	   if (status != LEARN_OK && b.final_pass > b.current_pass) {
-	      b.final_pass = b.current_pass;
-	   }
+      }
 
-	   if (b.output_regularizer && b.final_pass == b.current_pass) {
-	     zero_preconditioner(*all);
-	     b.preconditioner_pass = true;
-	   }
+      //attain convergence before reaching max iterations
+      if (status != LEARN_OK && b.final_pass > b.current_pass) {
+        b.final_pass = b.current_pass;
+      }
 
-	   if(!all->holdout_set_off)
-	   {
-	     if(summarize_holdout_set(*all, b.no_win_counter))
-               finalize_regressor(*all, all->final_regressor_name); 
-	     if(b.early_stop_thres == b.no_win_counter)
-	     { 
-               set_done(*all);
-               cerr<<"Early termination reached w.r.t. holdout set error";
-             }
-	   } if (b.final_pass == b.current_pass) {
-	     finalize_regressor(*all, all->final_regressor_name); 
-	     set_done(*all);
-	   }
-           
-       }else{//reaching convergence in the previous pass
-        if(b.output_regularizer) 
-           preconditioner_to_regularizer(*all, b, (*all).l2_lambda);
-        b.current_pass ++;
-      }   
-                
+      if (b.output_regularizer && b.final_pass == b.current_pass) {
+        zero_preconditioner(*all);
+        b.preconditioner_pass = true;
+      }
+
+      if(!all->holdout_set_off)
+      {
+        if(summarize_holdout_set(*all, b.no_win_counter))
+          finalize_regressor(*all, all->final_regressor_name);
+        if(b.early_stop_thres == b.no_win_counter)
+        {
+          set_done(*all);
+          cerr<<"Early termination reached w.r.t. holdout set error";
+        }
+      }
+      if (b.final_pass == b.current_pass) {
+        finalize_regressor(*all, all->final_regressor_name);
+        set_done(*all);
+      }
+
+    } else { //reaching convergence in the previous pass
+      if(b.output_regularizer)
+        preconditioner_to_regularizer(*all, b, (*all).l2_lambda);
+      b.current_pass ++;
+    }
+
   }
 }
 
@@ -824,12 +826,12 @@ void learn(bfgs& b, base_learner& base, example& ec)
   assert(ec.in_use);
 
   if (b.current_pass <= b.final_pass)
-    {
-      if (test_example(ec))
-	predict(b, base, ec);
-      else
-	process_example(*all, b, ec);
-    }
+  {
+    if (test_example(ec))
+      predict(b, base, ec);
+    else
+      process_example(*all, b, ec);
+  }
 }
 
 void finish(bfgs& b)
@@ -848,40 +850,40 @@ void save_load_regularizer(vw& all, bfgs& b, io_buf& model_file, bool read, bool
   uint32_t length = 2*(1 << all.num_bits);
   uint32_t i = 0;
   size_t brw = 1;
-  do 
+  do
+  {
+    brw = 1;
+    weight* v;
+    if (read)
     {
-      brw = 1;
-      weight* v;
-      if (read)
-	{
-	  c++;
-	  brw = bin_read_fixed(model_file, (char*)&i, sizeof(i),"");
-	  if (brw > 0)
-	    {
-	      assert (i< length);		
-	      v = &(b.regularizers[i]);
-	      if (brw > 0)
-		brw += bin_read_fixed(model_file, (char*)v, sizeof(*v), "");
-	    }
-	}
-      else // write binary or text
-	{
-	  v = &(b.regularizers[i]);
-	  if (*v != 0.)
-	    {
-	      c++;
-	      int text_len = sprintf(buff, "%d", i);
-	      brw = bin_text_write_fixed(model_file,(char *)&i, sizeof (i),
-					 buff, text_len, text);
-	      
-	      text_len = sprintf(buff, ":%f\n", *v);
-	      brw+= bin_text_write_fixed(model_file,(char *)v, sizeof (*v),
-					 buff, text_len, text);
-	    }
-	}
-      if (!read)
-	i++;
-    }  
+      c++;
+      brw = bin_read_fixed(model_file, (char*)&i, sizeof(i),"");
+      if (brw > 0)
+      {
+        assert (i< length);
+        v = &(b.regularizers[i]);
+        if (brw > 0)
+          brw += bin_read_fixed(model_file, (char*)v, sizeof(*v), "");
+      }
+    }
+    else // write binary or text
+    {
+      v = &(b.regularizers[i]);
+      if (*v != 0.)
+      {
+        c++;
+        int text_len = sprintf(buff, "%d", i);
+        brw = bin_text_write_fixed(model_file,(char *)&i, sizeof (i),
+                                   buff, text_len, text);
+
+        text_len = sprintf(buff, ":%f\n", *v);
+        brw+= bin_text_write_fixed(model_file,(char *)v, sizeof (*v),
+                                   buff, text_len, text);
+      }
+    }
+    if (!read)
+      i++;
+  }
   while ((!read && i < length) || (read && brw >0));
 }
 
@@ -893,65 +895,65 @@ void save_load(bfgs& b, io_buf& model_file, bool read, bool text)
   uint32_t length = 1 << all->num_bits;
 
   if (read)
+  {
+    initialize_regressor(*all);
+    if (all->per_feature_regularizer_input != "")
     {
-      initialize_regressor(*all);
-      if (all->per_feature_regularizer_input != "")
-	{
-	  b.regularizers = calloc_or_die<weight>(2*length);
-	  if (b.regularizers == nullptr)
-	    THROW( "Failed to allocate regularizers array: try decreasing -b <bits>");
-	}
-      int m = b.m;
-      
-      b.mem_stride = (m==0) ? CG_EXTRA : 2*m;
-      b.mem = (float*) malloc(sizeof(float)*all->length()*(b.mem_stride));
-      b.rho = (double*) malloc(sizeof(double)*m);
-      b.alpha = (double*) malloc(sizeof(double)*m);
-      
-      if (!all->quiet) 
-	{
-	  fprintf(stderr, "m = %d\nAllocated %luM for weights and mem\n", m, (long unsigned int)all->length()*(sizeof(float)*(b.mem_stride)+(sizeof(weight) << all->reg.stride_shift)) >> 20);
-	}
-      
-      b.net_time = 0.0;
-      ftime(&b.t_start_global);
-      
-      if (!all->quiet)
-	{
-	  const char * header_fmt = "%2s %-10s\t%-10s\t%-10s\t %-10s\t%-10s\t%-10s\t%-10s\t%-10s\t%-10s\n";
-	  fprintf(stderr, header_fmt,
-		  "##", "avg. loss", "der. mag.", "d. m. cond.", "wolfe1", "wolfe2", "mix fraction", "curvature", "dir. magnitude", "step size");
-	  cerr.precision(5);
-	}
-      
-      if (b.regularizers != nullptr)
-	all->l2_lambda = 1; // To make sure we are adding the regularization
-      b.output_regularizer =  (all->per_feature_regularizer_output != "" || all->per_feature_regularizer_text != "");
-      reset_state(*all, b, false);
+      b.regularizers = calloc_or_die<weight>(2*length);
+      if (b.regularizers == nullptr)
+        THROW( "Failed to allocate regularizers array: try decreasing -b <bits>");
     }
+    int m = b.m;
+
+    b.mem_stride = (m==0) ? CG_EXTRA : 2*m;
+    b.mem = (float*) malloc(sizeof(float)*all->length()*(b.mem_stride));
+    b.rho = (double*) malloc(sizeof(double)*m);
+    b.alpha = (double*) malloc(sizeof(double)*m);
+
+    if (!all->quiet)
+    {
+      fprintf(stderr, "m = %d\nAllocated %luM for weights and mem\n", m, (long unsigned int)all->length()*(sizeof(float)*(b.mem_stride)+(sizeof(weight) << all->reg.stride_shift)) >> 20);
+    }
+
+    b.net_time = 0.0;
+    ftime(&b.t_start_global);
+
+    if (!all->quiet)
+    {
+      const char * header_fmt = "%2s %-10s\t%-10s\t%-10s\t %-10s\t%-10s\t%-10s\t%-10s\t%-10s\t%-10s\n";
+      fprintf(stderr, header_fmt,
+              "##", "avg. loss", "der. mag.", "d. m. cond.", "wolfe1", "wolfe2", "mix fraction", "curvature", "dir. magnitude", "step size");
+      cerr.precision(5);
+    }
+
+    if (b.regularizers != nullptr)
+      all->l2_lambda = 1; // To make sure we are adding the regularization
+    b.output_regularizer =  (all->per_feature_regularizer_output != "" || all->per_feature_regularizer_text != "");
+    reset_state(*all, b, false);
+  }
 
   //bool reg_vector = b.output_regularizer || all->per_feature_regularizer_input.length() > 0;
   bool reg_vector = (b.output_regularizer && !read) || (all->per_feature_regularizer_input.length() > 0 && read);
-    
+
   if (model_file.files.size() > 0)
-    {
-      char buff[512];
-      uint32_t text_len = sprintf(buff, ":%d\n", reg_vector);
-      bin_text_read_write_fixed(model_file,(char *)&reg_vector, sizeof (reg_vector),
-				"", read,
-				buff, text_len, text);
-      
-      if (reg_vector)
-	save_load_regularizer(*all, b, model_file, read, text);
-      else
-	GD::save_load_regressor(*all, model_file, read, text);
-    }
+  {
+    char buff[512];
+    uint32_t text_len = sprintf(buff, ":%d\n", reg_vector);
+    bin_text_read_write_fixed(model_file,(char *)&reg_vector, sizeof (reg_vector),
+                              "", read,
+                              buff, text_len, text);
+
+    if (reg_vector)
+      save_load_regularizer(*all, b, model_file, read, text);
+    else
+      GD::save_load_regressor(*all, model_file, read, text);
+  }
 }
 
-  void init_driver(bfgs& b)
-  {
-    b.backstep_on = true;
-  }
+void init_driver(bfgs& b)
+{
+  b.backstep_on = true;
+}
 
 base_learner* bfgs_setup(vw& all)
 {
@@ -959,9 +961,9 @@ base_learner* bfgs_setup(vw& all)
       missing_option(all, false, "conjugate_gradient", "use conjugate gradient based optimization"))
     return nullptr;
   new_options(all, "LBFGS options")
-    ("hessian_on", "use second derivative in line search")
-    ("mem", po::value<uint32_t>()->default_value(15), "memory in bfgs")
-    ("termination", po::value<float>()->default_value(0.001f),"Termination threshold");
+  ("hessian_on", "use second derivative in line search")
+  ("mem", po::value<uint32_t>()->default_value(15), "memory in bfgs")
+  ("termination", po::value<float>()->default_value(0.001f),"Termination threshold");
   add_options(all);
 
   po::variables_map& vm = all.vm;
@@ -975,17 +977,17 @@ base_learner* bfgs_setup(vw& all)
   b.gradient_pass = true;
   b.preconditioner_pass = true;
   b.backstep_on = false;
-  b.final_pass=all.numpasses;  
+  b.final_pass=all.numpasses;
   b.no_win_counter = 0;
   b.early_stop_thres = 3;
 
   if(!all.holdout_set_off)
   {
     all.sd->holdout_best_loss = FLT_MAX;
-    if(vm.count("early_terminate"))      
-      b.early_stop_thres = vm["early_terminate"].as< size_t>();     
+    if(vm.count("early_terminate"))
+      b.early_stop_thres = vm["early_terminate"].as< size_t>();
   }
-  
+
   if (vm.count("hessian_on") || b.m==0) {
     all.hessian_on = true;
   }
@@ -1001,7 +1003,7 @@ base_learner* bfgs_setup(vw& all)
   }
   if (all.numpasses < 2)
     THROW("you must make at least 2 passes to use BFGS");
-	  
+
   all.bfgs = true;
   all.reg.stride_shift = 2;
 

--- a/vowpalwabbit/binary.cc
+++ b/vowpalwabbit/binary.cc
@@ -7,31 +7,30 @@ void predict_or_learn(char&, LEARNER::base_learner& base, example& ec) {
     base.learn(ec);
   else
     base.predict(ec);
-  
+
   if ( ec.pred.scalar > 0)
     ec.pred.scalar = 1;
   else
     ec.pred.scalar = -1;
-  
+
   if (ec.l.simple.label != FLT_MAX)
-    {
-      if (fabs(ec.l.simple.label) != 1.f)
-	cout << "You are using label " << ec.l.simple.label << " not -1 or 1 as loss function expects!" << endl;
-      else
-	if (ec.l.simple.label == ec.pred.scalar)
-	  ec.loss = 0.;
-	else
-	  ec.loss = ec.l.simple.weight; 
-    }
+  {
+    if (fabs(ec.l.simple.label) != 1.f)
+      cout << "You are using label " << ec.l.simple.label << " not -1 or 1 as loss function expects!" << endl;
+    else if (ec.l.simple.label == ec.pred.scalar)
+      ec.loss = 0.;
+    else
+      ec.loss = ec.l.simple.weight;
+  }
 }
 
 LEARNER::base_learner* binary_setup(vw& all)
 {
   if (missing_option(all, false, "binary", "report loss as binary classification on -1,1"))
     return nullptr;
-  
-  LEARNER::learner<char>& ret = 
-    LEARNER::init_learner<char>(nullptr, setup_base(all), 
-				predict_or_learn<true>, predict_or_learn<false>);
+
+  LEARNER::learner<char>& ret =
+    LEARNER::init_learner<char>(nullptr, setup_base(all),
+                                predict_or_learn<true>, predict_or_learn<false>);
   return make_base(ret);
 }

--- a/vowpalwabbit/boosting.cc
+++ b/vowpalwabbit/boosting.cc
@@ -6,8 +6,8 @@
 
 /*
  * Implementation of online boosting algorithms from
- *    Beygelzimer, Kale, Luo: Optimal and adaptive algorithms for online boosting, 
- *    ICML-2015. 
+ *    Beygelzimer, Kale, Luo: Optimal and adaptive algorithms for online boosting,
+ *    ICML-2015.
  */
 
 #include <float.h>
@@ -25,227 +25,233 @@
 using namespace std;
 using namespace LEARNER;
 
-inline float sign(float w) { if (w <= 0.) return -1.; else  return 1.;}
+inline float sign(float w) {
+  if (w <= 0.) return -1.;
+  else  return 1.;
+}
 
 long long choose(long long n, long long k) {
-    if (k > n) return 0;
-    if (k<0) return 0;
-    if (k==n) return 1;
-    if (k==0 && n!=0) return 1;
-    long long r = 1;
-    for (long long d = 1; d <= k; ++d) {
-      r *= n--;
-      r /= d;
-    }
-    return r;
+  if (k > n) return 0;
+  if (k<0) return 0;
+  if (k==n) return 1;
+  if (k==0 && n!=0) return 1;
+  long long r = 1;
+  for (long long d = 1; d <= k; ++d) {
+    r *= n--;
+    r /= d;
+  }
+  return r;
 }
-  
+
 struct boosting {
-    int N;
-    float gamma;
-    string* alg;
-    vw* all;
-    std::vector<std::vector<long long> > C;
-    std::vector<float> alpha;
-    std::vector<float> v;
-    int t;
+  int N;
+  float gamma;
+  string* alg;
+  vw* all;
+  std::vector<std::vector<long long> > C;
+  std::vector<float> alpha;
+  std::vector<float> v;
+  int t;
 };
-  
+
 //---------------------------------------------------
 // Online Boost-by-Majority (BBM)
 // --------------------------------------------------
 template <bool is_learn>
-  void predict_or_learn(boosting& o, LEARNER::base_learner& base, example& ec) {
-    label_data& ld = ec.l.simple;
-    
-    float final_prediction = 0;
-    
-    float s = 0;
-    float u = ld.weight;
+void predict_or_learn(boosting& o, LEARNER::base_learner& base, example& ec) {
+  label_data& ld = ec.l.simple;
 
-    if (is_learn) o.t++;
-      
-    for (int i = 0; i < o.N; i++)
-    {
-      if (is_learn) {
-        
-        float k = floorf((float)(o.N-i-s)/2);
-        long long c;
-        if (o.N-(i+1)<0) c=0;
-        else if (k > o.N-(i+1)) c=0;
-        else if (k < 0) c = 0;
-        else if (o.C[o.N-(i+1)][(long long)k] != -1) 
-	    c = o.C[o.N-(i+1)][(long long)k];
-        else { c = choose(o.N-(i+1),k); o.C[o.N-(i+1)][(long long)k] = c; }
-        
-        float w = c * pow((double)(0.5 + o.gamma),
-	    (double)k) * pow((double)0.5 - o.gamma,(double)(o.N-(i+1)-k));
-          
-        // update ld.weight, weight for learner i (starting from 0)
-	ld.weight = u * w;
-        
-        base.predict(ec, i);
+  float final_prediction = 0;
 
-	// ec.pred.scalar is now the i-th learner prediction on this example
-	s += ld.label * ec.pred.scalar;
+  float s = 0;
+  float u = ld.weight;
 
-	final_prediction += ec.pred.scalar;
+  if (is_learn) o.t++;
 
-        base.learn(ec, i);
-      }
+  for (int i = 0; i < o.N; i++)
+  {
+    if (is_learn) {
+
+      float k = floorf((float)(o.N-i-s)/2);
+      long long c;
+      if (o.N-(i+1)<0) c=0;
+      else if (k > o.N-(i+1)) c=0;
+      else if (k < 0) c = 0;
+      else if (o.C[o.N-(i+1)][(long long)k] != -1)
+        c = o.C[o.N-(i+1)][(long long)k];
       else {
-          base.predict(ec, i);
-          final_prediction += ec.pred.scalar;
+        c = choose(o.N-(i+1),k);
+        o.C[o.N-(i+1)][(long long)k] = c;
       }
-    }	
-    
-    ld.weight = u;
-    ec.pred.scalar = sign(final_prediction);
 
-    if (ld.label == ec.pred.scalar)
-      ec.loss = 0.;
-    else
-      ec.loss = ld.weight;
+      float w = c * pow((double)(0.5 + o.gamma),
+                        (double)k) * pow((double)0.5 - o.gamma,(double)(o.N-(i+1)-k));
+
+      // update ld.weight, weight for learner i (starting from 0)
+      ld.weight = u * w;
+
+      base.predict(ec, i);
+
+      // ec.pred.scalar is now the i-th learner prediction on this example
+      s += ld.label * ec.pred.scalar;
+
+      final_prediction += ec.pred.scalar;
+
+      base.learn(ec, i);
+    }
+    else {
+      base.predict(ec, i);
+      final_prediction += ec.pred.scalar;
+    }
+  }
+
+  ld.weight = u;
+  ec.pred.scalar = sign(final_prediction);
+
+  if (ld.label == ec.pred.scalar)
+    ec.loss = 0.;
+  else
+    ec.loss = ld.weight;
 }
 
 //-----------------------------------------------------------------
 // Logistic boost
 //-----------------------------------------------------------------
 template <bool is_learn>
-  void predict_or_learn_logistic(boosting& o, LEARNER::base_learner& base, example& ec) {
-    label_data& ld = ec.l.simple;
+void predict_or_learn_logistic(boosting& o, LEARNER::base_learner& base, example& ec) {
+  label_data& ld = ec.l.simple;
 
-    float final_prediction = 0;
+  float final_prediction = 0;
 
-    float s = 0;
-    float u = ld.weight;
+  float s = 0;
+  float u = ld.weight;
 
-    if (is_learn) o.t++;
-    float eta = 4 / sqrt(o.t);
+  if (is_learn) o.t++;
+  float eta = 4 / sqrt(o.t);
 
-    for (int i = 0; i < o.N; i++) {
+  for (int i = 0; i < o.N; i++) {
 
-      if (is_learn) {
-        float w = 1 / (1 + exp(s));
+    if (is_learn) {
+      float w = 1 / (1 + exp(s));
 
-        ld.weight = u * w;
+      ld.weight = u * w;
 
-        base.predict(ec, i);
-	float z;
-	z = ld.label * ec.pred.scalar;
+      base.predict(ec, i);
+      float z;
+      z = ld.label * ec.pred.scalar;
 
-        s += z * o.alpha[i];
+      s += z * o.alpha[i];
 
-	// if ld.label * ec.pred.scalar < 0, learner i made a mistake
+      // if ld.label * ec.pred.scalar < 0, learner i made a mistake
 
-	final_prediction += ec.pred.scalar * o.alpha[i];
+      final_prediction += ec.pred.scalar * o.alpha[i];
 
-	// update alpha
-        o.alpha[i] += eta * z / (1 + exp(s));
-	if (o.alpha[i] > 2.) o.alpha[i] = 2;
-	if (o.alpha[i] < -2.) o.alpha[i] = -2;
+      // update alpha
+      o.alpha[i] += eta * z / (1 + exp(s));
+      if (o.alpha[i] > 2.) o.alpha[i] = 2;
+      if (o.alpha[i] < -2.) o.alpha[i] = -2;
 
-        base.learn(ec, i);
+      base.learn(ec, i);
 
-      }
-      else {
-        base.predict(ec, i);
-	final_prediction += ec.pred.scalar * o.alpha[i];
-      }
     }
+    else {
+      base.predict(ec, i);
+      final_prediction += ec.pred.scalar * o.alpha[i];
+    }
+  }
 
-    ld.weight = u;
-    ec.pred.scalar = sign(final_prediction);
+  ld.weight = u;
+  ec.pred.scalar = sign(final_prediction);
 
-    if (ld.label == ec.pred.scalar)
-      ec.loss = 0.;
-    else
-      ec.loss = ld.weight;
+  if (ld.label == ec.pred.scalar)
+    ec.loss = 0.;
+  else
+    ec.loss = ld.weight;
 }
 
 template <bool is_learn>
-  void predict_or_learn_adaptive(boosting& o, LEARNER::base_learner& base, example& ec) {
-    label_data& ld = ec.l.simple;
+void predict_or_learn_adaptive(boosting& o, LEARNER::base_learner& base, example& ec) {
+  label_data& ld = ec.l.simple;
 
-    float final_prediction = 0, partial_prediction = 0;
+  float final_prediction = 0, partial_prediction = 0;
 
-    float s = 0;
-    float v_normalization = 0, v_partial_sum = 0;
-    float u = ld.weight;
+  float s = 0;
+  float v_normalization = 0, v_partial_sum = 0;
+  float u = ld.weight;
 
-    if (is_learn) o.t++;
-    float eta = 4 / sqrt(o.t);
+  if (is_learn) o.t++;
+  float eta = 4 / sqrt(o.t);
 
-    float stopping_point = frand48();
+  float stopping_point = frand48();
 
-    for (int i = 0; i < o.N; i++) {
+  for (int i = 0; i < o.N; i++) {
 
-      if (is_learn) {
-        float w = 1 / (1 + exp(s));
+    if (is_learn) {
+      float w = 1 / (1 + exp(s));
 
-        ld.weight = u * w;
+      ld.weight = u * w;
 
-        base.predict(ec, i);
-	float z;
+      base.predict(ec, i);
+      float z;
 
-	z = ld.label * ec.pred.scalar;
+      z = ld.label * ec.pred.scalar;
 
-        s += z * o.alpha[i];
+      s += z * o.alpha[i];
 
-        if (v_partial_sum <= stopping_point) {
-	    final_prediction += ec.pred.scalar * o.alpha[i];
-	}
+      if (v_partial_sum <= stopping_point) {
+        final_prediction += ec.pred.scalar * o.alpha[i];
+      }
 
-	partial_prediction += ec.pred.scalar * o.alpha[i];
+      partial_prediction += ec.pred.scalar * o.alpha[i];
 
-	v_partial_sum += o.v[i];
+      v_partial_sum += o.v[i];
 
-	// update v, exp(-1) = 0.36788
-	if (ld.label * partial_prediction < 0) {
-	    o.v[i] *= 0.36788;
-	}
-	v_normalization += o.v[i];
+      // update v, exp(-1) = 0.36788
+      if (ld.label * partial_prediction < 0) {
+        o.v[i] *= 0.36788;
+      }
+      v_normalization += o.v[i];
 
-	// update alpha
-        o.alpha[i] += eta * z / (1 + exp(s));
-	if (o.alpha[i] > 2.) o.alpha[i] = 2;
-	if (o.alpha[i] < -2.) o.alpha[i] = -2;
+      // update alpha
+      o.alpha[i] += eta * z / (1 + exp(s));
+      if (o.alpha[i] > 2.) o.alpha[i] = 2;
+      if (o.alpha[i] < -2.) o.alpha[i] = -2;
 
-        base.learn(ec, i);
+      base.learn(ec, i);
 
+    }
+    else {
+      base.predict(ec, i);
+      if (v_partial_sum <= stopping_point) {
+        final_prediction += ec.pred.scalar * o.alpha[i];
       }
       else {
-        base.predict(ec, i);
-        if (v_partial_sum <= stopping_point) {
-            final_prediction += ec.pred.scalar * o.alpha[i];
-	}
-	else { 
-	    // stopping at learner i
-	    break;
-	}
-	v_partial_sum += o.v[i];
+        // stopping at learner i
+        break;
       }
+      v_partial_sum += o.v[i];
     }
+  }
 
-    // normalize v vector in training
-    if (is_learn) {
-        for(int i = 0; i < o.N; i++) {
-	    if (v_normalization)
-	        o.v[i] /= v_normalization;
-        }
+  // normalize v vector in training
+  if (is_learn) {
+    for(int i = 0; i < o.N; i++) {
+      if (v_normalization)
+        o.v[i] /= v_normalization;
     }
+  }
 
-    ld.weight = u;
-    ec.pred.scalar = sign(final_prediction);
+  ld.weight = u;
+  ec.pred.scalar = sign(final_prediction);
 
-    if (ld.label == ec.pred.scalar)
-      ec.loss = 0.;
-    else
-      ec.loss = ld.weight;
+  if (ld.label == ec.pred.scalar)
+    ec.loss = 0.;
+  else
+    ec.loss = ld.weight;
 }
 
 
-void save_load_sampling(boosting &o, io_buf &model_file, bool read, bool text) 
+void save_load_sampling(boosting &o, io_buf &model_file, bool read, bool text)
 {
   if (model_file.files.size() == 0)
     return;
@@ -253,66 +259,66 @@ void save_load_sampling(boosting &o, io_buf &model_file, bool read, bool text)
   os << "boosts " << o.N << endl;
   const char* buff = os.str().c_str();
   bin_text_read_write_fixed(model_file, (char *) &(o.N),  sizeof(o.N), "", read, buff, strlen(buff), text);
-  
+
   if (read) {
     o.alpha.resize(o.N);
     o.v.resize(o.N);
   }
-  
+
   for (int i = 0; i < o.N; i++)
     if (read)
-      {
-	float f;
-	bin_read_fixed(model_file, (char *) &f,  sizeof(f), "");
-	o.alpha[i] = f;
-      }
+    {
+      float f;
+      bin_read_fixed(model_file, (char *) &f,  sizeof(f), "");
+      o.alpha[i] = f;
+    }
     else
-      {
-	stringstream os2;
-	os2 << "alpha " << o.alpha[i] << endl;
-	const char* buff2 = os.str().c_str();
-	bin_text_write_fixed(model_file, (char *) &(o.alpha[i]),  sizeof(o.alpha[i]), buff2, strlen(buff2), text);		  
-      }
+    {
+      stringstream os2;
+      os2 << "alpha " << o.alpha[i] << endl;
+      const char* buff2 = os.str().c_str();
+      bin_text_write_fixed(model_file, (char *) &(o.alpha[i]),  sizeof(o.alpha[i]), buff2, strlen(buff2), text);
+    }
 
-   for (int i = 0; i < o.N; i++)
+  for (int i = 0; i < o.N; i++)
     if (read)
-      {
-	float f;
-	bin_read_fixed(model_file, (char *) &f,  sizeof(f), "");
-	o.v[i] = f;
-      }
+    {
+      float f;
+      bin_read_fixed(model_file, (char *) &f,  sizeof(f), "");
+      o.v[i] = f;
+    }
     else
-      {
-	stringstream os2;
-	os2 << "v " << o.v[i] << endl;
-	const char* buff2 = os.str().c_str();
-	bin_text_write_fixed(model_file, (char *) &(o.v[i]),  sizeof(o.v[i]), buff2, strlen(buff2), text);		  
-      }
+    {
+      stringstream os2;
+      os2 << "v " << o.v[i] << endl;
+      const char* buff2 = os.str().c_str();
+      bin_text_write_fixed(model_file, (char *) &(o.v[i]),  sizeof(o.v[i]), buff2, strlen(buff2), text);
+    }
 
-   if (read) {
-	cerr << "Loading alpha and v: " << endl;
-   }
-   else {
-	cerr << "Saving alpha and v, current weighted_examples = " << o.all->sd->weighted_examples << endl;
-   }
-   for (int i = 0; i < o.N; i++) {
-	cerr << o.alpha[i] << " " << o.v[i] << endl;
-   }
-   cerr << endl;
+  if (read) {
+    cerr << "Loading alpha and v: " << endl;
+  }
+  else {
+    cerr << "Saving alpha and v, current weighted_examples = " << o.all->sd->weighted_examples << endl;
+  }
+  for (int i = 0; i < o.N; i++) {
+    cerr << o.alpha[i] << " " << o.v[i] << endl;
+  }
+  cerr << endl;
 }
 
 void finish(boosting& o) {
-    delete o.alg;
-    o.C.~vector();
-    o.alpha.~vector();
-}
-  
-void return_example(vw& all, boosting& a, example& ec) {
-    output_and_account_example(all, ec);
-    VW::finish_example(all,&ec);
+  delete o.alg;
+  o.C.~vector();
+  o.alpha.~vector();
 }
 
-void save_load(boosting &o, io_buf &model_file, bool read, bool text) 
+void return_example(vw& all, boosting& a, example& ec) {
+  output_and_account_example(all, ec);
+  VW::finish_example(all,&ec);
+}
+
+void save_load(boosting &o, io_buf &model_file, bool read, bool text)
 {
   if (model_file.files.size() == 0)
     return;
@@ -320,100 +326,100 @@ void save_load(boosting &o, io_buf &model_file, bool read, bool text)
   os << "boosts " << o.N << endl;
   const char* buff = os.str().c_str();
   bin_text_read_write_fixed(model_file, (char *) &(o.N),  sizeof(o.N), "", read, buff, strlen(buff), text);
-  
+
   if (read) {
     o.alpha.resize(o.N);
   }
-  
+
   for (int i = 0; i < o.N; i++)
     if (read)
-      {
-	float f;
-	bin_read_fixed(model_file, (char *) &f,  sizeof(f), "");
-	o.alpha[i] = f;
-      }
+    {
+      float f;
+      bin_read_fixed(model_file, (char *) &f,  sizeof(f), "");
+      o.alpha[i] = f;
+    }
     else
-      {
-	stringstream os2;
-	os2 << "alpha " << o.alpha[i] << endl;
-	const char* buff2 = os.str().c_str();
-	bin_text_write_fixed(model_file, (char *) &(o.alpha[i]),  sizeof(o.alpha[i]), buff2, strlen(buff2), text);		  
-      }
+    {
+      stringstream os2;
+      os2 << "alpha " << o.alpha[i] << endl;
+      const char* buff2 = os.str().c_str();
+      bin_text_write_fixed(model_file, (char *) &(o.alpha[i]),  sizeof(o.alpha[i]), buff2, strlen(buff2), text);
+    }
 
-   if (read) {
-	cerr << "Loading alpha: " << endl;
-   }
-   else {
-	cerr << "Saving alpha, current weighted_examples = " << o.all->sd->weighted_examples << endl;
-   }
-   for (int i = 0; i < o.N; i++) {
-	cerr << o.alpha[i] << " " << endl;
-   }
-   cerr << endl;
+  if (read) {
+    cerr << "Loading alpha: " << endl;
+  }
+  else {
+    cerr << "Saving alpha, current weighted_examples = " << o.all->sd->weighted_examples << endl;
+  }
+  for (int i = 0; i < o.N; i++) {
+    cerr << o.alpha[i] << " " << endl;
+  }
+  cerr << endl;
 }
 
 LEARNER::base_learner* boosting_setup(vw& all)
 {
-    if (missing_option<size_t,true>(all,"boosting",
-	"Online boosting with <N> weak learners"))
-        return NULL;
-    new_options(all, "Boosting Options")
-      ("gamma", po::value<float>()->default_value(0.1), 
-	 "weak learner's edge (=0.1), used only by online BBM")
-      ("alg", po::value<string>()->default_value("BBM"),
-	 "specify the boosting algorithm: BBM (default), logistic (AdaBoost.OL.W), adaptive (AdaBoost.OL)");
+  if (missing_option<size_t,true>(all,"boosting",
+                                  "Online boosting with <N> weak learners"))
+    return NULL;
+  new_options(all, "Boosting Options")
+  ("gamma", po::value<float>()->default_value(0.1),
+   "weak learner's edge (=0.1), used only by online BBM")
+  ("alg", po::value<string>()->default_value("BBM"),
+   "specify the boosting algorithm: BBM (default), logistic (AdaBoost.OL.W), adaptive (AdaBoost.OL)");
 
-    // Description of options:
-    // "BBM" implements online BBM (Algorithm 1 in BLK'15)
-    // "logistic" implements AdaBoost.OL.W (importance weighted version 
-    // 	    of Algorithm 2 in BLK'15)
-    // "adaptive" implements AdaBoost.OL (Algorithm 2 in BLK'15, 
-    // 	    using sampling rather than importance weighting)
-    add_options(all);
-    
-    boosting& data = calloc_or_die<boosting>();
-    data.N = (uint32_t)all.vm["boosting"].as<size_t>();
-    cerr << "Number of weak learners = " << data.N << endl;
-    data.gamma = all.vm["gamma"].as<float>();
-    cerr << "Gamma = " << data.gamma << endl;
-    string* temp = new string;
-    *temp = all.vm["alg"].as<string>();
-    data.alg = temp;
+  // Description of options:
+  // "BBM" implements online BBM (Algorithm 1 in BLK'15)
+  // "logistic" implements AdaBoost.OL.W (importance weighted version
+  // 	    of Algorithm 2 in BLK'15)
+  // "adaptive" implements AdaBoost.OL (Algorithm 2 in BLK'15,
+  // 	    using sampling rather than importance weighting)
+  add_options(all);
 
-    data.C = std::vector<std::vector<long long> >(data.N, 
-	std::vector<long long>(data.N,-1));
+  boosting& data = calloc_or_die<boosting>();
+  data.N = (uint32_t)all.vm["boosting"].as<size_t>();
+  cerr << "Number of weak learners = " << data.N << endl;
+  data.gamma = all.vm["gamma"].as<float>();
+  cerr << "Gamma = " << data.gamma << endl;
+  string* temp = new string;
+  *temp = all.vm["alg"].as<string>();
+  data.alg = temp;
 
-    data.t = 0;
-    
-    data.all = &all;
-    data.alpha = std::vector<float>(data.N,0);
-    data.v = std::vector<float>(data.N,1);
+  data.C = std::vector<std::vector<long long> >(data.N,
+           std::vector<long long>(data.N,-1));
 
-    learner<boosting>* l;
-    if (*data.alg == "BBM") {
+  data.t = 0;
 
-        l = &init_learner<boosting>(&data, setup_base(all), 
-	    predict_or_learn<true>, 
-	    predict_or_learn<false>, data.N);
-    } 
-    else if (*data.alg == "logistic") {
+  data.all = &all;
+  data.alpha = std::vector<float>(data.N,0);
+  data.v = std::vector<float>(data.N,1);
 
-        l = &init_learner<boosting>(&data, setup_base(all), 
-	    predict_or_learn_logistic<true>, 
-	    predict_or_learn_logistic<false>, data.N);
-	l->set_save_load(save_load);
-    } 
-    else if (*data.alg == "adaptive") {
-        l = &init_learner<boosting>(&data, setup_base(all), 
-	    predict_or_learn_adaptive<true>, 
-	    predict_or_learn_adaptive<false>, data.N);
-	l->set_save_load(save_load_sampling);
-    }
-    else 
-      THROW("Unrecognized boosting algorithm: \'" << *data.alg << "\' Bailing!");
+  learner<boosting>* l;
+  if (*data.alg == "BBM") {
 
-    l->set_finish(finish);
-    l->set_finish_example(return_example);
+    l = &init_learner<boosting>(&data, setup_base(all),
+                                predict_or_learn<true>,
+                                predict_or_learn<false>, data.N);
+  }
+  else if (*data.alg == "logistic") {
 
-    return make_base(*l);
+    l = &init_learner<boosting>(&data, setup_base(all),
+                                predict_or_learn_logistic<true>,
+                                predict_or_learn_logistic<false>, data.N);
+    l->set_save_load(save_load);
+  }
+  else if (*data.alg == "adaptive") {
+    l = &init_learner<boosting>(&data, setup_base(all),
+                                predict_or_learn_adaptive<true>,
+                                predict_or_learn_adaptive<false>, data.N);
+    l->set_save_load(save_load_sampling);
+  }
+  else
+    THROW("Unrecognized boosting algorithm: \'" << *data.alg << "\' Bailing!");
+
+  l->set_finish(finish);
+  l->set_finish_example(return_example);
+
+  return make_base(*l);
 }

--- a/vowpalwabbit/bs.cc
+++ b/vowpalwabbit/bs.cc
@@ -19,246 +19,248 @@ license as described in the file LICENSE.
 using namespace std;
 using namespace LEARNER;
 
-  struct bs {
-    uint32_t B; //number of bootstrap rounds
-    size_t bs_type;
-    float lb;
-    float ub;
-    vector<double> pred_vec;
-    vw* all; // for raw prediction and loss
-  };
+struct bs {
+  uint32_t B; //number of bootstrap rounds
+  size_t bs_type;
+  float lb;
+  float ub;
+  vector<double> pred_vec;
+  vw* all; // for raw prediction and loss
+};
 
-  void bs_predict_mean(vw& all, example& ec, vector<double> &pred_vec)
+void bs_predict_mean(vw& all, example& ec, vector<double> &pred_vec)
+{
+  ec.pred.scalar = (float)accumulate(pred_vec.begin(), pred_vec.end(), 0.0)/pred_vec.size();
+  ec.loss = all.loss->getLoss(all.sd, ec.pred.scalar, ec.l.simple.label) * ec.l.simple.weight;
+}
+
+void bs_predict_vote(example& ec, vector<double> &pred_vec)
+{ //majority vote in linear time
+  unsigned int counter = 0;
+  int current_label = 1, init_label = 1;
+  // float sum_labels = 0; // uncomment for: "avg on votes" and getLoss()
+  bool majority_found = false;
+  bool multivote_detected = false; // distinct(votes)>2: used to skip part of the algorithm
+  int* pred_vec_int = new int[pred_vec.size()];
+
+  for(unsigned int i=0; i<pred_vec.size(); i++)
   {
-    ec.pred.scalar = (float)accumulate(pred_vec.begin(), pred_vec.end(), 0.0)/pred_vec.size();
-    ec.loss = all.loss->getLoss(all.sd, ec.pred.scalar, ec.l.simple.label) * ec.l.simple.weight;    
-  }
+    pred_vec_int[i] = (int)floor(pred_vec[i]+0.5); // could be added: link(), min_label/max_label, cutoff between true/false for binary
 
-  void bs_predict_vote(example& ec, vector<double> &pred_vec)
-  { //majority vote in linear time
-    unsigned int counter = 0;
-    int current_label = 1, init_label = 1;
-    // float sum_labels = 0; // uncomment for: "avg on votes" and getLoss()
-    bool majority_found = false;
-    bool multivote_detected = false; // distinct(votes)>2: used to skip part of the algorithm
-    int* pred_vec_int = new int[pred_vec.size()];
-
-    for(unsigned int i=0; i<pred_vec.size(); i++)
-    {
-      pred_vec_int[i] = (int)floor(pred_vec[i]+0.5); // could be added: link(), min_label/max_label, cutoff between true/false for binary
-
-      if(multivote_detected == false) { // distinct(votes)>2 detection bloc
-        if(i == 0) {
-          init_label = pred_vec_int[i];
-          current_label = pred_vec_int[i];
-        }
-        else if(init_label != current_label && pred_vec_int[i] != current_label
-                 && pred_vec_int[i] != init_label)
-             multivote_detected = true; // more than 2 distinct votes detected
-      }
-
-      if (counter == 0) {
-        counter = 1;
+    if(multivote_detected == false) { // distinct(votes)>2 detection bloc
+      if(i == 0) {
+        init_label = pred_vec_int[i];
         current_label = pred_vec_int[i];
       }
+      else if(init_label != current_label && pred_vec_int[i] != current_label
+              && pred_vec_int[i] != init_label)
+        multivote_detected = true; // more than 2 distinct votes detected
+    }
+
+    if (counter == 0) {
+      counter = 1;
+      current_label = pred_vec_int[i];
+    }
+    else {
+      if(pred_vec_int[i] == current_label)
+        counter++;
       else {
-        if(pred_vec_int[i] == current_label)
-          counter++;
-        else {
-          counter--;
-        }
+        counter--;
       }
     }
+  }
 
-    if(counter > 0 && multivote_detected) { // remove this condition for: "avg on votes" and getLoss()
-      counter = 0;
-      for(unsigned int i=0; i<pred_vec.size(); i++)
-        if(pred_vec_int[i] == current_label) {
-          counter++;
-          // sum_labels += pred_vec[i]; // uncomment for: "avg on votes" and getLoss()
+  if(counter > 0 && multivote_detected) { // remove this condition for: "avg on votes" and getLoss()
+    counter = 0;
+    for(unsigned int i=0; i<pred_vec.size(); i++)
+      if(pred_vec_int[i] == current_label) {
+        counter++;
+        // sum_labels += pred_vec[i]; // uncomment for: "avg on votes" and getLoss()
       }
-      if(counter*2 > pred_vec.size())
-        majority_found = true;
-    }
+    if(counter*2 > pred_vec.size())
+      majority_found = true;
+  }
 
-    if(multivote_detected && majority_found == false) { // then find most frequent element - if tie: smallest tie label
-        std::sort(pred_vec_int, pred_vec_int+pred_vec.size());
-        int tmp_label = pred_vec_int[0];
-        counter = 1;
-        for(unsigned int i=1, temp_count=1; i<pred_vec.size(); i++)
-        {
-          if(tmp_label == pred_vec_int[i])
-            temp_count++;
-          else {
-            if(temp_count > counter) {
-              current_label = tmp_label;
-              counter = temp_count;
-            }
-            tmp_label = pred_vec_int[i];
-            temp_count = 1;
-          }
+  if(multivote_detected && majority_found == false) { // then find most frequent element - if tie: smallest tie label
+    std::sort(pred_vec_int, pred_vec_int+pred_vec.size());
+    int tmp_label = pred_vec_int[0];
+    counter = 1;
+    for(unsigned int i=1, temp_count=1; i<pred_vec.size(); i++)
+    {
+      if(tmp_label == pred_vec_int[i])
+        temp_count++;
+      else {
+        if(temp_count > counter) {
+          current_label = tmp_label;
+          counter = temp_count;
         }
-        /* uncomment for: "avg on votes" and getLoss()
-        sum_labels = 0;
-        for(unsigned int i=0; i<pred_vec.size(); i++)
-          if(pred_vec_int[i] == current_label)
-            sum_labels += pred_vec[i]; */
-    }
-	// TODO: unique_ptr would also handle exception case
-    delete[] pred_vec_int;
-
-    // ld.prediction = sum_labels/(float)counter; //replace line below for: "avg on votes" and getLoss()
-    ec.pred.scalar = (float)current_label;
-
-    // ec.loss = all.loss->getLoss(all.sd, ld.prediction, ld.label) * ld.weight; //replace line below for: "avg on votes" and getLoss()
-    ec.loss = ((ec.pred.scalar == ec.l.simple.label) ? 0.f : 1.f) * ec.l.simple.weight;
-  }
-
-  void print_result(int f, float res, v_array<char> tag, float lb, float ub)
-  {
-    if (f >= 0)
-    {
-      char temp[30];
-      sprintf(temp, "%f", res);
-      std::stringstream ss;
-      ss << temp;
-      print_tag(ss, tag);
-      ss << ' ';
-      sprintf(temp, "%f", lb);
-      ss << temp;
-      ss << ' ';
-      sprintf(temp, "%f", ub);
-      ss << temp;
-      ss << '\n';
-      ssize_t len = ss.str().size();
-      ssize_t t = io_buf::write_file_or_socket(f, ss.str().c_str(), (unsigned int)len);
-      if (t != len)
-        cerr << "write error: " << strerror(errno) << endl;
-    }    
-  }
-
-  void output_example(vw& all, bs& d, example& ec)
-  {
-    label_data& ld = ec.l.simple;
-    
-    all.sd->update(ec.test_only, ec.loss, ld.weight, ec.num_features);
-    if (ld.label != FLT_MAX && !ec.test_only)
-      all.sd->weighted_labels += ld.label * ld.weight;
-    
-    if(all.final_prediction_sink.size() != 0)//get confidence interval only when printing out predictions
-    {
-      d.lb = FLT_MAX;
-      d.ub = -FLT_MAX;
-      for (unsigned i = 0; i < d.pred_vec.size(); i++)
-      {
-        if(d.pred_vec[i] > d.ub)
-          d.ub = (float)d.pred_vec[i];
-        if(d.pred_vec[i] < d.lb)
-          d.lb = (float)d.pred_vec[i];
+        tmp_label = pred_vec_int[i];
+        temp_count = 1;
       }
     }
-
-    for (int* sink = all.final_prediction_sink.begin; sink != all.final_prediction_sink.end; sink++)
-      print_result(*sink, ec.pred.scalar, ec.tag, d.lb, d.ub);
-  
-    print_update(all, ec);
+    /* uncomment for: "avg on votes" and getLoss()
+    sum_labels = 0;
+    for(unsigned int i=0; i<pred_vec.size(); i++)
+      if(pred_vec_int[i] == current_label)
+        sum_labels += pred_vec[i]; */
   }
+  // TODO: unique_ptr would also handle exception case
+  delete[] pred_vec_int;
 
-  template <bool is_learn>
-  void predict_or_learn(bs& d, base_learner& base, example& ec)
+  // ld.prediction = sum_labels/(float)counter; //replace line below for: "avg on votes" and getLoss()
+  ec.pred.scalar = (float)current_label;
+
+  // ec.loss = all.loss->getLoss(all.sd, ld.prediction, ld.label) * ld.weight; //replace line below for: "avg on votes" and getLoss()
+  ec.loss = ((ec.pred.scalar == ec.l.simple.label) ? 0.f : 1.f) * ec.l.simple.weight;
+}
+
+void print_result(int f, float res, v_array<char> tag, float lb, float ub)
+{
+  if (f >= 0)
   {
-    vw& all = *d.all;
-    bool shouldOutput = all.raw_prediction > 0;
+    char temp[30];
+    sprintf(temp, "%f", res);
+    std::stringstream ss;
+    ss << temp;
+    print_tag(ss, tag);
+    ss << ' ';
+    sprintf(temp, "%f", lb);
+    ss << temp;
+    ss << ' ';
+    sprintf(temp, "%f", ub);
+    ss << temp;
+    ss << '\n';
+    ssize_t len = ss.str().size();
+    ssize_t t = io_buf::write_file_or_socket(f, ss.str().c_str(), (unsigned int)len);
+    if (t != len)
+      cerr << "write error: " << strerror(errno) << endl;
+  }
+}
 
-    float weight_temp = ec.l.simple.weight;
-  
-    stringstream outputStringStream;
-    d.pred_vec.clear();
+void output_example(vw& all, bs& d, example& ec)
+{
+  label_data& ld = ec.l.simple;
 
-    for (size_t i = 1; i <= d.B; i++)
-      {
-        ec.l.simple.weight = weight_temp * (float) BS::weight_gen();
+  all.sd->update(ec.test_only, ec.loss, ld.weight, ec.num_features);
+  if (ld.label != FLT_MAX && !ec.test_only)
+    all.sd->weighted_labels += ld.label * ld.weight;
 
-	if (is_learn)
-	  base.learn(ec, i-1);
-	else
-	  base.predict(ec, i-1);
-	
-        d.pred_vec.push_back(ec.pred.scalar);
-
-        if (shouldOutput) {
-          if (i > 1) outputStringStream << ' ';
-          outputStringStream << i << ':' << ec.partial_prediction;
-        }
-      }	
-    
-    ec.l.simple.weight = weight_temp;
-    
-    switch(d.bs_type)
+  if(all.final_prediction_sink.size() != 0)//get confidence interval only when printing out predictions
+  {
+    d.lb = FLT_MAX;
+    d.ub = -FLT_MAX;
+    for (unsigned i = 0; i < d.pred_vec.size(); i++)
     {
-      case BS_TYPE_MEAN:
-        bs_predict_mean(all, ec, d.pred_vec);
-        break;
-      case BS_TYPE_VOTE:
-        bs_predict_vote(ec, d.pred_vec);
-        break;
-      default:
-	THROW("Unknown bs_type specified: " << d.bs_type);
+      if(d.pred_vec[i] > d.ub)
+        d.ub = (float)d.pred_vec[i];
+      if(d.pred_vec[i] < d.lb)
+        d.lb = (float)d.pred_vec[i];
     }
-
-    if (shouldOutput) 
-      all.print_text(all.raw_prediction, outputStringStream.str(), ec.tag);
   }
 
-  void finish_example(vw& all, bs& d, example& ec)
+  for (int* sink = all.final_prediction_sink.begin; sink != all.final_prediction_sink.end; sink++)
+    print_result(*sink, ec.pred.scalar, ec.tag, d.lb, d.ub);
+
+  print_update(all, ec);
+}
+
+template <bool is_learn>
+void predict_or_learn(bs& d, base_learner& base, example& ec)
+{
+  vw& all = *d.all;
+  bool shouldOutput = all.raw_prediction > 0;
+
+  float weight_temp = ec.l.simple.weight;
+
+  stringstream outputStringStream;
+  d.pred_vec.clear();
+
+  for (size_t i = 1; i <= d.B; i++)
   {
-    output_example(all, d, ec);
-    VW::finish_example(all, &ec);
+    ec.l.simple.weight = weight_temp * (float) BS::weight_gen();
+
+    if (is_learn)
+      base.learn(ec, i-1);
+    else
+      base.predict(ec, i-1);
+
+    d.pred_vec.push_back(ec.pred.scalar);
+
+    if (shouldOutput) {
+      if (i > 1) outputStringStream << ' ';
+      outputStringStream << i << ':' << ec.partial_prediction;
+    }
   }
 
-  void finish(bs& d)
-  { d.pred_vec.~vector(); }
+  ec.l.simple.weight = weight_temp;
+
+  switch(d.bs_type)
+  {
+  case BS_TYPE_MEAN:
+    bs_predict_mean(all, ec, d.pred_vec);
+    break;
+  case BS_TYPE_VOTE:
+    bs_predict_vote(ec, d.pred_vec);
+    break;
+  default:
+    THROW("Unknown bs_type specified: " << d.bs_type);
+  }
+
+  if (shouldOutput)
+    all.print_text(all.raw_prediction, outputStringStream.str(), ec.tag);
+}
+
+void finish_example(vw& all, bs& d, example& ec)
+{
+  output_example(all, d, ec);
+  VW::finish_example(all, &ec);
+}
+
+void finish(bs& d)
+{
+  d.pred_vec.~vector();
+}
 
 base_learner* bs_setup(vw& all)
 {
   if (missing_option<size_t, true>(all, "bootstrap", "k-way bootstrap by online importance resampling"))
     return nullptr;
-  new_options(all, "Bootstrap options")("bs_type", po::value<string>(), 
-					"prediction type {mean,vote}");    
+  new_options(all, "Bootstrap options")("bs_type", po::value<string>(),
+                                        "prediction type {mean,vote}");
   add_options(all);
-  
+
   bs& data = calloc_or_die<bs>();
   data.ub = FLT_MAX;
   data.lb = -FLT_MAX;
   data.B = (uint32_t)all.vm["bootstrap"].as<size_t>();
-  
+
   std::string type_string("mean");
   if (all.vm.count("bs_type"))
-    {
-      type_string = all.vm["bs_type"].as<std::string>();
-      
-      if (type_string.compare("mean") == 0) { 
-        data.bs_type = BS_TYPE_MEAN;
-      }
-      else if (type_string.compare("vote") == 0) {
-        data.bs_type = BS_TYPE_VOTE;
-      }
-      else {
-        std::cerr << "warning: bs_type must be in {'mean','vote'}; resetting to mean." << std::endl;
-        data.bs_type = BS_TYPE_MEAN;
-      }
+  {
+    type_string = all.vm["bs_type"].as<std::string>();
+
+    if (type_string.compare("mean") == 0) {
+      data.bs_type = BS_TYPE_MEAN;
     }
+    else if (type_string.compare("vote") == 0) {
+      data.bs_type = BS_TYPE_VOTE;
+    }
+    else {
+      std::cerr << "warning: bs_type must be in {'mean','vote'}; resetting to mean." << std::endl;
+      data.bs_type = BS_TYPE_MEAN;
+    }
+  }
   else //by default use mean
     data.bs_type = BS_TYPE_MEAN;
   *all.file_options << " --bs_type " << type_string;
-  
+
   data.pred_vec.reserve(data.B);
   data.all = &all;
-  
-  learner<bs>& l = init_learner(&data, setup_base(all), predict_or_learn<true>, 
-				predict_or_learn<false>, data.B);
+
+  learner<bs>& l = init_learner(&data, setup_base(all), predict_or_learn<true>,
+                                predict_or_learn<false>, data.B);
   l.set_finish_example(finish_example);
   l.set_finish(finish);
-  
+
   return make_base(l);
 }

--- a/vowpalwabbit/bs.h
+++ b/vowpalwabbit/bs.h
@@ -11,29 +11,29 @@ LEARNER::base_learner* bs_setup(vw& all);
 
 namespace BS
 {
-  inline uint32_t weight_gen()//sampling from Poisson with rate 1
-  { 
-    float temp = frand48();
-    if(temp<=0.3678794411714423215955) return 0;
-    if(temp<=0.735758882342884643191)  return 1;
-    if(temp<=0.919698602928605803989)  return 2;
-    if(temp<=0.9810118431238461909214) return 3;
-    if(temp<=0.9963401531726562876545) return 4;
-    if(temp<=0.9994058151824183070012) return 5;
-    if(temp<=0.9999167588507119768923) return 6;
-    if(temp<=0.9999897508033253583053) return 7;
-    if(temp<=0.9999988747974020309819) return 8;
-    if(temp<=0.9999998885745216612793) return 9;
-    if(temp<=0.9999999899522336243091) return 10;
-    if(temp<=0.9999999991683892573118) return 11;
-    if(temp<=0.9999999999364022267287) return 12;
-    if(temp<=0.999999999995480147453) return 13;
-    if(temp<=0.9999999999996999989333) return 14;
-    if(temp<=0.9999999999999813223654) return 15;
-    if(temp<=0.9999999999999989050799) return 16;
-    if(temp<=0.9999999999999999393572) return 17;
-    if(temp<=0.999999999999999996817)  return 18;
-    if(temp<=0.9999999999999999998412) return 19;
-    return 20;
-  }
+inline uint32_t weight_gen()//sampling from Poisson with rate 1
+{
+  float temp = frand48();
+  if(temp<=0.3678794411714423215955) return 0;
+  if(temp<=0.735758882342884643191)  return 1;
+  if(temp<=0.919698602928605803989)  return 2;
+  if(temp<=0.9810118431238461909214) return 3;
+  if(temp<=0.9963401531726562876545) return 4;
+  if(temp<=0.9994058151824183070012) return 5;
+  if(temp<=0.9999167588507119768923) return 6;
+  if(temp<=0.9999897508033253583053) return 7;
+  if(temp<=0.9999988747974020309819) return 8;
+  if(temp<=0.9999998885745216612793) return 9;
+  if(temp<=0.9999999899522336243091) return 10;
+  if(temp<=0.9999999991683892573118) return 11;
+  if(temp<=0.9999999999364022267287) return 12;
+  if(temp<=0.999999999995480147453) return 13;
+  if(temp<=0.9999999999996999989333) return 14;
+  if(temp<=0.9999999999999813223654) return 15;
+  if(temp<=0.9999999999999989050799) return 16;
+  if(temp<=0.9999999999999999393572) return 17;
+  if(temp<=0.999999999999999996817)  return 18;
+  if(temp<=0.9999999999999999998412) return 19;
+  return 20;
+}
 }

--- a/vowpalwabbit/cache.cc
+++ b/vowpalwabbit/cache.cc
@@ -11,7 +11,7 @@ const size_t neg_1 = 1;
 const size_t general = 2;
 
 char* run_len_decode(char *p, uint32_t& i)
-{// read an int 7 bits at a time.
+{ // read an int 7 bits at a time.
   size_t count = 0;
   while(*p & 128)\
     i = i | ((*(p++) & 127) << 7*count++);
@@ -19,7 +19,9 @@ char* run_len_decode(char *p, uint32_t& i)
   return p;
 }
 
-inline int32_t ZigZagDecode(uint32_t n) { return (n >> 1) ^ -static_cast<int32_t>(n & 1); }
+inline int32_t ZigZagDecode(uint32_t n) {
+  return (n >> 1) ^ -static_cast<int32_t>(n & 1);
+}
 
 size_t read_cached_tag(io_buf& cache, example* ae)
 {
@@ -28,21 +30,23 @@ size_t read_cached_tag(io_buf& cache, example* ae)
   if (buf_read(cache, c, sizeof(tag_size)) < sizeof(tag_size))
     return 0;
   tag_size = *(size_t*)c;
-  c += sizeof(tag_size);  
+  c += sizeof(tag_size);
   cache.set(c);
-  if (buf_read(cache, c, tag_size) < tag_size) 
+  if (buf_read(cache, c, tag_size) < tag_size)
     return 0;
-  
+
   ae->tag.erase();
   push_many(ae->tag, c, tag_size);
   return tag_size+sizeof(tag_size);
 }
 
-struct one_float { float f; }
+struct one_float {
+  float f;
+}
 #ifndef _WIN32
 __attribute__((packed))
 #endif
-	;
+;
 
 int read_cached_features(void* in, example* ec)
 {
@@ -58,77 +62,77 @@ int read_cached_features(void* in, example* ec)
     return 0;
   char* c;
   unsigned char num_indices = 0;
-  if (buf_read(*input, c, sizeof(num_indices)) < sizeof(num_indices)) 
+  if (buf_read(*input, c, sizeof(num_indices)) < sizeof(num_indices))
     return 0;
   num_indices = *(unsigned char*)c;
   c += sizeof(num_indices);
 
   all->p->input->set(c);
-  for (;num_indices > 0; num_indices--)
-    {
-      size_t temp;
-      unsigned char index = 0;
-      if((temp = buf_read(*input,c,sizeof(index) + sizeof(size_t))) < sizeof(index) + sizeof(size_t)) {
-	cerr << "truncated example! " << temp << " " << char_size + sizeof(size_t) << endl;
-	return 0;
-      }
-
-      index = *(unsigned char*)c;
-      c+= sizeof(index);
-      ae->indices.push_back((size_t)index);
-      v_array<feature>* ours = ae->atomics+index;
-      float* our_sum_feat_sq = ae->sum_feat_sq+index;
-      size_t storage = *(size_t *)c;
-      c += sizeof(size_t);
-      all->p->input->set(c);
-      total += storage; 
-     if (buf_read(*input,c,storage) < storage) {
-	cerr << "truncated example! wanted: " << storage << " bytes" << endl;
-	return 0;
-      }
-
-      char *end = c+storage;
-
-      uint32_t last = 0;
-      
-      for (;c!= end;)
-	{	  
-	  feature f = {1., 0};
-	  c = run_len_decode(c,f.weight_index);
-	  if (f.weight_index & neg_1) 
-	    f.x = -1.;
-	  else if (f.weight_index & general)	    {
-	      f.x = ((one_float *)c)->f;
-	      c += sizeof(float);
-	    }
-	  *our_sum_feat_sq += f.x*f.x;
-          uint32_t diff = f.weight_index >> 2;
-
-          int32_t s_diff = ZigZagDecode(diff);
-	  if (s_diff < 0)
-	    ae->sorted = false;
-	  f.weight_index = last + s_diff;
-	  last = f.weight_index;
-	  ours->push_back(f);
-	}
-      all->p->input->set(c);
+  for (; num_indices > 0; num_indices--)
+  {
+    size_t temp;
+    unsigned char index = 0;
+    if((temp = buf_read(*input,c,sizeof(index) + sizeof(size_t))) < sizeof(index) + sizeof(size_t)) {
+      cerr << "truncated example! " << temp << " " << char_size + sizeof(size_t) << endl;
+      return 0;
     }
+
+    index = *(unsigned char*)c;
+    c+= sizeof(index);
+    ae->indices.push_back((size_t)index);
+    v_array<feature>* ours = ae->atomics+index;
+    float* our_sum_feat_sq = ae->sum_feat_sq+index;
+    size_t storage = *(size_t *)c;
+    c += sizeof(size_t);
+    all->p->input->set(c);
+    total += storage;
+    if (buf_read(*input,c,storage) < storage) {
+      cerr << "truncated example! wanted: " << storage << " bytes" << endl;
+      return 0;
+    }
+
+    char *end = c+storage;
+
+    uint32_t last = 0;
+
+    for (; c!= end;)
+    {
+      feature f = {1., 0};
+      c = run_len_decode(c,f.weight_index);
+      if (f.weight_index & neg_1)
+        f.x = -1.;
+      else if (f.weight_index & general)	    {
+        f.x = ((one_float *)c)->f;
+        c += sizeof(float);
+      }
+      *our_sum_feat_sq += f.x*f.x;
+      uint32_t diff = f.weight_index >> 2;
+
+      int32_t s_diff = ZigZagDecode(diff);
+      if (s_diff < 0)
+        ae->sorted = false;
+      f.weight_index = last + s_diff;
+      last = f.weight_index;
+      ours->push_back(f);
+    }
+    all->p->input->set(c);
+  }
 
   return (int)total;
 }
 
 char* run_len_encode(char *p, size_t i)
-{// store an int 7 bits at a time.
+{ // store an int 7 bits at a time.
   while (i >= 128)
-    {
-      *(p++) = (i & 127) | 128;
-      i = i >> 7;
-    }
+  {
+    *(p++) = (i & 127) | 128;
+    i = i >> 7;
+  }
   *(p++) = (i & 127);
   return p;
 }
 
-inline uint32_t ZigZagEncode(int32_t n) { 
+inline uint32_t ZigZagEncode(int32_t n) {
   uint32_t ret = (n << 1) ^ (n >> 31);
   return ret;
 }
@@ -136,7 +140,7 @@ inline uint32_t ZigZagEncode(int32_t n) {
 void output_byte(io_buf& cache, unsigned char s)
 {
   char *c;
-  
+
   buf_write(cache, c, 1);
   *(c++) = s;
   cache.set(c);
@@ -157,25 +161,25 @@ void output_features(io_buf& cache, unsigned char index, feature* begin, feature
   c += sizeof(size_t);
 
   uint32_t last = 0;
-  
+
   for (feature* i = begin; i != end; i++)
-    {
-      uint32_t cache_index = (i->weight_index) & mask;
-      int32_t s_diff = (cache_index - last);
-      size_t diff = ZigZagEncode(s_diff) << 2;
-      last = cache_index;
-      if (i->x == 1.) 
-	c = run_len_encode(c, diff);
-      else if (i->x == -1.) 
-	c = run_len_encode(c, diff | neg_1);
-      else {
-	c = run_len_encode(c, diff | general);
-	memcpy(c, &i->x, sizeof(i->x));
-	c += sizeof(i->x);
-      }
+  {
+    uint32_t cache_index = (i->weight_index) & mask;
+    int32_t s_diff = (cache_index - last);
+    size_t diff = ZigZagEncode(s_diff) << 2;
+    last = cache_index;
+    if (i->x == 1.)
+      c = run_len_encode(c, diff);
+    else if (i->x == -1.)
+      c = run_len_encode(c, diff | neg_1);
+    else {
+      c = run_len_encode(c, diff | general);
+      memcpy(c, &i->x, sizeof(i->x));
+      c += sizeof(i->x);
     }
+  }
   cache.set(c);
-  *(size_t*)storage_size_loc = c - storage_size_loc - sizeof(size_t);  
+  *(size_t*)storage_size_loc = c - storage_size_loc - sizeof(size_t);
 }
 
 void cache_tag(io_buf& cache, v_array<char> tag)

--- a/vowpalwabbit/cb.cc
+++ b/vowpalwabbit/cb.cc
@@ -14,274 +14,276 @@ using namespace LEARNER;
 
 namespace CB
 {
-  char* bufread_label(CB::label* ld, char* c, io_buf& cache)
+char* bufread_label(CB::label* ld, char* c, io_buf& cache)
+{
+  size_t num = *(size_t *)c;
+  ld->costs.erase();
+  c += sizeof(size_t);
+  size_t total = sizeof(cb_class)*num;
+  if (buf_read(cache, c, total) < total)
   {
-    size_t num = *(size_t *)c;
-    ld->costs.erase();
-    c += sizeof(size_t);
-    size_t total = sizeof(cb_class)*num;
-    if (buf_read(cache, c, total) < total) 
-      {
-        cout << "error in demarshal of cost data" << endl;
-        return c;
-      }
-    for (size_t i = 0; i<num; i++)
-      {
-        cb_class temp = *(cb_class *)c;
-        c += sizeof(cb_class);
-        ld->costs.push_back(temp);
-      }
-  
+    cout << "error in demarshal of cost data" << endl;
     return c;
   }
-
-  size_t read_cached_label(shared_data*, void* v, io_buf& cache)
+  for (size_t i = 0; i<num; i++)
   {
-    CB::label* ld = (CB::label*) v;
-    ld->costs.erase();
-    char *c;
-    size_t total = sizeof(size_t);
-    if (buf_read(cache, c, total) < total) 
-      return 0;
-    c = bufread_label(ld,c, cache);
-  
-    return total;
+    cb_class temp = *(cb_class *)c;
+    c += sizeof(cb_class);
+    ld->costs.push_back(temp);
   }
 
-  float weight(void*)
+  return c;
+}
+
+size_t read_cached_label(shared_data*, void* v, io_buf& cache)
+{
+  CB::label* ld = (CB::label*) v;
+  ld->costs.erase();
+  char *c;
+  size_t total = sizeof(size_t);
+  if (buf_read(cache, c, total) < total)
+    return 0;
+  c = bufread_label(ld,c, cache);
+
+  return total;
+}
+
+float weight(void*)
+{
+  return 1.;
+}
+
+char* bufcache_label(CB::label* ld, char* c)
+{
+  *(size_t *)c = ld->costs.size();
+  c += sizeof(size_t);
+  for (size_t i = 0; i< ld->costs.size(); i++)
   {
-    return 1.;
+    *(cb_class *)c = ld->costs[i];
+    c += sizeof(cb_class);
   }
+  return c;
+}
 
-  char* bufcache_label(CB::label* ld, char* c)
+void cache_label(void* v, io_buf& cache)
+{
+  char *c;
+  CB::label* ld = (CB::label*) v;
+  buf_write(cache, c, sizeof(size_t)+sizeof(cb_class)*ld->costs.size());
+  bufcache_label(ld,c);
+}
+
+void default_label(void* v)
+{
+  CB::label* ld = (CB::label*) v;
+  ld->costs.erase();
+}
+
+void delete_label(void* v)
+{
+  CB::label* ld = (CB::label*)v;
+  ld->costs.delete_v();
+}
+
+void copy_label(void*dst, void*src)
+{
+  CB::label* ldD = (CB::label*)dst;
+  CB::label* ldS = (CB::label*)src;
+  copy_array(ldD->costs, ldS->costs);
+}
+
+bool substring_eq(substring ss, const char* str) {
+  size_t len_ss  = ss.end - ss.begin;
+  size_t len_str = strlen(str);
+  if (len_ss != len_str) return false;
+  return (strncmp(ss.begin, str, len_ss) == 0);
+}
+
+void parse_label(parser* p, shared_data*, void* v, v_array<substring>& words)
+{
+  CB::label* ld = (CB::label*)v;
+
+  for (size_t i = 0; i < words.size(); i++)
   {
-    *(size_t *)c = ld->costs.size();
-    c += sizeof(size_t);
-    for (size_t i = 0; i< ld->costs.size(); i++)
-      {
-        *(cb_class *)c = ld->costs[i];
-        c += sizeof(cb_class);
-      }
-    return c;
-  }
+    cb_class f;
+    tokenize(':', words[i], p->parse_name);
 
-  void cache_label(void* v, io_buf& cache)
+    if( p->parse_name.size() < 1 || p->parse_name.size() > 3 )
+      THROW("malformed cost specification: " << p->parse_name);
+
+    f.partial_prediction = 0.;
+    f.action = (uint32_t)hashstring(p->parse_name[0], 0);
+    f.cost = FLT_MAX;
+
+    if(p->parse_name.size() > 1)
+      f.cost = float_of_substring(p->parse_name[1]);
+
+    if ( nanpattern(f.cost))
+      THROW("error NaN cost (" << p->parse_name[1] << " for action: " << p->parse_name[0]);
+
+    f.probability = .0;
+    if(p->parse_name.size() > 2)
+      f.probability = float_of_substring(p->parse_name[2]);
+
+    if ( nanpattern(f.probability))
+      THROW("error NaN probability (" << p->parse_name[2] << " for action: " << p->parse_name[0]);
+
+    if( f.probability > 1.0 )
+    {
+      cerr << "invalid probability > 1 specified for an action, resetting to 1." << endl;
+      f.probability = 1.0;
+    }
+    if( f.probability < 0.0 )
+    {
+      cerr << "invalid probability < 0 specified for an action, resetting to 0." << endl;
+      f.probability = .0;
+    }
+    if (substring_eq(p->parse_name[0], "shared")) {
+      if (p->parse_name.size() == 1) {
+        f.probability = -1.f;
+      } else
+        cerr << "shared feature vectors should not have costs" << endl;
+    }
+
+    ld->costs.push_back(f);
+  }
+}
+
+label_parser cb_label = {default_label, parse_label,
+                         cache_label, read_cached_label,
+                         delete_label, weight,
+                         copy_label,
+                         sizeof(label)
+                        };
+
+bool example_is_test(example& ec)
+{
+  v_array<CB::cb_class> costs = ec.l.cb.costs;
+  if (costs.size() == 0) return true;
+  for (size_t j=0; j<costs.size(); j++)
+    if (costs[j].cost != FLT_MAX) return false;
+  return true;
+}
+
+bool ec_is_example_header(example& ec)  // example headers look like "0:-1" or just "shared"
+{
+  v_array<CB::cb_class> costs = ec.l.cb.costs;
+  if (costs.size() != 1) return false;
+  if (costs[0].action != 0) return false;
+  if (costs[0].cost >= 0) return false;
+  return true;
+}
+
+void print_update(vw& all, bool is_test, example& ec, const v_array<example*>* ec_seq, bool multilabel)
+{
+  if (all.sd->weighted_examples >= all.sd->dump_interval && !all.quiet && !all.bfgs)
   {
-    char *c;
-    CB::label* ld = (CB::label*) v;
-    buf_write(cache, c, sizeof(size_t)+sizeof(cb_class)*ld->costs.size());
-    bufcache_label(ld,c);
+    size_t num_current_features = ec.num_features;
+    // for csoaa_ldf we want features from the whole (multiline example),
+    // not only from one line (the first one) represented by ec
+    if (ec_seq != nullptr)
+    {
+      num_current_features = 0;
+      // If the first example is "shared", don't include its features.
+      // These should be already included in each example (TODO: including quadratic and cubic).
+      // TODO: code duplication csoaa.cc LabelDict::ec_is_example_header
+      example** ecc=ec_seq->begin;
+      example& first_ex = **ecc;
+
+      v_array<CB::cb_class> costs = first_ex.l.cb.costs;
+      if (costs.size() == 1 && costs[0].action == 0 && costs[0].cost < 0) ecc++;
+
+      for (; ecc!=ec_seq->end; ecc++)
+        num_current_features += (*ecc)->num_features;
+    }
+
+    std::string label_buf;
+    if (is_test)
+      label_buf = " unknown";
+    else
+      label_buf = " known";
+
+    if (multilabel) {
+      std::ostringstream pred_buf;
+      pred_buf << std::setw(all.sd->col_current_predict) << std::right << std::setfill(' ')
+               << ec.pred.multilabels.label_v[0]<<".....";
+      all.sd->print_update(all.holdout_set_off, all.current_pass, label_buf, pred_buf.str(),
+                           num_current_features, all.progress_add, all.progress_arg);;
+    }
+    else
+      all.sd->print_update(all.holdout_set_off, all.current_pass, label_buf, ec.pred.multiclass,
+                           num_current_features, all.progress_add, all.progress_arg);
   }
-
-  void default_label(void* v)
-  {
-    CB::label* ld = (CB::label*) v;
-    ld->costs.erase();
-  }
-
-  void delete_label(void* v)
-  {
-    CB::label* ld = (CB::label*)v;
-    ld->costs.delete_v();
-  }
-
-  void copy_label(void*dst, void*src)
-  {
-    CB::label* ldD = (CB::label*)dst;
-    CB::label* ldS = (CB::label*)src;
-    copy_array(ldD->costs, ldS->costs);
-  }
-
-  bool substring_eq(substring ss, const char* str) {
-    size_t len_ss  = ss.end - ss.begin;
-    size_t len_str = strlen(str);
-    if (len_ss != len_str) return false;
-    return (strncmp(ss.begin, str, len_ss) == 0);
-  }
-
-  void parse_label(parser* p, shared_data*, void* v, v_array<substring>& words)
-  {
-    CB::label* ld = (CB::label*)v;
-
-    for (size_t i = 0; i < words.size(); i++)
-      {
-        cb_class f;
-	tokenize(':', words[i], p->parse_name);
-
-        if( p->parse_name.size() < 1 || p->parse_name.size() > 3 )
-	  THROW("malformed cost specification: " << p->parse_name);
-
-        f.partial_prediction = 0.;
-        f.action = (uint32_t)hashstring(p->parse_name[0], 0);
-        f.cost = FLT_MAX;
-
-	if(p->parse_name.size() > 1)
-	  f.cost = float_of_substring(p->parse_name[1]);
-	
-        if ( nanpattern(f.cost))
-	  THROW("error NaN cost (" << p->parse_name[1] << " for action: " << p->parse_name[0]);
-
-        f.probability = .0;
-        if(p->parse_name.size() > 2)
-          f.probability = float_of_substring(p->parse_name[2]);
-	
-        if ( nanpattern(f.probability))
-	  THROW("error NaN probability (" << p->parse_name[2] << " for action: " << p->parse_name[0]);
-        
-        if( f.probability > 1.0 )
-        {
-          cerr << "invalid probability > 1 specified for an action, resetting to 1." << endl;
-          f.probability = 1.0;
-        }
-        if( f.probability < 0.0 )
-	  {
-	    cerr << "invalid probability < 0 specified for an action, resetting to 0." << endl;
-	    f.probability = .0;
-	  }
-	if (substring_eq(p->parse_name[0], "shared")) {
-          if (p->parse_name.size() == 1) {
-            f.probability = -1.f;
-          } else
-            cerr << "shared feature vectors should not have costs" << endl;
-	}
-	
-        ld->costs.push_back(f);
-      }
-  }
-
-  label_parser cb_label = {default_label, parse_label, 
-				  cache_label, read_cached_label, 
-				  delete_label, weight, 
-				  copy_label,
-				  sizeof(label)};
-
-  bool example_is_test(example& ec)
-  {
-    v_array<CB::cb_class> costs = ec.l.cb.costs;
-    if (costs.size() == 0) return true;
-    for (size_t j=0; j<costs.size(); j++)
-      if (costs[j].cost != FLT_MAX) return false;
-    return true;    
-  }
-
-  bool ec_is_example_header(example& ec)  // example headers look like "0:-1" or just "shared"
-  {
-    v_array<CB::cb_class> costs = ec.l.cb.costs;
-    if (costs.size() != 1) return false;
-    if (costs[0].action != 0) return false;
-    if (costs[0].cost >= 0) return false;
-    return true;    
-  }
-
-  void print_update(vw& all, bool is_test, example& ec, const v_array<example*>* ec_seq, bool multilabel)
-  {
-    if (all.sd->weighted_examples >= all.sd->dump_interval && !all.quiet && !all.bfgs)
-      {
-	size_t num_current_features = ec.num_features;
-	// for csoaa_ldf we want features from the whole (multiline example),
-        // not only from one line (the first one) represented by ec
-        if (ec_seq != nullptr)
-	  {
-	    num_current_features = 0;
-          // If the first example is "shared", don't include its features.
-          // These should be already included in each example (TODO: including quadratic and cubic).
-          // TODO: code duplication csoaa.cc LabelDict::ec_is_example_header
-	    example** ecc=ec_seq->begin;
-	    example& first_ex = **ecc;
-	    
-	    v_array<CB::cb_class> costs = first_ex.l.cb.costs;
-	    if (costs.size() == 1 && costs[0].action == 0 && costs[0].cost < 0) ecc++;
-	    
-	    for (; ecc!=ec_seq->end; ecc++)
-	      num_current_features += (*ecc)->num_features;
-	  }
-	
-	std::string label_buf;
-        if (is_test)
-          label_buf = " unknown";
-        else
-          label_buf = " known";
-	
-	if (multilabel) {
-	  std::ostringstream pred_buf;
-	  pred_buf << std::setw(all.sd->col_current_predict) << std::right << std::setfill(' ')
-		   << ec.pred.multilabels.label_v[0]<<".....";			
-	  all.sd->print_update(all.holdout_set_off, all.current_pass, label_buf, pred_buf.str(), 
-			       num_current_features, all.progress_add, all.progress_arg);;
-	}
-	else
-	  all.sd->print_update(all.holdout_set_off, all.current_pass, label_buf, ec.pred.multiclass, 
-			     num_current_features, all.progress_add, all.progress_arg);
-      }
-  }
+}
 }
 
 namespace CB_EVAL
 {
-  size_t read_cached_label(shared_data*sd, void* v, io_buf& cache)
-  {
-    CB_EVAL::label* ld = (CB_EVAL::label*) v;
-    char* c;
-    size_t total = sizeof(uint32_t);
-    if (buf_read(cache, c, total) < total) 
-      return 0;
-    ld->action = *(uint32_t*)c;
-    c += sizeof(uint32_t);
-    
-    return total + CB::read_cached_label(sd, &(ld->event), cache);
-  }
+size_t read_cached_label(shared_data*sd, void* v, io_buf& cache)
+{
+  CB_EVAL::label* ld = (CB_EVAL::label*) v;
+  char* c;
+  size_t total = sizeof(uint32_t);
+  if (buf_read(cache, c, total) < total)
+    return 0;
+  ld->action = *(uint32_t*)c;
+  c += sizeof(uint32_t);
 
-  void cache_label(void* v, io_buf& cache)
-  {
-    char *c;
-    CB_EVAL::label* ld = (CB_EVAL::label*) v;
-    buf_write(cache, c, sizeof(uint32_t));
-    *(uint32_t *)c = ld->action;
-    c+= sizeof(uint32_t);
-    
-    CB::cache_label(&(ld->event), cache);
-  }
+  return total + CB::read_cached_label(sd, &(ld->event), cache);
+}
 
-  void default_label(void* v)
-  {
-    CB_EVAL::label* ld = (CB_EVAL::label*) v;
-    CB::default_label(&(ld->event));
-    ld->action = 0;
-  }
+void cache_label(void* v, io_buf& cache)
+{
+  char *c;
+  CB_EVAL::label* ld = (CB_EVAL::label*) v;
+  buf_write(cache, c, sizeof(uint32_t));
+  *(uint32_t *)c = ld->action;
+  c+= sizeof(uint32_t);
 
-  void delete_label(void* v)
-  {
-    CB_EVAL::label* ld = (CB_EVAL::label*)v;
-    CB::delete_label(&(ld->event));
-  }
+  CB::cache_label(&(ld->event), cache);
+}
 
-  void copy_label(void*dst, void*src)
-  {
-    CB_EVAL::label* ldD = (CB_EVAL::label*)dst;
-    CB_EVAL::label* ldS = (CB_EVAL::label*)src;
-    CB::copy_label(&(ldD->event), &(ldS)->event);
-    ldD->action = ldS->action;
-  }
+void default_label(void* v)
+{
+  CB_EVAL::label* ld = (CB_EVAL::label*) v;
+  CB::default_label(&(ld->event));
+  ld->action = 0;
+}
 
-  void parse_label(parser* p, shared_data* sd, void* v, v_array<substring>& words)
-  {
-    CB_EVAL::label* ld = (CB_EVAL::label*)v;
-    
-    if (words.size() < 2)
-      THROW("Evaluation can not happen without an action and an exploration");
-    
-    ld->action = (uint32_t)hashstring(words[0], 0);    
-    
-    words.begin++;
-    
-    CB::parse_label(p, sd, &(ld->event), words);
-    
-    words.begin--;
-  }
+void delete_label(void* v)
+{
+  CB_EVAL::label* ld = (CB_EVAL::label*)v;
+  CB::delete_label(&(ld->event));
+}
 
-  label_parser cb_eval = {default_label, parse_label, 
-			  cache_label, read_cached_label, 
-			  delete_label, CB::weight, 
-			  copy_label,
-			  sizeof(CB_EVAL::label)};
+void copy_label(void*dst, void*src)
+{
+  CB_EVAL::label* ldD = (CB_EVAL::label*)dst;
+  CB_EVAL::label* ldS = (CB_EVAL::label*)src;
+  CB::copy_label(&(ldD->event), &(ldS)->event);
+  ldD->action = ldS->action;
+}
+
+void parse_label(parser* p, shared_data* sd, void* v, v_array<substring>& words)
+{
+  CB_EVAL::label* ld = (CB_EVAL::label*)v;
+
+  if (words.size() < 2)
+    THROW("Evaluation can not happen without an action and an exploration");
+
+  ld->action = (uint32_t)hashstring(words[0], 0);
+
+  words.begin++;
+
+  CB::parse_label(p, sd, &(ld->event), words);
+
+  words.begin--;
+}
+
+label_parser cb_eval = {default_label, parse_label,
+                        cache_label, read_cached_label,
+                        delete_label, CB::weight,
+                        copy_label,
+                        sizeof(CB_EVAL::label)
+                       };
 }

--- a/vowpalwabbit/cb.h
+++ b/vowpalwabbit/cb.h
@@ -8,30 +8,32 @@ license as described in the file LICENSE.
 #include "label_parser.h"
 
 namespace CB {
-  struct cb_class {
-    float cost;  // the cost of this class
-    uint32_t action;  // the index of this class
-    float probability; //new for bandit setting, specifies the probability the data collection policy chose this class for importance weighting
-    float partial_prediction;//essentially a return value
-    bool operator==(cb_class j){return action == j.action;}
-  };
+struct cb_class {
+  float cost;  // the cost of this class
+  uint32_t action;  // the index of this class
+  float probability; //new for bandit setting, specifies the probability the data collection policy chose this class for importance weighting
+  float partial_prediction;//essentially a return value
+  bool operator==(cb_class j) {
+    return action == j.action;
+  }
+};
 
-  struct label {
-    v_array<cb_class> costs;
-  };
+struct label {
+  v_array<cb_class> costs;
+};
 
-  extern label_parser cb_label;//for learning
-  bool example_is_test(example& ec);
-  bool ec_is_example_header(example& ec);  // example headers look like "0:-1" or just "shared"
+extern label_parser cb_label;//for learning
+bool example_is_test(example& ec);
+bool ec_is_example_header(example& ec);  // example headers look like "0:-1" or just "shared"
 
-  void print_update(vw& all, bool is_test, example& ec, const v_array<example*>* ec_seq, bool multilabel);
+void print_update(vw& all, bool is_test, example& ec, const v_array<example*>* ec_seq, bool multilabel);
 }
 
 namespace CB_EVAL {
-  struct label {
-    uint32_t action;
-    CB::label event;
-  };
+struct label {
+  uint32_t action;
+  CB::label event;
+};
 
-  extern label_parser cb_eval;//for evaluation of an arbitrary policy.
+extern label_parser cb_eval;//for evaluation of an arbitrary policy.
 }

--- a/vowpalwabbit/cb_adf.cc
+++ b/vowpalwabbit/cb_adf.cc
@@ -41,430 +41,430 @@ struct cb_adf {
 
 namespace CB_ADF {
 
-  bool has_shared_example(v_array<example*> examples) {
-    if (examples[0]->l.cb.costs.size() > 0 && examples[0]->l.cb.costs[0].probability == -1.f)
-      return true;
-    return false;
+bool has_shared_example(v_array<example*> examples) {
+  if (examples[0]->l.cb.costs.size() > 0 && examples[0]->l.cb.costs[0].probability == -1.f)
+    return true;
+  return false;
+}
+
+void gen_cs_example_ips(v_array<example*> examples, v_array<COST_SENSITIVE::label>& cs_labels)
+{
+  if (cs_labels.size() < examples.size()) {
+    cs_labels.resize(examples.size(), true);
+    cs_labels.end = cs_labels.end_array;
   }
-
-  void gen_cs_example_ips(v_array<example*> examples, v_array<COST_SENSITIVE::label>& cs_labels)
+  for (size_t i = 0; i < examples.size(); i++)
   {
-    if (cs_labels.size() < examples.size()) {
-      cs_labels.resize(examples.size(), true);
-      cs_labels.end = cs_labels.end_array;
-    }
-    for (size_t i = 0; i < examples.size(); i++)
-      {
-	CB::label ld = examples[i]->l.cb;
+    CB::label ld = examples[i]->l.cb;
 
-	COST_SENSITIVE::wclass wc;
-	wc.class_index = 0;
-	if ( ld.costs.size() == 1 && ld.costs[0].cost != FLT_MAX)  
-	  wc.x = ld.costs[0].cost / ld.costs[0].probability;
-	else 
-	  wc.x = 0.f;
-	cs_labels[i].costs.erase();
-	cs_labels[i].costs.push_back(wc);
-      }
-    cs_labels[examples.size()-1].costs[0].x = FLT_MAX; //trigger end of multiline example.
-
-    if (has_shared_example(examples))//take care of shared examples
-      {
-	cs_labels[0].costs[0].class_index = 0;
-	cs_labels[0].costs[0].x = -FLT_MAX;
-      }
-  }
-  
-  template <bool is_learn>
-  void gen_cs_example_dr(cb_adf& c, v_array<example*> examples, v_array<COST_SENSITIVE::label>& cs_labels)
-  {
-    //size_t mysize = examples.size();
-    if (cs_labels.size() < examples.size()) {
-      cs_labels.resize(examples.size(), true);
-      cs_labels.end = cs_labels.end_array;		
-    }
-
-    c.pred_scores.costs.erase();
-    bool shared = false;
-    if(has_shared_example(examples))
-      shared = true;
-
-    int startK = 0;
-    if(shared) startK = 1;
-
-    for (size_t i = 0; i < examples.size(); i++)
-      {
-	examples[i]->l.cb.costs.erase();
-	if(example_is_newline(*examples[i])) continue;
-	//CB::label ld = examples[i]->l.cb;		
-
-	COST_SENSITIVE::wclass wc;
-	wc.class_index = 0;	
-	
-	if(c.known_cost.action + startK == i) {
-	  int known_index = c.known_cost.action;
-	  c.known_cost.action = 0;
-	  //get cost prediction for this label
-	  // num_actions should be 1 effectively.
-	  // my get_cost_pred function will use 1 for 'index-1+base'			
-	  wc.x = CB_ALGS::get_cost_pred<is_learn>(c.scorer, &(c.known_cost), *(examples[i]), 0, 2);
-	  c.known_cost.action = known_index;
-	}
-	else {
-	  wc.x = CB_ALGS::get_cost_pred<is_learn>(c.scorer, nullptr, *(examples[i]), 0, 2);
-	}
-
-	if(shared)
-	  wc.class_index = i-1;
-	else
-	  wc.class_index = i;
-	c.pred_scores.costs.push_back(wc); // done
-	wc.class_index = 0;
-
-	//add correction if we observed cost for this action and regressor is wrong
-	if (c.known_cost.probability != -1 && c.known_cost.action + startK == i)
-	  {			
-	    wc.x += (c.known_cost.cost - wc.x) / c.known_cost.probability;
-	  }
-
-	//cout<<"Action "<<c.known_cost.action<<" Cost "<<c.known_cost.cost<<" Probability "<<c.known_cost.probability<<endl;
-	
-	//cout<<"Prediction = "<<wc.x<<" ";
-	cs_labels[i].costs.erase();
-	cs_labels[i].costs.push_back(wc);
-      }
     COST_SENSITIVE::wclass wc;
     wc.class_index = 0;
-    wc.x = FLT_MAX;
-    cs_labels[examples.size()-1].costs.erase();
-    cs_labels[examples.size()-1].costs.push_back(wc); //trigger end of multiline example.
-
-    if (shared)//take care of shared examples
-      {
-	cs_labels[0].costs[0].class_index = 0;
-	cs_labels[0].costs[0].x = -FLT_MAX;
-      }
-
-    //cout<<endl;
-
-  }
-
-  void get_observed_cost(cb_adf& mydata, v_array<example*>& examples)
-  {
-    CB::label ld;
-    int index = -1;
-
-    for (example **ec = examples.begin; ec != examples.end; ec++)
-      {
-	if ((**ec).l.cb.costs.size() == 1 &&
-	    (**ec).l.cb.costs[0].cost != FLT_MAX &&
-	    (**ec).l.cb.costs[0].probability > 0)
-	  {
-	    ld = (**ec).l.cb;
-	    index = ec - examples.begin;
-	  }
-      }
-
-  
-    // handle -1 case.
-    if (index == -1){
-      mydata.known_cost.probability = -1;
-      return;
-      //std::cerr << "None of the examples has known cost. Exiting." << endl;
-      //throw exception();
-    }
-
-    bool shared = false;
-    if (has_shared_example(examples))
-      shared = true;
-  
-    for (CB::cb_class *cl = ld.costs.begin; cl != ld.costs.end; cl++)
-      {
-	mydata.known_cost = ld.costs[0];
-	mydata.known_cost.action = index;
-      
-	// take care of shared example
-	if(shared)
-	  mydata.known_cost.action--;	
-      }
-  }
-
-  template<bool is_learn>
-  void call_predict_or_learn(cb_adf& mydata, base_learner& base, v_array<example*> examples)
-  {
-    // m2: still save, store, and restore
-    // starting with 3 for loops
-    // first of all, clear the container mydata.array.
-    mydata.cb_labels.erase();
-  
-    // 1st: save cb_label (into mydata) and store cs_label for each example, which will be passed into base.learn.
-    size_t index = 0;
-    for (example **ec = examples.begin; ec != examples.end; ec++)
-      {
-	mydata.cb_labels.push_back((**ec).l.cb);
-	(**ec).l.cs = mydata.cs_labels[index++]; 
-      }
-  
-    // 2nd: predict for each ex
-    // // call base.predict for each vw exmaple in the sequence
-    for (example **ec = examples.begin; ec != examples.end; ec++) {
-      //cout<<"Number of features = "<<(**ec).num_features<<" label = "<<(**ec).l.cs.costs[0].x<<" "<<example_is_newline(**ec)<<endl;
-      if (is_learn)
-	base.learn(**ec);
-      else
-	base.predict(**ec);
-    }
-
-    //cout<<"Prediction size = "<<(**examples.begin).pred.multilabels.label_v.size()<<endl;
-  
-    // 3rd: restore cb_label for each example
-    // (**ec).l.cb = mydata.array.element.
-    size_t i = 0;
-    for (example **ec = examples.begin; ec != examples.end; ec++)
-      (**ec).l.cb = mydata.cb_labels[i++];
-  }
-
-  template<uint32_t reduction_type>
-  void learn(cb_adf& mydata, base_learner& base, v_array<example*>& examples)
-  {
-	if(reduction_type == CB_TYPE_IPS)
-      gen_cs_example_ips(examples, mydata.cs_labels);
-    else if (reduction_type == CB_TYPE_DR)
-      gen_cs_example_dr<true>(mydata, examples, mydata.cs_labels);
+    if ( ld.costs.size() == 1 && ld.costs[0].cost != FLT_MAX)
+      wc.x = ld.costs[0].cost / ld.costs[0].probability;
     else
-      THROW("Unknown cb_type specified for contextual bandit learning: " << mydata.cb_type);
-	
-    call_predict_or_learn<true>(mydata,base,examples);
+      wc.x = 0.f;
+    cs_labels[i].costs.erase();
+    cs_labels[i].costs.push_back(wc);
+  }
+  cs_labels[examples.size()-1].costs[0].x = FLT_MAX; //trigger end of multiline example.
+
+  if (has_shared_example(examples))//take care of shared examples
+  {
+    cs_labels[0].costs[0].class_index = 0;
+    cs_labels[0].costs[0].x = -FLT_MAX;
+  }
+}
+
+template <bool is_learn>
+void gen_cs_example_dr(cb_adf& c, v_array<example*> examples, v_array<COST_SENSITIVE::label>& cs_labels)
+{
+  //size_t mysize = examples.size();
+  if (cs_labels.size() < examples.size()) {
+    cs_labels.resize(examples.size(), true);
+    cs_labels.end = cs_labels.end_array;
   }
 
-  bool test_adf_sequence(cb_adf& data)
+  c.pred_scores.costs.erase();
+  bool shared = false;
+  if(has_shared_example(examples))
+    shared = true;
+
+  int startK = 0;
+  if(shared) startK = 1;
+
+  for (size_t i = 0; i < examples.size(); i++)
   {
-    uint32_t count = 0;
-    for (size_t k=0; k<data.ec_seq.size(); k++) {
-      example *ec = data.ec_seq[k];
-    
-      if (ec->l.cb.costs.size() > 1)
-	THROW("cb_adf: badly formatted example, only one cost can be known.");
-    
-      if (ec->l.cb.costs.size() == 1 && ec->l.cb.costs[0].cost != FLT_MAX)      
-	count += 1;
-      
-      if (CB::ec_is_example_header(*ec))
-	THROW("warning: example headers at position " << k << ": can only have in initial position!");
+    examples[i]->l.cb.costs.erase();
+    if(example_is_newline(*examples[i])) continue;
+    //CB::label ld = examples[i]->l.cb;
+
+    COST_SENSITIVE::wclass wc;
+    wc.class_index = 0;
+
+    if(c.known_cost.action + startK == i) {
+      int known_index = c.known_cost.action;
+      c.known_cost.action = 0;
+      //get cost prediction for this label
+      // num_actions should be 1 effectively.
+      // my get_cost_pred function will use 1 for 'index-1+base'
+      wc.x = CB_ALGS::get_cost_pred<is_learn>(c.scorer, &(c.known_cost), *(examples[i]), 0, 2);
+      c.known_cost.action = known_index;
     }
-    if (count == 0)
-      return true;
-    else if (count == 1)
-      return false;
+    else {
+      wc.x = CB_ALGS::get_cost_pred<is_learn>(c.scorer, nullptr, *(examples[i]), 0, 2);
+    }
+
+    if(shared)
+      wc.class_index = i-1;
     else
-      THROW("cb_adf: badly formatted example, only one line can have a cost");
+      wc.class_index = i;
+    c.pred_scores.costs.push_back(wc); // done
+    wc.class_index = 0;
+
+    //add correction if we observed cost for this action and regressor is wrong
+    if (c.known_cost.probability != -1 && c.known_cost.action + startK == i)
+    {
+      wc.x += (c.known_cost.cost - wc.x) / c.known_cost.probability;
+    }
+
+    //cout<<"Action "<<c.known_cost.action<<" Cost "<<c.known_cost.cost<<" Probability "<<c.known_cost.probability<<endl;
+
+    //cout<<"Prediction = "<<wc.x<<" ";
+    cs_labels[i].costs.erase();
+    cs_labels[i].costs.push_back(wc);
+  }
+  COST_SENSITIVE::wclass wc;
+  wc.class_index = 0;
+  wc.x = FLT_MAX;
+  cs_labels[examples.size()-1].costs.erase();
+  cs_labels[examples.size()-1].costs.push_back(wc); //trigger end of multiline example.
+
+  if (shared)//take care of shared examples
+  {
+    cs_labels[0].costs[0].class_index = 0;
+    cs_labels[0].costs[0].x = -FLT_MAX;
   }
 
-  template <bool is_learn>
-  void do_actual_learning(cb_adf& data, base_learner& base)
+  //cout<<endl;
+
+}
+
+void get_observed_cost(cb_adf& mydata, v_array<example*>& examples)
+{
+  CB::label ld;
+  int index = -1;
+
+  for (example **ec = examples.begin; ec != examples.end; ec++)
   {
-    bool isTest = test_adf_sequence(data);
-    get_observed_cost(data, data.ec_seq);
-  
-    if (isTest || !is_learn)
-      {
-	gen_cs_example_ips(data.ec_seq, data.cs_labels);//create test labels.
-	call_predict_or_learn<false>(data, base, data.ec_seq);
-      }
+    if ((**ec).l.cb.costs.size() == 1 &&
+        (**ec).l.cb.costs[0].cost != FLT_MAX &&
+        (**ec).l.cb.costs[0].probability > 0)
+    {
+      ld = (**ec).l.cb;
+      index = ec - examples.begin;
+    }
+  }
+
+
+  // handle -1 case.
+  if (index == -1) {
+    mydata.known_cost.probability = -1;
+    return;
+    //std::cerr << "None of the examples has known cost. Exiting." << endl;
+    //throw exception();
+  }
+
+  bool shared = false;
+  if (has_shared_example(examples))
+    shared = true;
+
+  for (CB::cb_class *cl = ld.costs.begin; cl != ld.costs.end; cl++)
+  {
+    mydata.known_cost = ld.costs[0];
+    mydata.known_cost.action = index;
+
+    // take care of shared example
+    if(shared)
+      mydata.known_cost.action--;
+  }
+}
+
+template<bool is_learn>
+void call_predict_or_learn(cb_adf& mydata, base_learner& base, v_array<example*> examples)
+{
+  // m2: still save, store, and restore
+  // starting with 3 for loops
+  // first of all, clear the container mydata.array.
+  mydata.cb_labels.erase();
+
+  // 1st: save cb_label (into mydata) and store cs_label for each example, which will be passed into base.learn.
+  size_t index = 0;
+  for (example **ec = examples.begin; ec != examples.end; ec++)
+  {
+    mydata.cb_labels.push_back((**ec).l.cb);
+    (**ec).l.cs = mydata.cs_labels[index++];
+  }
+
+  // 2nd: predict for each ex
+  // // call base.predict for each vw exmaple in the sequence
+  for (example **ec = examples.begin; ec != examples.end; ec++) {
+    //cout<<"Number of features = "<<(**ec).num_features<<" label = "<<(**ec).l.cs.costs[0].x<<" "<<example_is_newline(**ec)<<endl;
+    if (is_learn)
+      base.learn(**ec);
     else
-      {
-	if (data.cb_type == CB_TYPE_IPS)
-	  {
-	    learn<CB_TYPE_IPS>(data, base, data.ec_seq);
-	  }
-	else if (data.cb_type == CB_TYPE_DR)
-	  {
-	    learn<CB_TYPE_DR>(data, base, data.ec_seq);
-	  }
-	else
-	  THROW("Unknown cb_type specified for contextual bandit learning: " << data.cb_type);
-      }
+      base.predict(**ec);
   }
 
-  void global_print_newline(vw& all)
-  {
-    char temp[1];
-    temp[0] = '\n';
-    for (size_t i=0; i<all.final_prediction_sink.size(); i++) {
-      int f = all.final_prediction_sink[i];
-      ssize_t t;
-      t = io_buf::write_file_or_socket(f, temp, 1);
-      if (t != 1)
-	cerr << "write error: " << strerror(errno) << endl;
-    }
+  //cout<<"Prediction size = "<<(**examples.begin).pred.multilabels.label_v.size()<<endl;
+
+  // 3rd: restore cb_label for each example
+  // (**ec).l.cb = mydata.array.element.
+  size_t i = 0;
+  for (example **ec = examples.begin; ec != examples.end; ec++)
+    (**ec).l.cb = mydata.cb_labels[i++];
+}
+
+template<uint32_t reduction_type>
+void learn(cb_adf& mydata, base_learner& base, v_array<example*>& examples)
+{
+  if(reduction_type == CB_TYPE_IPS)
+    gen_cs_example_ips(examples, mydata.cs_labels);
+  else if (reduction_type == CB_TYPE_DR)
+    gen_cs_example_dr<true>(mydata, examples, mydata.cs_labels);
+  else
+    THROW("Unknown cb_type specified for contextual bandit learning: " << mydata.cb_type);
+
+  call_predict_or_learn<true>(mydata,base,examples);
+}
+
+bool test_adf_sequence(cb_adf& data)
+{
+  uint32_t count = 0;
+  for (size_t k=0; k<data.ec_seq.size(); k++) {
+    example *ec = data.ec_seq[k];
+
+    if (ec->l.cb.costs.size() > 1)
+      THROW("cb_adf: badly formatted example, only one cost can be known.");
+
+    if (ec->l.cb.costs.size() == 1 && ec->l.cb.costs[0].cost != FLT_MAX)
+      count += 1;
+
+    if (CB::ec_is_example_header(*ec))
+      THROW("warning: example headers at position " << k << ": can only have in initial position!");
   }
+  if (count == 0)
+    return true;
+  else if (count == 1)
+    return false;
+  else
+    THROW("cb_adf: badly formatted example, only one line can have a cost");
+}
 
-  // how to 
+template <bool is_learn>
+void do_actual_learning(cb_adf& data, base_learner& base)
+{
+  bool isTest = test_adf_sequence(data);
+  get_observed_cost(data, data.ec_seq);
 
-  void output_example(vw& all, cb_adf& c, example& ec, v_array<example*>* ec_seq)
+  if (isTest || !is_learn)
   {
-    v_array<CB::cb_class> costs = ec.l.cb.costs;
-    
-    if (example_is_newline(ec)) return;
-    if (CB::ec_is_example_header(ec)) return;
-
-    all.sd->total_features += ec.num_features;
-
-    float loss = 0.;
-
-    if (!CB::example_is_test(ec)) {
-      loss = get_unbiased_cost(&(c.known_cost), c.pred_scores, ec.pred.multiclass);
-      all.sd->sum_loss += loss;
-      all.sd->sum_loss_since_last_dump += loss;
-    }
-  
-    for (int* sink = all.final_prediction_sink.begin; sink != all.final_prediction_sink.end; sink++)
-      all.print(*sink, (float)ec.pred.multiclass, 0, ec.tag);
-
-    if (all.raw_prediction > 0) {
-      string outputString;
-      stringstream outputStringStream(outputString);
-      for (size_t i = 0; i < costs.size(); i++) {
-	if (i > 0) outputStringStream << ' ';
-	outputStringStream << costs[i].action << ':' << costs[i].partial_prediction;
-      }
-      //outputStringStream << endl;
-      all.print_text(all.raw_prediction, outputStringStream.str(), ec.tag);
-    }
-    
-    CB::print_update(all, CB::example_is_test(ec), ec, ec_seq, false);
+    gen_cs_example_ips(data.ec_seq, data.cs_labels);//create test labels.
+    call_predict_or_learn<false>(data, base, data.ec_seq);
   }
-
-  void output_rank_example(vw& all, cb_adf& c, example& head_ec, v_array<example*>* ec_seq)
+  else
   {
-    label& ld = head_ec.l.cb;
-    v_array<CB::cb_class> costs = ld.costs;
-  
-    if (example_is_newline(head_ec)) return;
-  
-    all.sd->total_features += head_ec.num_features;
-  
-    float loss = 0.;
-    v_array<uint32_t> preds = head_ec.pred.multilabels.label_v;
-    bool is_test = false;
-    //cout<<"Preds size = "<<preds.size()<<endl;
-    
-    if (c.known_cost.probability > 0) {
-      //c.pred_scores.costs.erase();
-      loss = get_unbiased_cost(&(c.known_cost), c.pred_scores, preds[0]);
-      all.sd->sum_loss += loss;
-      all.sd->sum_loss_since_last_dump += loss;
+    if (data.cb_type == CB_TYPE_IPS)
+    {
+      learn<CB_TYPE_IPS>(data, base, data.ec_seq);
+    }
+    else if (data.cb_type == CB_TYPE_DR)
+    {
+      learn<CB_TYPE_DR>(data, base, data.ec_seq);
     }
     else
-      is_test = true;
-      
-  
-    //for (int i = 0; i < preds.size();i++)
-    for (int* sink = all.final_prediction_sink.begin; sink != all.final_prediction_sink.end; sink++)
-      MULTILABEL::print_multilabel(*sink, head_ec.pred.multilabels, head_ec.tag);
-  
-    if (all.raw_prediction > 0) {
-      string outputString;
-      stringstream outputStringStream(outputString);
-      for (size_t i = 0; i < costs.size(); i++) {
-	if (i > 0) outputStringStream << ' ';
-	outputStringStream << costs[i].action << ':' << costs[i].partial_prediction;
-      }
-      all.print_text(all.raw_prediction, outputStringStream.str(), head_ec.tag);
-    }
-  
-    CB::print_update(all, is_test, head_ec, ec_seq, true);
+      THROW("Unknown cb_type specified for contextual bandit learning: " << data.cb_type);
+  }
+}
+
+void global_print_newline(vw& all)
+{
+  char temp[1];
+  temp[0] = '\n';
+  for (size_t i=0; i<all.final_prediction_sink.size(); i++) {
+    int f = all.final_prediction_sink[i];
+    ssize_t t;
+    t = io_buf::write_file_or_socket(f, temp, 1);
+    if (t != 1)
+      cerr << "write error: " << strerror(errno) << endl;
+  }
+}
+
+// how to
+
+void output_example(vw& all, cb_adf& c, example& ec, v_array<example*>* ec_seq)
+{
+  v_array<CB::cb_class> costs = ec.l.cb.costs;
+
+  if (example_is_newline(ec)) return;
+  if (CB::ec_is_example_header(ec)) return;
+
+  all.sd->total_features += ec.num_features;
+
+  float loss = 0.;
+
+  if (!CB::example_is_test(ec)) {
+    loss = get_unbiased_cost(&(c.known_cost), c.pred_scores, ec.pred.multiclass);
+    all.sd->sum_loss += loss;
+    all.sd->sum_loss_since_last_dump += loss;
   }
 
-  void output_example_seq(vw& all, cb_adf& data)
-  {
-    if (data.ec_seq.size() > 0) {
-      all.sd->weighted_examples += 1;
-      all.sd->example_number++;
-      
-      //bool hit_loss = false;
+  for (int* sink = all.final_prediction_sink.begin; sink != all.final_prediction_sink.end; sink++)
+    all.print(*sink, (float)ec.pred.multiclass, 0, ec.tag);
 
-      if (data.rank_all)
-	output_rank_example(all, data, **(data.ec_seq.begin), &(data.ec_seq));
-      else
-	{
-	  for (example** ecc=data.ec_seq.begin; ecc!=data.ec_seq.end; ecc++)
-	    output_example(all, data, **ecc, &(data.ec_seq));
-	
-	  if (all.raw_prediction > 0)
-	    all.print_text(all.raw_prediction, "", data.ec_seq[0]->tag);
-	}
+  if (all.raw_prediction > 0) {
+    string outputString;
+    stringstream outputStringStream(outputString);
+    for (size_t i = 0; i < costs.size(); i++) {
+      if (i > 0) outputStringStream << ' ';
+      outputStringStream << costs[i].action << ':' << costs[i].partial_prediction;
     }
+    //outputStringStream << endl;
+    all.print_text(all.raw_prediction, outputStringStream.str(), ec.tag);
   }
 
-  void clear_seq_and_finish_examples(vw& all, cb_adf& data)
-  {
-    if (data.ec_seq.size() > 0) 
+  CB::print_update(all, CB::example_is_test(ec), ec, ec_seq, false);
+}
+
+void output_rank_example(vw& all, cb_adf& c, example& head_ec, v_array<example*>* ec_seq)
+{
+  label& ld = head_ec.l.cb;
+  v_array<CB::cb_class> costs = ld.costs;
+
+  if (example_is_newline(head_ec)) return;
+
+  all.sd->total_features += head_ec.num_features;
+
+  float loss = 0.;
+  v_array<uint32_t> preds = head_ec.pred.multilabels.label_v;
+  bool is_test = false;
+  //cout<<"Preds size = "<<preds.size()<<endl;
+
+  if (c.known_cost.probability > 0) {
+    //c.pred_scores.costs.erase();
+    loss = get_unbiased_cost(&(c.known_cost), c.pred_scores, preds[0]);
+    all.sd->sum_loss += loss;
+    all.sd->sum_loss_since_last_dump += loss;
+  }
+  else
+    is_test = true;
+
+
+  //for (int i = 0; i < preds.size();i++)
+  for (int* sink = all.final_prediction_sink.begin; sink != all.final_prediction_sink.end; sink++)
+    MULTILABEL::print_multilabel(*sink, head_ec.pred.multilabels, head_ec.tag);
+
+  if (all.raw_prediction > 0) {
+    string outputString;
+    stringstream outputStringStream(outputString);
+    for (size_t i = 0; i < costs.size(); i++) {
+      if (i > 0) outputStringStream << ' ';
+      outputStringStream << costs[i].action << ':' << costs[i].partial_prediction;
+    }
+    all.print_text(all.raw_prediction, outputStringStream.str(), head_ec.tag);
+  }
+
+  CB::print_update(all, is_test, head_ec, ec_seq, true);
+}
+
+void output_example_seq(vw& all, cb_adf& data)
+{
+  if (data.ec_seq.size() > 0) {
+    all.sd->weighted_examples += 1;
+    all.sd->example_number++;
+
+    //bool hit_loss = false;
+
+    if (data.rank_all)
+      output_rank_example(all, data, **(data.ec_seq.begin), &(data.ec_seq));
+    else
+    {
       for (example** ecc=data.ec_seq.begin; ecc!=data.ec_seq.end; ecc++)
-	if ((*ecc)->in_use)
-	  VW::finish_example(all, *ecc);
+        output_example(all, data, **ecc, &(data.ec_seq));
+
+      if (all.raw_prediction > 0)
+        all.print_text(all.raw_prediction, "", data.ec_seq[0]->tag);
+    }
+  }
+}
+
+void clear_seq_and_finish_examples(vw& all, cb_adf& data)
+{
+  if (data.ec_seq.size() > 0)
+    for (example** ecc=data.ec_seq.begin; ecc!=data.ec_seq.end; ecc++)
+      if ((*ecc)->in_use)
+        VW::finish_example(all, *ecc);
+  data.ec_seq.erase();
+}
+
+void finish_multiline_example(vw& all, cb_adf& data, example& ec)
+{
+  if (data.need_to_clear) {
+    if (data.ec_seq.size() > 0) {
+      output_example_seq(all, data);
+      global_print_newline(all);
+    }
+    clear_seq_and_finish_examples(all, data);
+    data.need_to_clear = false;
+    if (ec.in_use) VW::finish_example(all, &ec);
+  }
+}
+
+void end_examples(cb_adf& data)
+{
+  if (data.need_to_clear)
     data.ec_seq.erase();
-  }
+}
 
-  void finish_multiline_example(vw& all, cb_adf& data, example& ec)
-  {
-    if (data.need_to_clear) {
-      if (data.ec_seq.size() > 0) {
-	output_example_seq(all, data);
-	global_print_newline(all);
-      }        
-      clear_seq_and_finish_examples(all, data);
-      data.need_to_clear = false;
-      if (ec.in_use) VW::finish_example(all, &ec);
-    }
-  }
 
-  void end_examples(cb_adf& data)
-  {
-    if (data.need_to_clear)
+void finish(cb_adf& data)
+{
+  data.ec_seq.delete_v();
+  data.cb_labels.delete_v();
+  for(size_t i = 0; i < data.cs_labels.size(); i++)
+    data.cs_labels[i].costs.delete_v();
+  data.cs_labels.delete_v();
+  data.pred_scores.costs.delete_v();
+}
+
+template <bool is_learn>
+void predict_or_learn(cb_adf& data, base_learner& base, example &ec) {
+  vw* all = data.all;
+  data.base = &base;
+  bool is_test_ec = CB::example_is_test(ec);
+  bool need_to_break = data.ec_seq.size() >= all->p->ring_size - 2;
+
+  if ((example_is_newline(ec) && is_test_ec) || need_to_break) {
+    data.ec_seq.push_back(&ec);
+    do_actual_learning<is_learn>(data, base);
+    data.need_to_clear = true;
+  } else {
+    if (data.need_to_clear) {  // should only happen if we're NOT driving
       data.ec_seq.erase();
-  }
-
-
-  void finish(cb_adf& data)
-  {
-    data.ec_seq.delete_v();
-    data.cb_labels.delete_v();
-    for(size_t i = 0; i < data.cs_labels.size(); i++)
-      data.cs_labels[i].costs.delete_v();
-    data.cs_labels.delete_v();
-    data.pred_scores.costs.delete_v();
-  }
-
-  template <bool is_learn>
-  void predict_or_learn(cb_adf& data, base_learner& base, example &ec) {
-    vw* all = data.all;
-    data.base = &base;
-    bool is_test_ec = CB::example_is_test(ec);
-    bool need_to_break = data.ec_seq.size() >= all->p->ring_size - 2;
-
-    if ((example_is_newline(ec) && is_test_ec) || need_to_break) {
-      data.ec_seq.push_back(&ec);
-      do_actual_learning<is_learn>(data, base);
-      data.need_to_clear = true;
-    } else {
-      if (data.need_to_clear) {  // should only happen if we're NOT driving
-	data.ec_seq.erase();
-	data.need_to_clear = false;
-      }
-      data.ec_seq.push_back(&ec);
+      data.need_to_clear = false;
     }
+    data.ec_seq.push_back(&ec);
   }
+}
 }
 
 base_learner* cb_adf_setup(vw& all)
 {
   if (missing_option(all, true, "cb_adf", "Do Contextual Bandit learning with multiline action dependent features."))
     return nullptr;
-  new_options(all, "ADF Options")		
-    ("rank_all", "Return actions sorted by score order")
-    ("cb_type", po::value<string>(), "contextual bandit method to use in {ips,dm,dr}");
-  add_options(all);		
+  new_options(all, "ADF Options")
+  ("rank_all", "Return actions sorted by score order")
+  ("cb_type", po::value<string>(), "contextual bandit method to use in {ips,dm,dr}");
+  add_options(all);
 
   cb_adf& ld = calloc_or_die<cb_adf>();
 
@@ -472,26 +472,26 @@ base_learner* cb_adf_setup(vw& all)
 
   size_t problem_multiplier = 1;//default for IPS
   if (all.vm.count("cb_type"))
-    {
-      std::string type_string;
+  {
+    std::string type_string;
 
-      type_string = all.vm["cb_type"].as<std::string>();
-      *all.file_options << " --cb_type " << type_string;
+    type_string = all.vm["cb_type"].as<std::string>();
+    *all.file_options << " --cb_type " << type_string;
 
-      if (type_string.compare("dr") == 0) {
-	ld.cb_type = CB_TYPE_DR;
-	problem_multiplier = 2;
-      }
-      else if (type_string.compare("ips") == 0)
-	{
-	  ld.cb_type = CB_TYPE_IPS;
-	  problem_multiplier = 1;
-	}
-      else {
-	std::cerr << "warning: cb_type must be in {'ips','dr'}; resetting to ips." << std::endl;
-	ld.cb_type = CB_TYPE_IPS;
-      }
+    if (type_string.compare("dr") == 0) {
+      ld.cb_type = CB_TYPE_DR;
+      problem_multiplier = 2;
     }
+    else if (type_string.compare("ips") == 0)
+    {
+      ld.cb_type = CB_TYPE_IPS;
+      problem_multiplier = 1;
+    }
+    else {
+      std::cerr << "warning: cb_type must be in {'ips','dr'}; resetting to ips." << std::endl;
+      ld.cb_type = CB_TYPE_IPS;
+    }
+  }
   else {
     //by default use ips
     ld.cb_type = CB_TYPE_IPS;
@@ -499,31 +499,31 @@ base_learner* cb_adf_setup(vw& all)
   }
 
   if (all.vm.count("rank_all"))
-    {
-      ld.rank_all = true;
-      all.multilabel_prediction = true;
-      *all.file_options << " --rank_all";
-    }
+  {
+    ld.rank_all = true;
+    all.multilabel_prediction = true;
+    *all.file_options << " --rank_all";
+  }
 
   // Push necessary flags.
   if ( (count(all.args.begin(), all.args.end(), "--csoaa_ldf") == 0 && count(all.args.begin(), all.args.end(), "--wap_ldf") == 0)
        || all.vm.count("rank_all"))
-    {
-      if (count(all.args.begin(), all.args.end(), "--csoaa_ldf") == 0)
-	all.args.push_back("--csoaa_ldf");
-      if (count(all.args.begin(), all.args.end(), "multiline") == 0)
-	all.args.push_back("multiline");
-      if (ld.rank_all && count(all.args.begin(), all.args.end(), "--csoaa_rank") == 0)
-	all.args.push_back("--csoaa_rank");
-    }	
-	
+  {
+    if (count(all.args.begin(), all.args.end(), "--csoaa_ldf") == 0)
+      all.args.push_back("--csoaa_ldf");
+    if (count(all.args.begin(), all.args.end(), "multiline") == 0)
+      all.args.push_back("multiline");
+    if (ld.rank_all && count(all.args.begin(), all.args.end(), "--csoaa_rank") == 0)
+      all.args.push_back("--csoaa_rank");
+  }
+
   base_learner* base = setup_base(all);
   all.p->lp = CB::cb_label;
 
   learner<cb_adf>& l = init_learner(&ld, base, CB_ADF::predict_or_learn<true>, CB_ADF::predict_or_learn<false>, problem_multiplier);
   l.set_finish_example(CB_ADF::finish_multiline_example);
 
-  l.increment = base->increment; 
+  l.increment = base->increment;
   ld.scorer = all.scorer;
 
   l.set_finish(CB_ADF::finish);

--- a/vowpalwabbit/cb_algs.cc
+++ b/vowpalwabbit/cb_algs.cc
@@ -28,429 +28,432 @@ struct cb {
   size_t nb_ex_regressors;
   float last_pred_reg;
   float last_correct_cost;
-  
+
   cb_class* known_cost;
 };
-  
-  bool know_all_cost_example(CB::label& ld)
-  {
-    if (ld.costs.size() <= 1) //this means we specified an example where all actions are possible but only specified the cost for the observed action
+
+bool know_all_cost_example(CB::label& ld)
+{
+  if (ld.costs.size() <= 1) //this means we specified an example where all actions are possible but only specified the cost for the observed action
+    return false;
+
+  //if we specified more than 1 action for this example, i.e. either we have a limited set of possible actions, or all actions are specified
+  //than check if all actions have a specified cost
+  for (cb_class* cl = ld.costs.begin; cl != ld.costs.end; cl++)
+    if (cl->cost == FLT_MAX)
       return false;
 
-    //if we specified more than 1 action for this example, i.e. either we have a limited set of possible actions, or all actions are specified
-    //than check if all actions have a specified cost
-    for (cb_class* cl = ld.costs.begin; cl != ld.costs.end; cl++)
-      if (cl->cost == FLT_MAX)
-        return false;
+  return true;
+}
 
+bool is_test_label(CB::label& ld)
+{
+  if (ld.costs.size() == 0)
     return true;
-  }
+  for (size_t i=0; i<ld.costs.size(); i++)
+    if (FLT_MAX != ld.costs[i].cost && ld.costs[i].probability > 0.)
+      return false;
+  return true;
+}
 
-  bool is_test_label(CB::label& ld)
-  {
-    if (ld.costs.size() == 0)
-      return true;
-    for (size_t i=0; i<ld.costs.size(); i++)
-      if (FLT_MAX != ld.costs[i].cost && ld.costs[i].probability > 0.)
-        return false;
-    return true;
-  }
-  
-  inline bool observed_cost(cb_class* cl)
-  {
-    //cost observed for this action if it has non zero probability and cost != FLT_MAX
-    return (cl != nullptr && cl->cost != FLT_MAX && cl->probability > .0);
-  }
-  
-  cb_class* get_observed_cost(CB::label& ld)
-  {
-    for (cb_class *cl = ld.costs.begin; cl != ld.costs.end; cl++)
-      if( observed_cost(cl) ) 
-        return cl;
-    return nullptr;
-  }
+inline bool observed_cost(cb_class* cl)
+{
+  //cost observed for this action if it has non zero probability and cost != FLT_MAX
+  return (cl != nullptr && cl->cost != FLT_MAX && cl->probability > .0);
+}
 
-  void gen_cs_example_ips(cb& c, CB::label& ld, COST_SENSITIVE::label& cs_ld)
-  {//this implements the inverse propensity score method, where cost are importance weighted by the probability of the chosen action
-    //generate cost-sensitive example
-    cs_ld.costs.erase();
-    if( ld.costs.size() == 1) { //this is a typical example where we can perform all actions
-      //in this case generate cost-sensitive example with all actions
-      for(uint32_t i = 1; i <= c.num_actions; i++)
-      {
-        COST_SENSITIVE::wclass wc;
-        wc.wap_value = 0.;
-        wc.x = 0.;
-        wc.class_index = i;
-        wc.partial_prediction = 0.;
-        wc.wap_value = 0.;
-        if( c.known_cost != nullptr && i == c.known_cost->action )
-        {
-          wc.x = c.known_cost->cost / c.known_cost->probability; //use importance weighted cost for observed action, 0 otherwise 
-          //ips can be thought as the doubly robust method with a fixed regressor that predicts 0 costs for everything
-          //update the loss of this regressor 
-          c.nb_ex_regressors++;
-          c.avg_loss_regressors += (1.0f/c.nb_ex_regressors)*( (c.known_cost->cost)*(c.known_cost->cost) - c.avg_loss_regressors );
-          c.last_pred_reg = 0;
-          c.last_correct_cost = c.known_cost->cost;
-        }
+cb_class* get_observed_cost(CB::label& ld)
+{
+  for (cb_class *cl = ld.costs.begin; cl != ld.costs.end; cl++)
+    if( observed_cost(cl) )
+      return cl;
+  return nullptr;
+}
 
-        cs_ld.costs.push_back(wc );
-      }
-    }
-    else { //this is an example where we can only perform a subset of the actions
-      //in this case generate cost-sensitive example with only allowed actions
-      for( cb_class* cl = ld.costs.begin; cl != ld.costs.end; cl++ )
-      {
-        COST_SENSITIVE::wclass wc;
-        wc.wap_value = 0.;
-        wc.x = 0.;
-        wc.class_index = cl->action;
-        wc.partial_prediction = 0.;
-        wc.wap_value = 0.;
-        if( c.known_cost != nullptr && cl->action == c.known_cost->action )
-        {
-          wc.x = c.known_cost->cost / c.known_cost->probability; //use importance weighted cost for observed action, 0 otherwise 
-
-          //ips can be thought as the doubly robust method with a fixed regressor that predicts 0 costs for everything
-          //update the loss of this regressor 
-          c.nb_ex_regressors++;
-          c.avg_loss_regressors += (1.0f/c.nb_ex_regressors)*( (c.known_cost->cost)*(c.known_cost->cost) - c.avg_loss_regressors );
-          c.last_pred_reg = 0;
-          c.last_correct_cost = c.known_cost->cost;
-        }
-
-        cs_ld.costs.push_back( wc );
-      }
-    }
-
-  }
-
-  template <bool is_learn>
-  void gen_cs_example_dm(cb& c, example& ec, COST_SENSITIVE::label& cs_ld)
-  {
-    //this implements the direct estimation method, where costs are directly specified by the learned regressor.
-    CB::label ld = ec.l.cb;
-
-    float min = FLT_MAX;
-    uint32_t argmin = 1;
-    //generate cost sensitive example
-    cs_ld.costs.erase();  
-    c.pred_scores.costs.erase();
-
-    if( ld.costs.size() == 1) { //this is a typical example where we can perform all actions
-      //in this case generate cost-sensitive example with all actions  
-      for(uint32_t i = 1; i <= c.num_actions; i++)
-      {
-        COST_SENSITIVE::wclass wc;
-        wc.wap_value = 0.;
-      
-        //get cost prediction for this action
-        wc.x = CB_ALGS::get_cost_pred<is_learn>(c.scorer, c.known_cost, ec, i, 0);
-	if (wc.x < min)
-	  {
-	    min = wc.x;
-	    argmin = i;
-	  }
-
-        wc.class_index = i;
-        wc.partial_prediction = 0.;
-        wc.wap_value = 0.;
-
-	c.pred_scores.costs.push_back(wc);
-
-        if( c.known_cost != nullptr && c.known_cost->action == i ) {
-          c.nb_ex_regressors++;
-          c.avg_loss_regressors += (1.0f/c.nb_ex_regressors)*( (c.known_cost->cost - wc.x)*(c.known_cost->cost - wc.x) - c.avg_loss_regressors );
-          c.last_pred_reg = wc.x;
-          c.last_correct_cost = c.known_cost->cost;
-        }
-
-        cs_ld.costs.push_back( wc );	
-      }
-    }
-    else { //this is an example where we can only perform a subset of the actions
-      //in this case generate cost-sensitive example with only allowed actions
-      for( cb_class* cl = ld.costs.begin; cl != ld.costs.end; cl++ )
-      {
-        COST_SENSITIVE::wclass wc;
-        wc.wap_value = 0.;
-      
-        //get cost prediction for this action
-        wc.x = CB_ALGS::get_cost_pred<is_learn>(c.scorer, c.known_cost, ec, cl->action, 0);
-	if (wc.x < min || (wc.x == min && cl->action < argmin))
-	  {
-	    min = wc.x;
-	    argmin = cl->action;
-	  }
-
-        wc.class_index = cl->action;
-        wc.partial_prediction = 0.;
-        wc.wap_value = 0.;
-	
-	c.pred_scores.costs.push_back(wc);
-
-        if( c.known_cost != nullptr && c.known_cost->action == cl->action ) {
-          c.nb_ex_regressors++;
-          c.avg_loss_regressors += (1.0f/c.nb_ex_regressors)*( (c.known_cost->cost - wc.x)*(c.known_cost->cost - wc.x) - c.avg_loss_regressors );
-          c.last_pred_reg = wc.x;
-          c.last_correct_cost = c.known_cost->cost;
-        }
-
-        cs_ld.costs.push_back( wc );
-      }
-    }
-    
-    ec.pred.multiclass = argmin;
-  }
-
-  template <bool is_learn>
-  void gen_cs_label(cb& c, example& ec, COST_SENSITIVE::label& cs_ld, uint32_t label)
-  {
-    COST_SENSITIVE::wclass wc;
-    wc.wap_value = 0.;
-    
-    //get cost prediction for this label
-    wc.x = CB_ALGS::get_cost_pred<is_learn>(c.scorer, c.known_cost, ec, label, c.num_actions);
-    wc.class_index = label;
-    wc.partial_prediction = 0.;
-    wc.wap_value = 0.;
-
-    c.pred_scores.costs.push_back(wc);
-    
-    //add correction if we observed cost for this action and regressor is wrong
-    if( c.known_cost != nullptr && c.known_cost->action == label ) {
-      c.nb_ex_regressors++;
-      c.avg_loss_regressors += (1.0f/c.nb_ex_regressors)*( (c.known_cost->cost - wc.x)*(c.known_cost->cost - wc.x) - c.avg_loss_regressors );
-      c.last_pred_reg = wc.x;
-      c.last_correct_cost = c.known_cost->cost;
-      wc.x += (c.known_cost->cost - wc.x) / c.known_cost->probability;      
-    }
-    //cout<<"Prediction = "<<wc.x<<" ";
-    cs_ld.costs.push_back( wc );
-    
-  }
-
-  template <bool is_learn>
-  void gen_cs_example_dr(cb& c, example& ec, CB::label& ld, COST_SENSITIVE::label& cs_ld)
-  {//this implements the doubly robust method
-    cs_ld.costs.erase();
-    c.pred_scores.costs.erase();
-    if(ld.costs.size() == 0)//a test example
-      for(uint32_t i = 1; i <= c.num_actions; i++)
-	{//Explicit declaration for a weak compiler.
-	  COST_SENSITIVE::wclass c = {FLT_MAX, i, 0., 0.};
-	  cs_ld.costs.push_back(c);
-	}
-    else if( ld.costs.size() == 1) //this is a typical example where we can perform all actions
-      //in this case generate cost-sensitive example with all actions
-      for(uint32_t i = 1; i <= c.num_actions; i++)
-	gen_cs_label<is_learn>(c, ec, cs_ld, i);
-    else  //this is an example where we can only perform a subset of the actions
-      //in this case generate cost-sensitive example with only allowed actions
-      for( cb_class* cl = ld.costs.begin; cl != ld.costs.end; cl++ )
-	gen_cs_label<is_learn>(c, ec, cs_ld, cl->action);
-    //cout<<endl;
-  }
-
-  template <bool is_learn>
-  void predict_or_learn(cb& c, base_learner& base, example& ec) {
-    CB::label ld = ec.l.cb;
-
-    c.known_cost = get_observed_cost(ld);
-    if (c.known_cost != nullptr && (c.known_cost->action < 1 || c.known_cost->action > c.num_actions))
-      cerr << "invalid action: " << c.known_cost->action << endl;
-    //generate a cost-sensitive example to update classifiers
-    switch(c.cb_type)
+void gen_cs_example_ips(cb& c, CB::label& ld, COST_SENSITIVE::label& cs_ld)
+{ //this implements the inverse propensity score method, where cost are importance weighted by the probability of the chosen action
+  //generate cost-sensitive example
+  cs_ld.costs.erase();
+  if( ld.costs.size() == 1) { //this is a typical example where we can perform all actions
+    //in this case generate cost-sensitive example with all actions
+    for(uint32_t i = 1; i <= c.num_actions; i++)
     {
-      case CB_TYPE_IPS:
-        gen_cs_example_ips(c,ld,c.cb_cs_ld);
-        break;
-      case CB_TYPE_DM:
-        gen_cs_example_dm<is_learn>(c,ec,c.cb_cs_ld);
-        break;
-      case CB_TYPE_DR:
-        gen_cs_example_dr<is_learn>(c,ec,ld,c.cb_cs_ld);
-        break;
-      default:
-        THROW("Unknown cb_type specified for contextual bandit learning: " << c.cb_type);
-    }
-
-    if (c.cb_type != CB_TYPE_DM)
+      COST_SENSITIVE::wclass wc;
+      wc.wap_value = 0.;
+      wc.x = 0.;
+      wc.class_index = i;
+      wc.partial_prediction = 0.;
+      wc.wap_value = 0.;
+      if( c.known_cost != nullptr && i == c.known_cost->action )
       {
-	ec.l.cs = c.cb_cs_ld;
-
-	if (is_learn)
-	  base.learn(ec);
-	else
-	  base.predict(ec);
-	
-        for (size_t i=0; i<ld.costs.size(); i++)
-          ld.costs[i].partial_prediction = c.cb_cs_ld.costs[i].partial_prediction;
-	ec.l.cb = ld;
+        wc.x = c.known_cost->cost / c.known_cost->probability; //use importance weighted cost for observed action, 0 otherwise
+        //ips can be thought as the doubly robust method with a fixed regressor that predicts 0 costs for everything
+        //update the loss of this regressor
+        c.nb_ex_regressors++;
+        c.avg_loss_regressors += (1.0f/c.nb_ex_regressors)*( (c.known_cost->cost)*(c.known_cost->cost) - c.avg_loss_regressors );
+        c.last_pred_reg = 0;
+        c.last_correct_cost = c.known_cost->cost;
       }
+
+      cs_ld.costs.push_back(wc );
+    }
   }
+  else { //this is an example where we can only perform a subset of the actions
+    //in this case generate cost-sensitive example with only allowed actions
+    for( cb_class* cl = ld.costs.begin; cl != ld.costs.end; cl++ )
+    {
+      COST_SENSITIVE::wclass wc;
+      wc.wap_value = 0.;
+      wc.x = 0.;
+      wc.class_index = cl->action;
+      wc.partial_prediction = 0.;
+      wc.wap_value = 0.;
+      if( c.known_cost != nullptr && cl->action == c.known_cost->action )
+      {
+        wc.x = c.known_cost->cost / c.known_cost->probability; //use importance weighted cost for observed action, 0 otherwise
+
+        //ips can be thought as the doubly robust method with a fixed regressor that predicts 0 costs for everything
+        //update the loss of this regressor
+        c.nb_ex_regressors++;
+        c.avg_loss_regressors += (1.0f/c.nb_ex_regressors)*( (c.known_cost->cost)*(c.known_cost->cost) - c.avg_loss_regressors );
+        c.last_pred_reg = 0;
+        c.last_correct_cost = c.known_cost->cost;
+      }
+
+      cs_ld.costs.push_back( wc );
+    }
+  }
+
+}
+
+template <bool is_learn>
+void gen_cs_example_dm(cb& c, example& ec, COST_SENSITIVE::label& cs_ld)
+{
+  //this implements the direct estimation method, where costs are directly specified by the learned regressor.
+  CB::label ld = ec.l.cb;
+
+  float min = FLT_MAX;
+  uint32_t argmin = 1;
+  //generate cost sensitive example
+  cs_ld.costs.erase();
+  c.pred_scores.costs.erase();
+
+  if( ld.costs.size() == 1) { //this is a typical example where we can perform all actions
+    //in this case generate cost-sensitive example with all actions
+    for(uint32_t i = 1; i <= c.num_actions; i++)
+    {
+      COST_SENSITIVE::wclass wc;
+      wc.wap_value = 0.;
+
+      //get cost prediction for this action
+      wc.x = CB_ALGS::get_cost_pred<is_learn>(c.scorer, c.known_cost, ec, i, 0);
+      if (wc.x < min)
+      {
+        min = wc.x;
+        argmin = i;
+      }
+
+      wc.class_index = i;
+      wc.partial_prediction = 0.;
+      wc.wap_value = 0.;
+
+      c.pred_scores.costs.push_back(wc);
+
+      if( c.known_cost != nullptr && c.known_cost->action == i ) {
+        c.nb_ex_regressors++;
+        c.avg_loss_regressors += (1.0f/c.nb_ex_regressors)*( (c.known_cost->cost - wc.x)*(c.known_cost->cost - wc.x) - c.avg_loss_regressors );
+        c.last_pred_reg = wc.x;
+        c.last_correct_cost = c.known_cost->cost;
+      }
+
+      cs_ld.costs.push_back( wc );
+    }
+  }
+  else { //this is an example where we can only perform a subset of the actions
+    //in this case generate cost-sensitive example with only allowed actions
+    for( cb_class* cl = ld.costs.begin; cl != ld.costs.end; cl++ )
+    {
+      COST_SENSITIVE::wclass wc;
+      wc.wap_value = 0.;
+
+      //get cost prediction for this action
+      wc.x = CB_ALGS::get_cost_pred<is_learn>(c.scorer, c.known_cost, ec, cl->action, 0);
+      if (wc.x < min || (wc.x == min && cl->action < argmin))
+      {
+        min = wc.x;
+        argmin = cl->action;
+      }
+
+      wc.class_index = cl->action;
+      wc.partial_prediction = 0.;
+      wc.wap_value = 0.;
+
+      c.pred_scores.costs.push_back(wc);
+
+      if( c.known_cost != nullptr && c.known_cost->action == cl->action ) {
+        c.nb_ex_regressors++;
+        c.avg_loss_regressors += (1.0f/c.nb_ex_regressors)*( (c.known_cost->cost - wc.x)*(c.known_cost->cost - wc.x) - c.avg_loss_regressors );
+        c.last_pred_reg = wc.x;
+        c.last_correct_cost = c.known_cost->cost;
+      }
+
+      cs_ld.costs.push_back( wc );
+    }
+  }
+
+  ec.pred.multiclass = argmin;
+}
+
+template <bool is_learn>
+void gen_cs_label(cb& c, example& ec, COST_SENSITIVE::label& cs_ld, uint32_t label)
+{
+  COST_SENSITIVE::wclass wc;
+  wc.wap_value = 0.;
+
+  //get cost prediction for this label
+  wc.x = CB_ALGS::get_cost_pred<is_learn>(c.scorer, c.known_cost, ec, label, c.num_actions);
+  wc.class_index = label;
+  wc.partial_prediction = 0.;
+  wc.wap_value = 0.;
+
+  c.pred_scores.costs.push_back(wc);
+
+  //add correction if we observed cost for this action and regressor is wrong
+  if( c.known_cost != nullptr && c.known_cost->action == label ) {
+    c.nb_ex_regressors++;
+    c.avg_loss_regressors += (1.0f/c.nb_ex_regressors)*( (c.known_cost->cost - wc.x)*(c.known_cost->cost - wc.x) - c.avg_loss_regressors );
+    c.last_pred_reg = wc.x;
+    c.last_correct_cost = c.known_cost->cost;
+    wc.x += (c.known_cost->cost - wc.x) / c.known_cost->probability;
+  }
+  //cout<<"Prediction = "<<wc.x<<" ";
+  cs_ld.costs.push_back( wc );
+
+}
+
+template <bool is_learn>
+void gen_cs_example_dr(cb& c, example& ec, CB::label& ld, COST_SENSITIVE::label& cs_ld)
+{ //this implements the doubly robust method
+  cs_ld.costs.erase();
+  c.pred_scores.costs.erase();
+  if(ld.costs.size() == 0)//a test example
+    for(uint32_t i = 1; i <= c.num_actions; i++)
+    { //Explicit declaration for a weak compiler.
+      COST_SENSITIVE::wclass c = {FLT_MAX, i, 0., 0.};
+      cs_ld.costs.push_back(c);
+    }
+  else if( ld.costs.size() == 1) //this is a typical example where we can perform all actions
+    //in this case generate cost-sensitive example with all actions
+    for(uint32_t i = 1; i <= c.num_actions; i++)
+      gen_cs_label<is_learn>(c, ec, cs_ld, i);
+  else  //this is an example where we can only perform a subset of the actions
+    //in this case generate cost-sensitive example with only allowed actions
+    for( cb_class* cl = ld.costs.begin; cl != ld.costs.end; cl++ )
+      gen_cs_label<is_learn>(c, ec, cs_ld, cl->action);
+  //cout<<endl;
+}
+
+template <bool is_learn>
+void predict_or_learn(cb& c, base_learner& base, example& ec) {
+  CB::label ld = ec.l.cb;
+
+  c.known_cost = get_observed_cost(ld);
+  if (c.known_cost != nullptr && (c.known_cost->action < 1 || c.known_cost->action > c.num_actions))
+    cerr << "invalid action: " << c.known_cost->action << endl;
+  //generate a cost-sensitive example to update classifiers
+  switch(c.cb_type)
+  {
+  case CB_TYPE_IPS:
+    gen_cs_example_ips(c,ld,c.cb_cs_ld);
+    break;
+  case CB_TYPE_DM:
+    gen_cs_example_dm<is_learn>(c,ec,c.cb_cs_ld);
+    break;
+  case CB_TYPE_DR:
+    gen_cs_example_dr<is_learn>(c,ec,ld,c.cb_cs_ld);
+    break;
+  default:
+    THROW("Unknown cb_type specified for contextual bandit learning: " << c.cb_type);
+  }
+
+  if (c.cb_type != CB_TYPE_DM)
+  {
+    ec.l.cs = c.cb_cs_ld;
+
+    if (is_learn)
+      base.learn(ec);
+    else
+      base.predict(ec);
+
+    for (size_t i=0; i<ld.costs.size(); i++)
+      ld.costs[i].partial_prediction = c.cb_cs_ld.costs[i].partial_prediction;
+    ec.l.cb = ld;
+  }
+}
 
 void predict_eval(cb&, base_learner&, example&) {
   THROW("can not use a test label for evaluation");
 }
 
-  void learn_eval(cb& c, base_learner&, example& ec) {
-    CB_EVAL::label ld = ec.l.cb_eval;
-    
-    c.known_cost = get_observed_cost(ld.event);
-    
-    if (c.cb_type == CB_TYPE_DR)
-      gen_cs_example_dr<true>(c, ec, ld.event, c.cb_cs_ld);
-    else //c.cb_type == CB_TYPE_IPS
-      gen_cs_example_ips(c, ld.event, c.cb_cs_ld);
-    
-    for (size_t i=0; i<ld.event.costs.size(); i++)
-      ld.event.costs[i].partial_prediction = c.cb_cs_ld.costs[i].partial_prediction;
+void learn_eval(cb& c, base_learner&, example& ec) {
+  CB_EVAL::label ld = ec.l.cb_eval;
 
-    ec.pred.multiclass = ec.l.cb_eval.action;
-  }
+  c.known_cost = get_observed_cost(ld.event);
+
+  if (c.cb_type == CB_TYPE_DR)
+    gen_cs_example_dr<true>(c, ec, ld.event, c.cb_cs_ld);
+  else //c.cb_type == CB_TYPE_IPS
+    gen_cs_example_ips(c, ld.event, c.cb_cs_ld);
+
+  for (size_t i=0; i<ld.event.costs.size(); i++)
+    ld.event.costs[i].partial_prediction = c.cb_cs_ld.costs[i].partial_prediction;
+
+  ec.pred.multiclass = ec.l.cb_eval.action;
+}
 
 float get_unbiased_cost(CB::cb_class* known_cost, COST_SENSITIVE::label& scores, uint32_t action) {
   float loss = 0.;
-  
+
   //cout<<scores.costs.size()<<endl;
 
-  for (COST_SENSITIVE::wclass *cl = scores.costs.begin; cl != scores.costs.end; cl++) 
+  for (COST_SENSITIVE::wclass *cl = scores.costs.begin; cl != scores.costs.end; cl++)
     if (cl->class_index == action)
-	loss = cl->x;
+      loss = cl->x;
 
-  if (known_cost->action == action) 
+  if (known_cost->action == action)
     loss += (known_cost->cost - loss) / known_cost->probability;
 
   //cout<<"loss = "<<loss<<endl;
 
   //if (chosen_loss == FLT_MAX)
   //cerr << "warning: cb predicted an invalid class" << endl;
-  
+
   return loss;
 }
-  
-  void output_example(vw& all, cb& c, example& ec, CB::label& ld)
-  {
-    float loss = 0.;
-    if(!is_test_label(ld))
-      loss = get_unbiased_cost(c.known_cost, c.pred_scores, ec.pred.multiclass);    
 
-    all.sd->update(ec.test_only, loss, 1.f, ec.num_features);
+void output_example(vw& all, cb& c, example& ec, CB::label& ld)
+{
+  float loss = 0.;
+  if(!is_test_label(ld))
+    loss = get_unbiased_cost(c.known_cost, c.pred_scores, ec.pred.multiclass);
 
-    for (int* sink = all.final_prediction_sink.begin; sink != all.final_prediction_sink.end; sink++)
-      all.print(*sink, (float)ec.pred.multiclass, 0, ec.tag);
+  all.sd->update(ec.test_only, loss, 1.f, ec.num_features);
 
-    if (all.raw_prediction > 0) {
-      stringstream outputStringStream;
-      for (unsigned int i = 0; i < ld.costs.size(); i++) {
-    	  cb_class cl = ld.costs[i];
-        if (i > 0) outputStringStream << ' ';
-        outputStringStream <<  cl.action <<':' << cl.partial_prediction;
-      }
-      all.print_text(all.raw_prediction, outputStringStream.str(), ec.tag);
+  for (int* sink = all.final_prediction_sink.begin; sink != all.final_prediction_sink.end; sink++)
+    all.print(*sink, (float)ec.pred.multiclass, 0, ec.tag);
+
+  if (all.raw_prediction > 0) {
+    stringstream outputStringStream;
+    for (unsigned int i = 0; i < ld.costs.size(); i++) {
+      cb_class cl = ld.costs[i];
+      if (i > 0) outputStringStream << ' ';
+      outputStringStream <<  cl.action <<':' << cl.partial_prediction;
     }
-
-    print_update(all, is_test_label(ld), ec, nullptr, false);
+    all.print_text(all.raw_prediction, outputStringStream.str(), ec.tag);
   }
 
-  void finish(cb& c)
-  { c.cb_cs_ld.costs.delete_v(); c.pred_scores.costs.delete_v();}
+  print_update(all, is_test_label(ld), ec, nullptr, false);
+}
 
-  void finish_example(vw& all, cb& c, example& ec)
+void finish(cb& c)
+{
+  c.cb_cs_ld.costs.delete_v();
+  c.pred_scores.costs.delete_v();
+}
+
+void finish_example(vw& all, cb& c, example& ec)
+{
+  output_example(all, c, ec, ec.l.cb);
+  VW::finish_example(all, &ec);
+}
+
+void eval_finish_example(vw& all, cb& c, example& ec)
+{
+  output_example(all, c, ec, ec.l.cb_eval.event);
+  VW::finish_example(all, &ec);
+}
+
+base_learner* cb_algs_setup(vw& all)
+{
+  if (missing_option<size_t, true>(all, "cb", "Use contextual bandit learning with <k> costs"))
+    return nullptr;
+  new_options(all, "CB options")
+  ("cb_type", po::value<string>(), "contextual bandit method to use in {ips,dm,dr}")
+  ("eval", "Evaluate a policy rather than optimizing.");
+  add_options(all);
+
+  cb& c = calloc_or_die<cb>();
+  c.num_actions = (uint32_t)all.vm["cb"].as<size_t>();
+
+  bool eval = false;
+  if (all.vm.count("eval"))
+    eval = true;
+
+  size_t problem_multiplier = 2;//default for DR
+  if (all.vm.count("cb_type"))
   {
-    output_example(all, c, ec, ec.l.cb);
-    VW::finish_example(all, &ec);
-  }
+    std::string type_string;
 
-  void eval_finish_example(vw& all, cb& c, example& ec)
-  {
-    output_example(all, c, ec, ec.l.cb_eval.event);
-    VW::finish_example(all, &ec);
-  }
+    type_string = all.vm["cb_type"].as<std::string>();
+    *all.file_options << " --cb_type " << type_string;
 
-  base_learner* cb_algs_setup(vw& all)
-  {
-    if (missing_option<size_t, true>(all, "cb", "Use contextual bandit learning with <k> costs"))
-      return nullptr;
-    new_options(all, "CB options")
-      ("cb_type", po::value<string>(), "contextual bandit method to use in {ips,dm,dr}")
-      ("eval", "Evaluate a policy rather than optimizing.");
-    add_options(all);
-
-    cb& c = calloc_or_die<cb>();
-    c.num_actions = (uint32_t)all.vm["cb"].as<size_t>();
-
-    bool eval = false;
-    if (all.vm.count("eval"))
-      eval = true;
-
-    size_t problem_multiplier = 2;//default for DR
-    if (all.vm.count("cb_type"))
+    if (type_string.compare("dr") == 0)
+      c.cb_type = CB_TYPE_DR;
+    else if (type_string.compare("dm") == 0)
     {
-      std::string type_string;
+      if (eval)
+        THROW( "direct method can not be used for evaluation --- it is biased.");
 
-      type_string = all.vm["cb_type"].as<std::string>();
-      *all.file_options << " --cb_type " << type_string;
-      
-      if (type_string.compare("dr") == 0) 
-	c.cb_type = CB_TYPE_DR;
-      else if (type_string.compare("dm") == 0)
-	{
-	  if (eval)
-	    THROW( "direct method can not be used for evaluation --- it is biased.");
-
-	  c.cb_type = CB_TYPE_DM;
-	  problem_multiplier = 1;
-	}
-      else if (type_string.compare("ips") == 0)
-	{
-	  c.cb_type = CB_TYPE_IPS;
-	  problem_multiplier = 1;
-	}
-      else {
-        std::cerr << "warning: cb_type must be in {'ips','dm','dr'}; resetting to dr." << std::endl;
-        c.cb_type = CB_TYPE_DR;
-      }
+      c.cb_type = CB_TYPE_DM;
+      problem_multiplier = 1;
+    }
+    else if (type_string.compare("ips") == 0)
+    {
+      c.cb_type = CB_TYPE_IPS;
+      problem_multiplier = 1;
     }
     else {
-      //by default use doubly robust
+      std::cerr << "warning: cb_type must be in {'ips','dm','dr'}; resetting to dr." << std::endl;
       c.cb_type = CB_TYPE_DR;
-      *all.file_options << " --cb_type dr";
     }
-
-    if (count(all.args.begin(), all.args.end(),"--csoaa") == 0)
-      {
-	all.args.push_back("--csoaa");
-	stringstream ss;
-	ss << all.vm["cb"].as<size_t>();
-	all.args.push_back(ss.str());
-      }
-
-    base_learner* base = setup_base(all);
-    if (eval)
-      all.p->lp = CB_EVAL::cb_eval; 
-    else
-      all.p->lp = CB::cb_label; 
-
-    learner<cb>* l;
-    if (eval)
-      {
-	l = &init_learner(&c, base, learn_eval, predict_eval, problem_multiplier);
-	l->set_finish_example(eval_finish_example); 
-      }
-    else
-      {
-	l = &init_learner(&c, base, predict_or_learn<true>, predict_or_learn<false>, 
-			  problem_multiplier);
-	l->set_finish_example(finish_example); 
-      }
-    // preserve the increment of the base learner since we are
-    // _adding_ to the number of problems rather than multiplying.
-    l->increment = base->increment; 
-    c.scorer = all.scorer;
-    
-    l->set_finish(finish);
-    return make_base(*l);
   }
+  else {
+    //by default use doubly robust
+    c.cb_type = CB_TYPE_DR;
+    *all.file_options << " --cb_type dr";
+  }
+
+  if (count(all.args.begin(), all.args.end(),"--csoaa") == 0)
+  {
+    all.args.push_back("--csoaa");
+    stringstream ss;
+    ss << all.vm["cb"].as<size_t>();
+    all.args.push_back(ss.str());
+  }
+
+  base_learner* base = setup_base(all);
+  if (eval)
+    all.p->lp = CB_EVAL::cb_eval;
+  else
+    all.p->lp = CB::cb_label;
+
+  learner<cb>* l;
+  if (eval)
+  {
+    l = &init_learner(&c, base, learn_eval, predict_eval, problem_multiplier);
+    l->set_finish_example(eval_finish_example);
+  }
+  else
+  {
+    l = &init_learner(&c, base, predict_or_learn<true>, predict_or_learn<false>,
+                      problem_multiplier);
+    l->set_finish_example(finish_example);
+  }
+  // preserve the increment of the base learner since we are
+  // _adding_ to the number of problems rather than multiplying.
+  l->increment = base->increment;
+  c.scorer = all.scorer;
+
+  l->set_finish(finish);
+  return make_base(*l);
+}

--- a/vowpalwabbit/cb_algs.h
+++ b/vowpalwabbit/cb_algs.h
@@ -5,44 +5,44 @@ license as described in the file LICENSE.
  */
 #pragma once
 //TODO: extend to handle CSOAA_LDF and WAP_LDF
-  LEARNER::base_learner* cb_algs_setup(vw& all);
+LEARNER::base_learner* cb_algs_setup(vw& all);
 
 namespace CB_ALGS {
-  template <bool is_learn>
-    float get_cost_pred(LEARNER::base_learner* scorer, CB::cb_class* known_cost, example& ec, uint32_t index, uint32_t base)
+template <bool is_learn>
+float get_cost_pred(LEARNER::base_learner* scorer, CB::cb_class* known_cost, example& ec, uint32_t index, uint32_t base)
+{
+  CB::label ld = ec.l.cb;
+
+  label_data simple_temp;
+  simple_temp.initial = 0.;
+  if (known_cost != nullptr && index == known_cost->action)
   {
-    CB::label ld = ec.l.cb;
-
-    label_data simple_temp;
-    simple_temp.initial = 0.;
-    if (known_cost != nullptr && index == known_cost->action)
-      {
-	simple_temp.label = known_cost->cost;
-	simple_temp.weight = 1.;
-      }
-    else 
-      {
-	simple_temp.label = FLT_MAX;
-	simple_temp.weight = 0.;
-      }
-    
-    ec.l.simple = simple_temp;
-    polyprediction p = ec.pred;
-
-    if (is_learn && simple_temp.label != FLT_MAX)
-      scorer->learn(ec, index-1+base);
-    else
-      scorer->predict(ec, index-1+base);
-    
-    float pred = ec.pred.scalar;
-    ec.pred = p;
-    
-    ec.l.cb = ld;
-
-    return pred;
+    simple_temp.label = known_cost->cost;
+    simple_temp.weight = 1.;
+  }
+  else
+  {
+    simple_temp.label = FLT_MAX;
+    simple_temp.weight = 0.;
   }
 
-	
+  ec.l.simple = simple_temp;
+  polyprediction p = ec.pred;
+
+  if (is_learn && simple_temp.label != FLT_MAX)
+    scorer->learn(ec, index-1+base);
+  else
+    scorer->predict(ec, index-1+base);
+
+  float pred = ec.pred.scalar;
+  ec.pred = p;
+
+  ec.l.cb = ld;
+
+  return pred;
+}
+
+
 }
 
 float get_unbiased_cost(CB::cb_class* known_cost, COST_SENSITIVE::label& cb_label, uint32_t action);

--- a/vowpalwabbit/cbify.cc
+++ b/vowpalwabbit/cbify.cc
@@ -44,7 +44,7 @@ class vw_cover : public IScorer<vw_context>
 public:
   vw_cover(float eps, size_t s, u32 num_a) :
     epsilon(eps), size(s), num_actions(num_a), counter(1)
-  { 
+  {
     probabilities = v_init<float>();
     probabilities.resize(num_actions + 1);
     predictions = v_init<uint32_t>();
@@ -53,17 +53,17 @@ public:
 
   virtual ~vw_cover()
   { }
-  
+
   v_array<float>& Get_Scores()
-  { 
+  {
     probabilities.erase();
     for (size_t i = 0; i < num_actions; i++)
       probabilities.push_back(0);
-    return probabilities; 
+    return probabilities;
   };
 
   vector<float> Score_Actions(vw_context& ctx);
-  
+
   float epsilon;
   size_t size;
   u32 num_actions;
@@ -89,14 +89,14 @@ struct vw_recorder : public IRecorder<vw_context>
 
 struct cbify {
   uint32_t k;
-  
+
   CB::label cb_label;
   COST_SENSITIVE::label cs_label;
   COST_SENSITIVE::label second_cs_label;
-  
+
   base_learner* cs;
   LEARNER::base_learner* reg;
-  
+
   vw_policy* policy;
   TauFirstExplorer<vw_context>* tau_explorer;
   vw_recorder* recorder;
@@ -122,69 +122,69 @@ vector<float> vw_cover::Score_Actions(vw_context& ctx)
 {
   float additive_probability = 1.f / (float)size;
   for (size_t i = 0; i < size; i++)
-    { //get predicted cost-sensitive predictions
-      if (i == 0)
-        ctx.data.cs->predict(ctx.e, i);
-      else
-        ctx.data.cs->predict(ctx.e, i + 1);
-      uint32_t pred = ctx.e.pred.multiclass;
-      probabilities[pred - 1] += additive_probability;
-      predictions[i] = (uint32_t)pred;
-    }
+  { //get predicted cost-sensitive predictions
+    if (i == 0)
+      ctx.data.cs->predict(ctx.e, i);
+    else
+      ctx.data.cs->predict(ctx.e, i + 1);
+    uint32_t pred = ctx.e.pred.multiclass;
+    probabilities[pred - 1] += additive_probability;
+    predictions[i] = (uint32_t)pred;
+  }
   float min_prob = epsilon * min(1.f / ctx.data.k, 1.f / (float)sqrt(counter * ctx.data.k));
-  
+
   safety(probabilities, min_prob);
-  
+
   vector<float> scores;
   for (size_t i = 0; i < ctx.data.k; i++)
     scores.push_back(probabilities[i]);
-  
+
   counter++;
-  
+
   return scores;
 }
 
 template <bool is_learn>
 void predict_or_learn_first(cbify& data, base_learner& base, example& ec)
-{//Explore tau times, then act according to optimal.
+{ //Explore tau times, then act according to optimal.
   MULTICLASS::label_t ld = ec.l.multi;
-  
+
   data.cb_label.costs.erase();
   ec.l.cb = data.cb_label;
   //Use CB to find current prediction for remaining rounds.
-  
+
   vw_context vwc = {data, base, ec};
   uint32_t action = data.mwt_explorer->Choose_Action(*data.tau_explorer, to_string((unsigned long long)ec.example_counter), vwc);
-  
+
   if (vwc.recorded && is_learn)
-    {
-      CB::cb_class l = {loss(ld.label, action), action, data.recorder->probability };
-      data.cb_label.costs.push_back(l);
-      ec.l.cb = data.cb_label;
-      base.learn(ec);
-    }
-  
+  {
+    CB::cb_class l = {loss(ld.label, action), action, data.recorder->probability };
+    data.cb_label.costs.push_back(l);
+    ec.l.cb = data.cb_label;
+    base.learn(ec);
+  }
+
   ec.pred.multiclass = action;
   ec.l.multi = ld;
 }
 
 template <bool is_learn>
 void predict_or_learn_greedy(cbify& data, base_learner& base, example& ec)
-{//Explore uniform random an epsilon fraction of the time.
+{ //Explore uniform random an epsilon fraction of the time.
   MULTICLASS::label_t ld = ec.l.multi;
-  
+
   data.cb_label.costs.erase();
   ec.l.cb = data.cb_label;
-  
+
   vw_context vwc = {data, base, ec};
   uint32_t action = data.mwt_explorer->Choose_Action(*data.greedy_explorer, to_string((unsigned long long)ec.example_counter), vwc);
-  
+
   if (is_learn) {
     CB::cb_class l = { loss(ld.label, action), action, data.recorder->probability };
     data.cb_label.costs.push_back(l);
     ec.l.cb = data.cb_label;
     base.learn(ec);
-  }  
+  }
 
   ec.pred.multiclass = action;
   ec.l.multi = ld;
@@ -192,242 +192,246 @@ void predict_or_learn_greedy(cbify& data, base_learner& base, example& ec)
 
 template <bool is_learn>
 void predict_or_learn_bag(cbify& data, base_learner& base, example& ec)
-{//Randomize over predictions from a base set of predictors
+{ //Randomize over predictions from a base set of predictors
   //Use CB to find current predictions.
   MULTICLASS::label_t ld = ec.l.multi;
-  
+
   data.cb_label.costs.erase();
   ec.l.cb = data.cb_label;
-  
+
   vw_context context = {data, base, ec};
   uint32_t action = data.mwt_explorer->Choose_Action(*data.bootstrap_explorer, to_string((unsigned long long)ec.example_counter), context);
-  
+
   if (is_learn)
+  {
+    CB::cb_class l = {loss(ld.label, action),
+                      action, data.recorder->probability
+                     };
+    data.cb_label.costs.push_back(l);
+    ec.l.cb = data.cb_label;
+    for (size_t i = 0; i < data.policies.size(); i++)
     {
-      CB::cb_class l = {loss(ld.label, action), 
-			action, data.recorder->probability};
-      data.cb_label.costs.push_back(l);
-      ec.l.cb = data.cb_label;
-      for (size_t i = 0; i < data.policies.size(); i++)
-	{
-	  uint32_t count = BS::weight_gen();
-	  for (uint32_t j = 0; j < count; j++)
-	    base.learn(ec,i);
-	}
+      uint32_t count = BS::weight_gen();
+      for (uint32_t j = 0; j < count; j++)
+        base.learn(ec,i);
     }
+  }
   ec.pred.multiclass = action;
   ec.l.multi = ld;
 }
- 
- void safety(v_array<float>& distribution, float min_prob)
- {
-   float added_mass = 0.;
-   for (uint32_t i = 0; i < distribution.size();i++)
-     if (distribution[i] > 0 && distribution[i] <= min_prob)
-       {
-	 added_mass += min_prob - distribution[i];
-	 distribution[i] = min_prob;
-       }
-   
-   float ratio = 1.f / (1.f + added_mass);
-   if (ratio < 0.999)
-     {
-       for (uint32_t i = 0; i < distribution.size(); i++)
-	 if (distribution[i] > min_prob)
-	   distribution[i] = distribution[i] * ratio; 
-       safety(distribution, min_prob);
-     }
- }
- 
- void gen_cs_label(cbify& c, CB::cb_class& known_cost, example& ec, COST_SENSITIVE::label& cs_ld, uint32_t label)
- {
-   COST_SENSITIVE::wclass wc;
-   
-   //get cost prediction for this label
-   wc.x = CB_ALGS::get_cost_pred<false>(c.reg, &known_cost, ec, label, c.k);
-   wc.class_index = label;
-   wc.partial_prediction = 0.;
-   wc.wap_value = 0.;
-   
-   //add correction if we observed cost for this action and regressor is wrong
-   if( known_cost.action == label ) 
-     wc.x += (known_cost.cost - wc.x) / known_cost.probability;
-   
-   cs_ld.costs.push_back( wc );
- }
- 
- template <bool is_learn>
-   void predict_or_learn_cover(cbify& data, base_learner& base, example& ec)
- {//Randomize over predictions from a base set of predictors
-   //Use cost sensitive oracle to cover actions to form distribution.
-   MULTICLASS::label_t ld = ec.l.multi;
-   
-   data.cs_label.costs.erase();
-   for (uint32_t j = 0; j < data.k; j++)
-     {
-       COST_SENSITIVE::wclass wc;
-       
-       //get cost prediction for this label
-       wc.x = FLT_MAX;
-       wc.class_index = j+1;
-       wc.partial_prediction = 0.;
-       wc.wap_value = 0.;
-       data.cs_label.costs.push_back(wc);
-     }
-   
-   float epsilon = data.cover->epsilon;
-   size_t cover_size = data.cover->size;
-   size_t counter = data.cover->counter;
-   v_array<float>& scores = data.cover->Get_Scores();
-   v_array<uint32_t>& predictions = data.cover->predictions;
-   
-   float additive_probability = 1.f / (float)cover_size;
-   
-   ec.l.cs = data.cs_label;
-   
-   float min_prob = epsilon * min(1.f / data.k, 1.f / (float)sqrt(counter * data.k));
-   
-   vw_context cp = {data, base, ec};
-   uint32_t action = data.mwt_explorer->Choose_Action(*data.generic_explorer, to_string((unsigned long long)ec.example_counter), cp);
-   
-   if (is_learn)
-     {
-       data.cb_label.costs.erase();
-       float probability = data.recorder->probability;
-       CB::cb_class l = {loss(ld.label, action), 
-			 action, probability};
-       data.cb_label.costs.push_back(l);
-       ec.l.cb = data.cb_label;
-       base.learn(ec);
-       
-       //Now update oracles
-       
-       //1. Compute loss vector
-       data.cs_label.costs.erase();
-       float norm = min_prob * data.k;
-       for (uint32_t j = 0; j < data.k; j++)
-	 { //data.cs_label now contains an unbiased estimate of cost of each class.
-	   gen_cs_label(data, l, ec, data.cs_label, j+1);
-	   scores[j] = 0;
-	 }
-       
-       ec.l.cs = data.second_cs_label;
-       //2. Update functions
-       for (size_t i = 0; i < cover_size; i++)
-	 { //get predicted cost-sensitive predictions
-	   for (uint32_t j = 0; j < data.k; j++)
-	     {
-	       float pseudo_cost = data.cs_label.costs[j].x - epsilon * min_prob / (max(scores[j], min_prob) / norm) + 1;
-	       data.second_cs_label.costs[j].class_index = j+1;
-	       data.second_cs_label.costs[j].x = pseudo_cost;
-	     }
-	   if (i != 0)
-	     data.cs->learn(ec,i+1);
-	   if (scores[predictions[i] - 1] < min_prob)
-	     norm += max(0, additive_probability - (min_prob - scores[predictions[i] - 1]));
-	   else
-	     norm += additive_probability;
-	   scores[predictions[i] - 1] += additive_probability;
-	 }
-     }
-   
-   ec.pred.multiclass = action;
-   ec.l.multi = ld;
- }
-  
-template<class T> inline void delete_it(T* p) { if (p != nullptr) delete p; } 
 
-  void finish(cbify& data)
-  { CB::cb_label.delete_label(&data.cb_label);
-    COST_SENSITIVE::cs_label.delete_label(&data.cs_label); 
-    COST_SENSITIVE::cs_label.delete_label(&data.second_cs_label); 
-    delete_it(data.policy);
-    delete_it(data.tau_explorer);
-    delete_it(data.greedy_explorer);
-    delete_it(data.bootstrap_explorer);
-    delete_it(data.generic_explorer);
-    delete_it(data.mwt_explorer);
-    delete_it(data.recorder);
-    if (data.cover != nullptr)
-      {
-	data.cover->predictions.delete_v();
-	data.cover->probabilities.delete_v();
-      }
-    delete_it(data.cover);
-    if (data.policies.size() > 0)
-      data.policies.~vector();
+void safety(v_array<float>& distribution, float min_prob)
+{
+  float added_mass = 0.;
+  for (uint32_t i = 0; i < distribution.size(); i++)
+    if (distribution[i] > 0 && distribution[i] <= min_prob)
+    {
+      added_mass += min_prob - distribution[i];
+      distribution[i] = min_prob;
+    }
+
+  float ratio = 1.f / (1.f + added_mass);
+  if (ratio < 0.999)
+  {
+    for (uint32_t i = 0; i < distribution.size(); i++)
+      if (distribution[i] > min_prob)
+        distribution[i] = distribution[i] * ratio;
+    safety(distribution, min_prob);
+  }
+}
+
+void gen_cs_label(cbify& c, CB::cb_class& known_cost, example& ec, COST_SENSITIVE::label& cs_ld, uint32_t label)
+{
+  COST_SENSITIVE::wclass wc;
+
+  //get cost prediction for this label
+  wc.x = CB_ALGS::get_cost_pred<false>(c.reg, &known_cost, ec, label, c.k);
+  wc.class_index = label;
+  wc.partial_prediction = 0.;
+  wc.wap_value = 0.;
+
+  //add correction if we observed cost for this action and regressor is wrong
+  if( known_cost.action == label )
+    wc.x += (known_cost.cost - wc.x) / known_cost.probability;
+
+  cs_ld.costs.push_back( wc );
+}
+
+template <bool is_learn>
+void predict_or_learn_cover(cbify& data, base_learner& base, example& ec)
+{ //Randomize over predictions from a base set of predictors
+  //Use cost sensitive oracle to cover actions to form distribution.
+  MULTICLASS::label_t ld = ec.l.multi;
+
+  data.cs_label.costs.erase();
+  for (uint32_t j = 0; j < data.k; j++)
+  {
+    COST_SENSITIVE::wclass wc;
+
+    //get cost prediction for this label
+    wc.x = FLT_MAX;
+    wc.class_index = j+1;
+    wc.partial_prediction = 0.;
+    wc.wap_value = 0.;
+    data.cs_label.costs.push_back(wc);
   }
 
-  base_learner* cbify_setup(vw& all)
-  {//parse and set arguments
-    if (missing_option<size_t, true>(all, "cbify", "Convert multiclass on <k> classes into a contextual bandit problem"))
-      return nullptr;
-    new_options(all, "CBIFY options")
-      ("first", po::value<size_t>(), "tau-first exploration")
-      ("epsilon",po::value<float>() ,"epsilon-greedy exploration")
-      ("bag",po::value<size_t>() ,"bagging-based exploration")
-      ("cover",po::value<size_t>() ,"bagging-based exploration");
-    add_options(all);
+  float epsilon = data.cover->epsilon;
+  size_t cover_size = data.cover->size;
+  size_t counter = data.cover->counter;
+  v_array<float>& scores = data.cover->Get_Scores();
+  v_array<uint32_t>& predictions = data.cover->predictions;
 
-    po::variables_map& vm = all.vm;
-    cbify& data = calloc_or_die<cbify>();
-    data.k = (uint32_t)vm["cbify"].as<size_t>();
+  float additive_probability = 1.f / (float)cover_size;
 
-    if (count(all.args.begin(), all.args.end(),"--cb") == 0)
+  ec.l.cs = data.cs_label;
+
+  float min_prob = epsilon * min(1.f / data.k, 1.f / (float)sqrt(counter * data.k));
+
+  vw_context cp = {data, base, ec};
+  uint32_t action = data.mwt_explorer->Choose_Action(*data.generic_explorer, to_string((unsigned long long)ec.example_counter), cp);
+
+  if (is_learn)
+  {
+    data.cb_label.costs.erase();
+    float probability = data.recorder->probability;
+    CB::cb_class l = {loss(ld.label, action),
+                      action, probability
+                     };
+    data.cb_label.costs.push_back(l);
+    ec.l.cb = data.cb_label;
+    base.learn(ec);
+
+    //Now update oracles
+
+    //1. Compute loss vector
+    data.cs_label.costs.erase();
+    float norm = min_prob * data.k;
+    for (uint32_t j = 0; j < data.k; j++)
+    { //data.cs_label now contains an unbiased estimate of cost of each class.
+      gen_cs_label(data, l, ec, data.cs_label, j+1);
+      scores[j] = 0;
+    }
+
+    ec.l.cs = data.second_cs_label;
+    //2. Update functions
+    for (size_t i = 0; i < cover_size; i++)
+    { //get predicted cost-sensitive predictions
+      for (uint32_t j = 0; j < data.k; j++)
       {
-	all.args.push_back("--cb");
-	stringstream ss;
-	ss << vm["cbify"].as<size_t>();
-	all.args.push_back(ss.str());
+        float pseudo_cost = data.cs_label.costs[j].x - epsilon * min_prob / (max(scores[j], min_prob) / norm) + 1;
+        data.second_cs_label.costs[j].class_index = j+1;
+        data.second_cs_label.costs[j].x = pseudo_cost;
       }
-    base_learner* base = setup_base(all);
-    
-    learner<cbify>* l;
-    data.recorder = new vw_recorder();
-    data.mwt_explorer = new MwtExplorer<vw_context>("vw", *data.recorder);
-    if (vm.count("cover"))
-      {
-	size_t cover = (uint32_t)vm["cover"].as<size_t>();
-	data.cs = all.cost_sensitive;
-	data.second_cs_label.costs.resize(data.k);
-	data.second_cs_label.costs.end = data.second_cs_label.costs.begin+data.k;
-	float epsilon = 0.05f;
-	if (vm.count("epsilon")) 
-	  epsilon = vm["epsilon"].as<float>();
-	data.cover = new vw_cover(epsilon, cover, (u32)data.k);
-	data.generic_explorer = new GenericExplorer<vw_context>(*data.cover, (u32)data.k);
-	l = &init_multiclass_learner(&data, base, predict_or_learn_cover<true>, 
-					     predict_or_learn_cover<false>, all.p, cover + 1);
-      }
-    else if (vm.count("bag"))
-      {
-	size_t bags = (uint32_t)vm["bag"].as<size_t>();
-	for (size_t i = 0; i < bags; i++)
-	  data.policies.push_back(unique_ptr<IPolicy<vw_context>>(new vw_policy(i)));
-	data.bootstrap_explorer = new BootstrapExplorer<vw_context>(data.policies, (u32)data.k);
-	l = &init_multiclass_learner(&data, base, predict_or_learn_bag<true>, 
-					     predict_or_learn_bag<false>, all.p, bags);
-      }
-    else if (vm.count("first") )
-      {
-	uint32_t tau = (uint32_t)vm["first"].as<size_t>();
-	data.policy = new vw_policy(0);
-	data.tau_explorer = new TauFirstExplorer<vw_context>(*data.policy, (u32)tau, (u32)data.k);
-	l = &init_multiclass_learner(&data, base, predict_or_learn_first<true>, 
-					     predict_or_learn_first<false>, all.p, 1);
-      }
-    else
-      {
-	float epsilon = 0.05f;
-	if (vm.count("epsilon"))
-	  epsilon = vm["epsilon"].as<float>();
-	data.policy = new vw_policy(0);
-	data.greedy_explorer = new EpsilonGreedyExplorer<vw_context>(*data.policy, epsilon, (u32)data.k);
-	l = &init_multiclass_learner(&data, base, predict_or_learn_greedy<true>, 
-				     predict_or_learn_greedy<false>, all.p, 1);
-      }
-    data.reg = all.scorer;
-    l->set_finish(finish);
-    
-    return make_base(*l);
+      if (i != 0)
+        data.cs->learn(ec,i+1);
+      if (scores[predictions[i] - 1] < min_prob)
+        norm += max(0, additive_probability - (min_prob - scores[predictions[i] - 1]));
+      else
+        norm += additive_probability;
+      scores[predictions[i] - 1] += additive_probability;
+    }
   }
+
+  ec.pred.multiclass = action;
+  ec.l.multi = ld;
+}
+
+template<class T> inline void delete_it(T* p) {
+  if (p != nullptr) delete p;
+}
+
+void finish(cbify& data)
+{ CB::cb_label.delete_label(&data.cb_label);
+  COST_SENSITIVE::cs_label.delete_label(&data.cs_label);
+  COST_SENSITIVE::cs_label.delete_label(&data.second_cs_label);
+  delete_it(data.policy);
+  delete_it(data.tau_explorer);
+  delete_it(data.greedy_explorer);
+  delete_it(data.bootstrap_explorer);
+  delete_it(data.generic_explorer);
+  delete_it(data.mwt_explorer);
+  delete_it(data.recorder);
+  if (data.cover != nullptr)
+  {
+    data.cover->predictions.delete_v();
+    data.cover->probabilities.delete_v();
+  }
+  delete_it(data.cover);
+  if (data.policies.size() > 0)
+    data.policies.~vector();
+}
+
+base_learner* cbify_setup(vw& all)
+{ //parse and set arguments
+  if (missing_option<size_t, true>(all, "cbify", "Convert multiclass on <k> classes into a contextual bandit problem"))
+    return nullptr;
+  new_options(all, "CBIFY options")
+  ("first", po::value<size_t>(), "tau-first exploration")
+  ("epsilon",po::value<float>() ,"epsilon-greedy exploration")
+  ("bag",po::value<size_t>() ,"bagging-based exploration")
+  ("cover",po::value<size_t>() ,"bagging-based exploration");
+  add_options(all);
+
+  po::variables_map& vm = all.vm;
+  cbify& data = calloc_or_die<cbify>();
+  data.k = (uint32_t)vm["cbify"].as<size_t>();
+
+  if (count(all.args.begin(), all.args.end(),"--cb") == 0)
+  {
+    all.args.push_back("--cb");
+    stringstream ss;
+    ss << vm["cbify"].as<size_t>();
+    all.args.push_back(ss.str());
+  }
+  base_learner* base = setup_base(all);
+
+  learner<cbify>* l;
+  data.recorder = new vw_recorder();
+  data.mwt_explorer = new MwtExplorer<vw_context>("vw", *data.recorder);
+  if (vm.count("cover"))
+  {
+    size_t cover = (uint32_t)vm["cover"].as<size_t>();
+    data.cs = all.cost_sensitive;
+    data.second_cs_label.costs.resize(data.k);
+    data.second_cs_label.costs.end = data.second_cs_label.costs.begin+data.k;
+    float epsilon = 0.05f;
+    if (vm.count("epsilon"))
+      epsilon = vm["epsilon"].as<float>();
+    data.cover = new vw_cover(epsilon, cover, (u32)data.k);
+    data.generic_explorer = new GenericExplorer<vw_context>(*data.cover, (u32)data.k);
+    l = &init_multiclass_learner(&data, base, predict_or_learn_cover<true>,
+                                 predict_or_learn_cover<false>, all.p, cover + 1);
+  }
+  else if (vm.count("bag"))
+  {
+    size_t bags = (uint32_t)vm["bag"].as<size_t>();
+    for (size_t i = 0; i < bags; i++)
+      data.policies.push_back(unique_ptr<IPolicy<vw_context>>(new vw_policy(i)));
+    data.bootstrap_explorer = new BootstrapExplorer<vw_context>(data.policies, (u32)data.k);
+    l = &init_multiclass_learner(&data, base, predict_or_learn_bag<true>,
+                                 predict_or_learn_bag<false>, all.p, bags);
+  }
+  else if (vm.count("first") )
+  {
+    uint32_t tau = (uint32_t)vm["first"].as<size_t>();
+    data.policy = new vw_policy(0);
+    data.tau_explorer = new TauFirstExplorer<vw_context>(*data.policy, (u32)tau, (u32)data.k);
+    l = &init_multiclass_learner(&data, base, predict_or_learn_first<true>,
+                                 predict_or_learn_first<false>, all.p, 1);
+  }
+  else
+  {
+    float epsilon = 0.05f;
+    if (vm.count("epsilon"))
+      epsilon = vm["epsilon"].as<float>();
+    data.policy = new vw_policy(0);
+    data.greedy_explorer = new EpsilonGreedyExplorer<vw_context>(*data.policy, epsilon, (u32)data.k);
+    l = &init_multiclass_learner(&data, base, predict_or_learn_greedy<true>,
+                                 predict_or_learn_greedy<false>, all.p, 1);
+  }
+  data.reg = all.scorer;
+  l->set_finish(finish);
+
+  return make_base(*l);
+}

--- a/vowpalwabbit/comp_io.cc
+++ b/vowpalwabbit/comp_io.cc
@@ -1,79 +1,83 @@
 #include "zlib.h"
 #include "comp_io.h"
 
-int comp_io_buf::open_file(const char* name, bool stdin_off, int flag){
-	gzFile fil = nullptr;
-	int ret = -1;
-	switch (flag){
-	case READ:
-		if (*name != '\0')
-			fil = gzopen(name, "rb");
-		else if (!stdin_off)
+int comp_io_buf::open_file(const char* name, bool stdin_off, int flag) {
+  gzFile fil = nullptr;
+  int ret = -1;
+  switch (flag) {
+  case READ:
+    if (*name != '\0')
+      fil = gzopen(name, "rb");
+    else if (!stdin_off)
 #ifdef _WIN32
-			fil = gzdopen(_fileno(stdin), "rb");
+      fil = gzdopen(_fileno(stdin), "rb");
 #else
-			fil = gzdopen(fileno(stdin), "rb");
+      fil = gzdopen(fileno(stdin), "rb");
 #endif
-		if (fil != nullptr){
-			gz_files.push_back(fil);
-			ret = (int)gz_files.size() - 1;
-			files.push_back(ret);
-		}
-		break;
+    if (fil != nullptr) {
+      gz_files.push_back(fil);
+      ret = (int)gz_files.size() - 1;
+      files.push_back(ret);
+    }
+    break;
 
-	case WRITE:
-		fil = gzopen(name, "wb");
-		if (fil != nullptr){
-			gz_files.push_back(fil);
-			ret = (int)gz_files.size() - 1;
-			files.push_back(ret);
-		}
-		break;
+  case WRITE:
+    fil = gzopen(name, "wb");
+    if (fil != nullptr) {
+      gz_files.push_back(fil);
+      ret = (int)gz_files.size() - 1;
+      files.push_back(ret);
+    }
+    break;
 
-	default:
-		std::cerr << "Unknown file operation. Something other than READ/WRITE specified" << std::endl;
-	}
-	return ret;
+  default:
+    std::cerr << "Unknown file operation. Something other than READ/WRITE specified" << std::endl;
+  }
+  return ret;
 }
 
-void comp_io_buf::reset_file(int f){
-	gzFile fil = gz_files[f];
-	gzseek(fil, 0, SEEK_SET);
-	endloaded = space.begin;
-	space.end = space.begin;
+void comp_io_buf::reset_file(int f) {
+  gzFile fil = gz_files[f];
+  gzseek(fil, 0, SEEK_SET);
+  endloaded = space.begin;
+  space.end = space.begin;
 }
 
 ssize_t comp_io_buf::read_file(int f, void* buf, size_t nbytes)
 {
-	gzFile fil = gz_files[f];
-	int num_read = gzread(fil, buf, (unsigned int)nbytes);
-	return (num_read > 0) ? num_read : 0;
+  gzFile fil = gz_files[f];
+  int num_read = gzread(fil, buf, (unsigned int)nbytes);
+  return (num_read > 0) ? num_read : 0;
 }
 
-size_t comp_io_buf::num_files(){ return gz_files.size(); }
+size_t comp_io_buf::num_files() {
+  return gz_files.size();
+}
 
 ssize_t comp_io_buf::write_file(int file, const void* buf, size_t nbytes)
 {
-	int num_written = gzwrite(gz_files[file], buf, (unsigned int)nbytes);
-	return (num_written > 0) ? num_written : 0;
+  int num_written = gzwrite(gz_files[file], buf, (unsigned int)nbytes);
+  return (num_written > 0) ? num_written : 0;
 }
 
-bool comp_io_buf::compressed() { return true; }
+bool comp_io_buf::compressed() {
+  return true;
+}
 
 void comp_io_buf::flush()
 {
-	if (write_file(0, space.begin, space.size()) != (int)((space.size())))
-		std::cerr << "error, failed to write to cache\n";
-	space.end = space.begin;
+  if (write_file(0, space.begin, space.size()) != (int)((space.size())))
+    std::cerr << "error, failed to write to cache\n";
+  space.end = space.begin;
 }
 
-bool comp_io_buf::close_file(){
-	if (gz_files.size()>0){
-		gzclose(gz_files.back());
-		gz_files.pop_back();
-		if (files.size() > 0)
-			files.pop();
-		return true;
-	}
-	return false;
+bool comp_io_buf::close_file() {
+  if (gz_files.size()>0) {
+    gzclose(gz_files.back());
+    gz_files.pop_back();
+    if (files.size() > 0)
+      files.pop();
+    return true;
+  }
+  return false;
 }

--- a/vowpalwabbit/comp_io.h
+++ b/vowpalwabbit/comp_io.h
@@ -10,11 +10,11 @@ license as described in the file LICENSE.
 #include <stdio.h>
 
 #if (ZLIB_VERNUM < 0x1252)
-	typedef void* gzFile;
+typedef void* gzFile;
 #else
-	struct gzFile_s;
-	typedef struct gzFile_s *gzFile;    
-#endif 
+struct gzFile_s;
+typedef struct gzFile_s *gzFile;
+#endif
 
 class comp_io_buf : public io_buf
 {
@@ -24,7 +24,7 @@ public:
   virtual int open_file(const char* name, bool stdin_off, int flag = READ);
 
   virtual void reset_file(int f);
-  
+
   virtual ssize_t read_file(int f, void* buf, size_t nbytes);
 
   virtual size_t num_files();

--- a/vowpalwabbit/cost_sensitive.cc
+++ b/vowpalwabbit/cost_sensitive.cc
@@ -4,283 +4,284 @@
 #include "vw_exception.h"
 namespace COST_SENSITIVE {
 
-  void name_value(substring &s, v_array<substring>& name, float &v)
-  {
-    tokenize(':', s, name);
-    
-    switch (name.size()) {
-    case 0:
-    case 1:
-      v = 1.;
-      break;
-    case 2:
-      v = float_of_substring(name[1]);
-      if (nanpattern(v))
-	THROW("error NaN value for: " << name[0]);
-      break;
-    default:
-      cerr << "example with a wierd name.  What is '";
-      cerr.write(s.begin, s.end - s.begin);
-      cerr << "'?\n";
-    }
-  }
+void name_value(substring &s, v_array<substring>& name, float &v)
+{
+  tokenize(':', s, name);
 
-  bool is_test_label(label& ld)
-  {
-    if (ld.costs.size() == 0)
-      return true;
-    for (unsigned int i=0; i<ld.costs.size(); i++)
-      if (FLT_MAX != ld.costs[i].x)
-        return false;
+  switch (name.size()) {
+  case 0:
+  case 1:
+    v = 1.;
+    break;
+  case 2:
+    v = float_of_substring(name[1]);
+    if (nanpattern(v))
+      THROW("error NaN value for: " << name[0]);
+    break;
+  default:
+    cerr << "example with a wierd name.  What is '";
+    cerr.write(s.begin, s.end - s.begin);
+    cerr << "'?\n";
+  }
+}
+
+bool is_test_label(label& ld)
+{
+  if (ld.costs.size() == 0)
     return true;
-  }
-  
-  char* bufread_label(label* ld, char* c, io_buf& cache)
+  for (unsigned int i=0; i<ld.costs.size(); i++)
+    if (FLT_MAX != ld.costs[i].x)
+      return false;
+  return true;
+}
+
+char* bufread_label(label* ld, char* c, io_buf& cache)
+{
+  size_t num = *(size_t *)c;
+  ld->costs.erase();
+  c += sizeof(size_t);
+  size_t total = sizeof(wclass)*num;
+  if (buf_read(cache, c, (int)total) < total)
   {
-    size_t num = *(size_t *)c;
-    ld->costs.erase();
-    c += sizeof(size_t);
-    size_t total = sizeof(wclass)*num;
-    if (buf_read(cache, c, (int)total) < total) 
-      {
-        cout << "error in demarshal of cost data" << endl;
-        return c;
-      }
-    for (size_t i = 0; i<num; i++)
-      {
-        wclass temp = *(wclass *)c;
-        c += sizeof(wclass);
-        ld->costs.push_back(temp);
-      }
-  
+    cout << "error in demarshal of cost data" << endl;
     return c;
   }
-
-  size_t read_cached_label(shared_data*, void* v, io_buf& cache)
+  for (size_t i = 0; i<num; i++)
   {
-    label* ld = (label*) v;
-    ld->costs.erase();
-    char *c;
-    size_t total = sizeof(size_t);
-    if (buf_read(cache, c, (int)total) < total) 
-      return 0;
-    c = bufread_label(ld,c, cache);
-  
-    return total;
+    wclass temp = *(wclass *)c;
+    c += sizeof(wclass);
+    ld->costs.push_back(temp);
   }
 
-  float weight(void*)
-  {
-    return 1.;
-  }
+  return c;
+}
 
-  char* bufcache_label(label* ld, char* c)
-  {
-    *(size_t *)c = ld->costs.size();
-    c += sizeof(size_t);
-    for (unsigned int i = 0; i< ld->costs.size(); i++)
-      {
-        *(wclass *)c = ld->costs[i];
-        c += sizeof(wclass);
-      }
-    return c;
-  }
+size_t read_cached_label(shared_data*, void* v, io_buf& cache)
+{
+  label* ld = (label*) v;
+  ld->costs.erase();
+  char *c;
+  size_t total = sizeof(size_t);
+  if (buf_read(cache, c, (int)total) < total)
+    return 0;
+  c = bufread_label(ld,c, cache);
 
-  void cache_label(void* v, io_buf& cache)
-  {
-    char *c;
-    label* ld = (label*) v;
-    buf_write(cache, c, sizeof(size_t)+sizeof(wclass)*ld->costs.size());
-    bufcache_label(ld,c);
-  }
+  return total;
+}
 
-  void default_label(void* v)
-  {
-    label* ld = (label*) v;
-    ld->costs.erase();
-  }
+float weight(void*)
+{
+  return 1.;
+}
 
-  void delete_label(void* v)
+char* bufcache_label(label* ld, char* c)
+{
+  *(size_t *)c = ld->costs.size();
+  c += sizeof(size_t);
+  for (unsigned int i = 0; i< ld->costs.size(); i++)
   {
-    label* ld = (label*)v;
-    if (ld) ld->costs.delete_v();
+    *(wclass *)c = ld->costs[i];
+    c += sizeof(wclass);
   }
+  return c;
+}
 
-  void copy_label(void*dst, void*src)
-  {
-    if (dst && src) {
-      label* ldD = (label*)dst;
-      label* ldS = (label*)src;
-      copy_array(ldD->costs, ldS->costs);
+void cache_label(void* v, io_buf& cache)
+{
+  char *c;
+  label* ld = (label*) v;
+  buf_write(cache, c, sizeof(size_t)+sizeof(wclass)*ld->costs.size());
+  bufcache_label(ld,c);
+}
+
+void default_label(void* v)
+{
+  label* ld = (label*) v;
+  ld->costs.erase();
+}
+
+void delete_label(void* v)
+{
+  label* ld = (label*)v;
+  if (ld) ld->costs.delete_v();
+}
+
+void copy_label(void*dst, void*src)
+{
+  if (dst && src) {
+    label* ldD = (label*)dst;
+    label* ldS = (label*)src;
+    copy_array(ldD->costs, ldS->costs);
+  }
+}
+
+bool substring_eq(substring ss, const char* str) {
+  size_t len_ss  = ss.end - ss.begin;
+  size_t len_str = strlen(str);
+  if (len_ss != len_str) return false;
+  return (strncmp(ss.begin, str, len_ss) == 0);
+}
+
+void parse_label(parser* p, shared_data*sd, void* v, v_array<substring>& words)
+{
+  label* ld = (label*)v;
+  ld->costs.erase();
+
+  // handle shared and label first
+  if (words.size() == 1) {
+    float fx;
+    name_value(words[0], p->parse_name, fx);
+    bool eq_shared = substring_eq(p->parse_name[0], "***shared***");
+    bool eq_label  = substring_eq(p->parse_name[0], "***label***");
+    if (! sd->ldict) {
+      eq_shared |= substring_eq(p->parse_name[0], "shared");
+      eq_label  |= substring_eq(p->parse_name[0], "label");
     }
-  }
-
-  bool substring_eq(substring ss, const char* str) {
-    size_t len_ss  = ss.end - ss.begin;
-    size_t len_str = strlen(str);
-    if (len_ss != len_str) return false;
-    return (strncmp(ss.begin, str, len_ss) == 0);
-  }
-
-  void parse_label(parser* p, shared_data*sd, void* v, v_array<substring>& words)
-  {
-    label* ld = (label*)v;
-    ld->costs.erase();
-
-    // handle shared and label first
-    if (words.size() == 1) {
-      float fx;
-      name_value(words[0], p->parse_name, fx);
-      bool eq_shared = substring_eq(p->parse_name[0], "***shared***");
-      bool eq_label  = substring_eq(p->parse_name[0], "***label***");
-      if (! sd->ldict) {
-        eq_shared |= substring_eq(p->parse_name[0], "shared");
-        eq_label  |= substring_eq(p->parse_name[0], "label");
-      }
-      if (eq_shared || eq_label) {
-        if (p->parse_name.size() != 1) cerr << "shared feature vectors and label feature vectors should not have costs on: " << words[0] << endl;
-        else {
-          wclass f = { eq_shared ? -FLT_MAX : 0.f, 0, 0., 0.};
-          ld->costs.push_back(f);
-          return;
-        }
-      }
-    }
-
-    // otherwise this is a "real" example
-    for (unsigned int i = 0; i < words.size(); i++) {
-      wclass f = {0.,0,0.,0.};
-      name_value(words[i], p->parse_name, f.x);
-      
-	  if (p->parse_name.size() == 0)
-	    THROW(" invalid cost: specification -- no names on: " << words[i]);
-
-      if (p->parse_name.size() == 1 || p->parse_name.size() == 2 || p->parse_name.size() == 3) {
-        f.class_index = sd->ldict ? sd->ldict->get(p->parse_name[0]) : (uint32_t)hashstring(p->parse_name[0], 0);
-        if (p->parse_name.size() == 1 && f.x >= 0)  // test examples are specified just by un-valued class #s
-          f.x = FLT_MAX;
-      } 
-      else 
-	THROW("malformed cost specification on '" << (p->parse_name[0].begin) << "'");
-
-      ld->costs.push_back(f);
-    }
-  }
-
-  label_parser cs_label = {default_label, parse_label, 
-				  cache_label, read_cached_label, 
-				  delete_label, weight, 
-				  copy_label,
-				  sizeof(label)};
-
-  void print_update(vw& all, bool is_test, example& ec, const v_array<example*>* ec_seq, bool multilabel)
-  {
-    if (all.sd->weighted_examples >= all.sd->dump_interval && !all.quiet && !all.bfgs)
-      {
-        size_t num_current_features = ec.num_features;
-        // for csoaa_ldf we want features from the whole (multiline example),
-        // not only from one line (the first one) represented by ec
-        if (ec_seq != nullptr)
-	  {
-          num_current_features = 0;
-          // If the first example is "shared", don't include its features.
-          // These should be already included in each example (TODO: including quadratic and cubic).
-          // TODO: code duplication csoaa.cc LabelDict::ec_is_example_header
-          example** ecc=ec_seq->begin;
-          example& first_ex = **ecc;
-	  
-	  v_array<COST_SENSITIVE::wclass> costs = first_ex.l.cs.costs;
-	  if (costs.size() == 1 && costs[0].class_index == 0 && costs[0].x < 0) ecc++;
-	  
-          for (; ecc!=ec_seq->end; ecc++)
-	    num_current_features += (*ecc)->num_features;
-        }
-
-	std::string label_buf;
-        if (is_test)
-          label_buf = " unknown";
-        else
-          label_buf = " known";
-
-	if (multilabel || all.sd->ldict) {
-	  std::ostringstream pred_buf;
-	  
-	  pred_buf << std::setw(all.sd->col_current_predict) << std::right << std::setfill(' ');
-          if (all.sd->ldict) {
-            if (multilabel) pred_buf << all.sd->ldict->get(ec.pred.multilabels.label_v[0]);
-            else            pred_buf << all.sd->ldict->get(ec.pred.multiclass);
-          } else            pred_buf << ec.pred.multilabels.label_v[0];
-          if (multilabel) pred_buf <<".....";
-	  all.sd->print_update(all.holdout_set_off, all.current_pass, label_buf, pred_buf.str(), 
-			       num_current_features, all.progress_add, all.progress_arg);;
-	}
-	else
-	  all.sd->print_update(all.holdout_set_off, all.current_pass, label_buf, ec.pred.multiclass, 
-			       num_current_features, all.progress_add, all.progress_arg);
-      }
-  }
-  
-  void output_example(vw& all, example& ec)
-  {
-    label& ld = ec.l.cs;
-
-    float loss = 0.;
-    if (!is_test_label(ld))
-      {//need to compute exact loss
-        size_t pred = (size_t)ec.pred.multiclass;
-
-        float chosen_loss = FLT_MAX;
-        float min = FLT_MAX;
-        for (wclass *cl = ld.costs.begin; cl != ld.costs.end; cl ++) {
-          if (cl->class_index == pred)
-            chosen_loss = cl->x;
-          if (cl->x < min)
-            min = cl->x;
-        }
-        if (chosen_loss == FLT_MAX)
-          cerr << "warning: csoaa predicted an invalid class" << endl;
-
-        loss = chosen_loss - min;
-      }
-
-    all.sd->update(ec.test_only, loss, 1.f, ec.num_features);
-    
-    for (int* sink = all.final_prediction_sink.begin; sink != all.final_prediction_sink.end; sink++)
-      if (! all.sd->ldict)
-        all.print(*sink, (float)ec.pred.multiclass, 0, ec.tag);
+    if (eq_shared || eq_label) {
+      if (p->parse_name.size() != 1) cerr << "shared feature vectors and label feature vectors should not have costs on: " << words[0] << endl;
       else {
-        substring ss_pred = all.sd->ldict->get(ec.pred.multiclass);
-        all.print_text(*sink, string(ss_pred.begin, ss_pred.end - ss_pred.begin), ec.tag);
+        wclass f = { eq_shared ? -FLT_MAX : 0.f, 0, 0., 0.};
+        ld->costs.push_back(f);
+        return;
       }
+    }
+  }
 
-    if (all.raw_prediction > 0) {
-      stringstream outputStringStream;
-      for (unsigned int i = 0; i < ld.costs.size(); i++) {
-        wclass cl = ld.costs[i];
-        if (i > 0) outputStringStream << ' ';
-        outputStringStream << cl.class_index << ':' << cl.partial_prediction;
-      }
-      all.print_text(all.raw_prediction, outputStringStream.str(), ec.tag);
+  // otherwise this is a "real" example
+  for (unsigned int i = 0; i < words.size(); i++) {
+    wclass f = {0.,0,0.,0.};
+    name_value(words[i], p->parse_name, f.x);
+
+    if (p->parse_name.size() == 0)
+      THROW(" invalid cost: specification -- no names on: " << words[i]);
+
+    if (p->parse_name.size() == 1 || p->parse_name.size() == 2 || p->parse_name.size() == 3) {
+      f.class_index = sd->ldict ? sd->ldict->get(p->parse_name[0]) : (uint32_t)hashstring(p->parse_name[0], 0);
+      if (p->parse_name.size() == 1 && f.x >= 0)  // test examples are specified just by un-valued class #s
+        f.x = FLT_MAX;
+    }
+    else
+      THROW("malformed cost specification on '" << (p->parse_name[0].begin) << "'");
+
+    ld->costs.push_back(f);
+  }
+}
+
+label_parser cs_label = {default_label, parse_label,
+                         cache_label, read_cached_label,
+                         delete_label, weight,
+                         copy_label,
+                         sizeof(label)
+                        };
+
+void print_update(vw& all, bool is_test, example& ec, const v_array<example*>* ec_seq, bool multilabel)
+{
+  if (all.sd->weighted_examples >= all.sd->dump_interval && !all.quiet && !all.bfgs)
+  {
+    size_t num_current_features = ec.num_features;
+    // for csoaa_ldf we want features from the whole (multiline example),
+    // not only from one line (the first one) represented by ec
+    if (ec_seq != nullptr)
+    {
+      num_current_features = 0;
+      // If the first example is "shared", don't include its features.
+      // These should be already included in each example (TODO: including quadratic and cubic).
+      // TODO: code duplication csoaa.cc LabelDict::ec_is_example_header
+      example** ecc=ec_seq->begin;
+      example& first_ex = **ecc;
+
+      v_array<COST_SENSITIVE::wclass> costs = first_ex.l.cs.costs;
+      if (costs.size() == 1 && costs[0].class_index == 0 && costs[0].x < 0) ecc++;
+
+      for (; ecc!=ec_seq->end; ecc++)
+        num_current_features += (*ecc)->num_features;
     }
 
-    print_update(all, is_test_label(ec.l.cs), ec, nullptr);
+    std::string label_buf;
+    if (is_test)
+      label_buf = " unknown";
+    else
+      label_buf = " known";
+
+    if (multilabel || all.sd->ldict) {
+      std::ostringstream pred_buf;
+
+      pred_buf << std::setw(all.sd->col_current_predict) << std::right << std::setfill(' ');
+      if (all.sd->ldict) {
+        if (multilabel) pred_buf << all.sd->ldict->get(ec.pred.multilabels.label_v[0]);
+        else            pred_buf << all.sd->ldict->get(ec.pred.multiclass);
+      } else            pred_buf << ec.pred.multilabels.label_v[0];
+      if (multilabel) pred_buf <<".....";
+      all.sd->print_update(all.holdout_set_off, all.current_pass, label_buf, pred_buf.str(),
+                           num_current_features, all.progress_add, all.progress_arg);;
+    }
+    else
+      all.sd->print_update(all.holdout_set_off, all.current_pass, label_buf, ec.pred.multiclass,
+                           num_current_features, all.progress_add, all.progress_arg);
+  }
+}
+
+void output_example(vw& all, example& ec)
+{
+  label& ld = ec.l.cs;
+
+  float loss = 0.;
+  if (!is_test_label(ld))
+  { //need to compute exact loss
+    size_t pred = (size_t)ec.pred.multiclass;
+
+    float chosen_loss = FLT_MAX;
+    float min = FLT_MAX;
+    for (wclass *cl = ld.costs.begin; cl != ld.costs.end; cl ++) {
+      if (cl->class_index == pred)
+        chosen_loss = cl->x;
+      if (cl->x < min)
+        min = cl->x;
+    }
+    if (chosen_loss == FLT_MAX)
+      cerr << "warning: csoaa predicted an invalid class" << endl;
+
+    loss = chosen_loss - min;
   }
 
-  bool example_is_test(example& ec)
-  {
-    v_array<COST_SENSITIVE::wclass> costs = ec.l.cs.costs;
-    if (costs.size() == 0) return true;
-    for (size_t j=0; j<costs.size(); j++)
-      if (costs[j].x != FLT_MAX) return false;
-    return true;
+  all.sd->update(ec.test_only, loss, 1.f, ec.num_features);
+
+  for (int* sink = all.final_prediction_sink.begin; sink != all.final_prediction_sink.end; sink++)
+    if (! all.sd->ldict)
+      all.print(*sink, (float)ec.pred.multiclass, 0, ec.tag);
+    else {
+      substring ss_pred = all.sd->ldict->get(ec.pred.multiclass);
+      all.print_text(*sink, string(ss_pred.begin, ss_pred.end - ss_pred.begin), ec.tag);
+    }
+
+  if (all.raw_prediction > 0) {
+    stringstream outputStringStream;
+    for (unsigned int i = 0; i < ld.costs.size(); i++) {
+      wclass cl = ld.costs[i];
+      if (i > 0) outputStringStream << ' ';
+      outputStringStream << cl.class_index << ':' << cl.partial_prediction;
+    }
+    all.print_text(all.raw_prediction, outputStringStream.str(), ec.tag);
   }
 
-  bool ec_is_example_header(example& ec)  // example headers look like "0:-1" or just "shared"
-  {
-    v_array<COST_SENSITIVE::wclass> costs = ec.l.cs.costs;
-    if (costs.size() != 1) return false;
-    if (costs[0].class_index != 0) return false;
-    if (costs[0].x != -FLT_MAX) return false;
-    return true;    
-  }
+  print_update(all, is_test_label(ec.l.cs), ec, nullptr);
+}
+
+bool example_is_test(example& ec)
+{
+  v_array<COST_SENSITIVE::wclass> costs = ec.l.cs.costs;
+  if (costs.size() == 0) return true;
+  for (size_t j=0; j<costs.size(); j++)
+    if (costs[j].x != FLT_MAX) return false;
+  return true;
+}
+
+bool ec_is_example_header(example& ec)  // example headers look like "0:-1" or just "shared"
+{
+  v_array<COST_SENSITIVE::wclass> costs = ec.l.cs.costs;
+  if (costs.size() != 1) return false;
+  if (costs[0].class_index != 0) return false;
+  if (costs[0].x != -FLT_MAX) return false;
+  return true;
+}
 }

--- a/vowpalwabbit/cost_sensitive.h
+++ b/vowpalwabbit/cost_sensitive.h
@@ -10,29 +10,31 @@ struct example;
 struct vw;
 
 namespace COST_SENSITIVE {
-  struct wclass {
-    float x;
-    uint32_t class_index;
-    float partial_prediction;  // a partial prediction: new!
-    float wap_value;  // used for wap to store values derived from costs
-    bool operator==(wclass j){return class_index == j.class_index;}
-  };
+struct wclass {
+  float x;
+  uint32_t class_index;
+  float partial_prediction;  // a partial prediction: new!
+  float wap_value;  // used for wap to store values derived from costs
+  bool operator==(wclass j) {
+    return class_index == j.class_index;
+  }
+};
 /* if class_index > 0, then this this a "normal" example
    if class_index == 0, then:
      if x == -FLT_MAX then this is a 'shared' example
      if x > 0 then this is a label feature vector for (size_t)x
 */
 
-  struct label {
-    v_array<wclass> costs;
-  };
-  
-  void output_example(vw& all, example& ec);
-  extern label_parser cs_label;
+struct label {
+  v_array<wclass> costs;
+};
 
-  bool is_test_label(label& ld);
-  bool example_is_test(example& ec);
+void output_example(vw& all, example& ec);
+extern label_parser cs_label;
 
-  void print_update(vw& all, bool is_test, example& ec, const v_array<example*> *ec_seq, bool multilabel = false);
-  bool ec_is_example_header(example& ec);  // example headers look like "0:-1" or just "shared"
+bool is_test_label(label& ld);
+bool example_is_test(example& ec);
+
+void print_update(vw& all, bool is_test, example& ec, const v_array<example*> *ec_seq, bool multilabel = false);
+bool ec_is_example_header(example& ec);  // example headers look like "0:-1" or just "shared"
 }

--- a/vowpalwabbit/csoaa.h
+++ b/vowpalwabbit/csoaa.h
@@ -8,6 +8,6 @@ LEARNER::base_learner* csoaa_setup(vw& all);
 
 LEARNER::base_learner* csldf_setup(vw& all);
 
-namespace LabelDict { 
-  bool ec_is_example_header(example& ec);// example headers look like "0:-1" or just "shared"
+namespace LabelDict {
+bool ec_is_example_header(example& ec);// example headers look like "0:-1" or just "shared"
 }

--- a/vowpalwabbit/ect.cc
+++ b/vowpalwabbit/ect.cc
@@ -4,7 +4,7 @@ individual contributors. All rights reserved.  Released under a BSD (revised)
 license as described in the file LICENSE.
  */
 /*
-  Initial implementation by Hal Daume and John Langford.  Reimplementation 
+  Initial implementation by Hal Daume and John Langford.  Reimplementation
   by John Langford.
 */
 
@@ -19,7 +19,7 @@ license as described in the file LICENSE.
 using namespace std;
 using namespace LEARNER;
 
-struct direction { 
+struct direction {
   size_t id; //unique id for node
   size_t tournament; //unique id for node
   uint32_t winner; //up traversal, winner
@@ -33,24 +33,24 @@ struct ect {
   uint32_t k;
   uint32_t errors;
   v_array<direction> directions;//The nodes of the tournament datastructure
-  
+
   v_array<v_array<v_array<uint32_t > > > all_levels;
-  
-  v_array<uint32_t> final_nodes; //The final nodes of each tournament. 
-  
+
+  v_array<uint32_t> final_nodes; //The final nodes of each tournament.
+
   v_array<size_t> up_directions; //On edge e, which node n is in the up direction?
   v_array<size_t> down_directions;//On edge e, which node n is in the down direction?
-  
+
   size_t tree_height; //The height of the final tournament.
-  
+
   uint32_t last_pair;
-  
+
   v_array<bool> tournaments_won;
 };
 
 bool exists(v_array<size_t> db)
 {
-  for (size_t i = 0; i< db.size();i++)
+  for (size_t i = 0; i< db.size(); i++)
     if (db[i] != 0)
       return true;
   return false;
@@ -69,21 +69,21 @@ size_t final_depth(size_t eliminations)
 bool not_empty(v_array<v_array<uint32_t > > tournaments)
 {
   for (size_t i = 0; i < tournaments.size(); i++)
-    {
-      if (tournaments[i].size() > 0)
-        return true;
-    }
+  {
+    if (tournaments[i].size() > 0)
+      return true;
+  }
   return false;
 }
 
 void print_level(v_array<v_array<uint32_t> > level)
 {
   for (size_t t = 0; t < level.size(); t++)
-    {
-      for (size_t i = 0; i < level[t].size(); i++)
-	cout << " " << level[t][i];
-      cout << " | ";
-    }
+  {
+    for (size_t i = 0; i < level[t].size(); i++)
+      cout << " " << level[t][i];
+    cout << " | ";
+  }
   cout << endl;
 }
 
@@ -91,280 +91,280 @@ size_t create_circuit(ect& e, uint32_t max_label, uint32_t eliminations)
 {
   if (max_label == 1)
     return 0;
-  
+
   v_array<v_array<uint32_t > > tournaments = v_init<v_array<uint32_t > >();
   v_array<uint32_t> t = v_init<uint32_t>();
-  
+
   for (uint32_t i = 0; i < max_label; i++)
-    {
-      t.push_back(i);	
-      direction d = {i,0,0,0,0,0, false};
-      e.directions.push_back(d);
-    }
-  
+  {
+    t.push_back(i);
+    direction d = {i,0,0,0,0,0, false};
+    e.directions.push_back(d);
+  }
+
   tournaments.push_back(t);
-  
+
   for (size_t i = 0; i < eliminations-1; i++)
     tournaments.push_back(v_array<uint32_t>());
-  
+
   e.all_levels.push_back(tournaments);
-  
+
   size_t level = 0;
-  
+
   uint32_t node = (uint32_t)e.directions.size();
-  
+
   while (not_empty(e.all_levels[level]))
+  {
+    v_array<v_array<uint32_t > > new_tournaments = v_init<v_array<uint32_t>>();
+    tournaments = e.all_levels[level];
+
+    for (size_t t = 0; t < tournaments.size(); t++)
     {
-      v_array<v_array<uint32_t > > new_tournaments = v_init<v_array<uint32_t>>();
-      tournaments = e.all_levels[level];
-      
-      for (size_t t = 0; t < tournaments.size(); t++)
-	{
-	  v_array<uint32_t> empty = v_init<uint32_t>();
-	  new_tournaments.push_back(empty);
-	}
-      
-      for (size_t t = 0; t < tournaments.size(); t++)
-	{
-	  for (size_t j = 0; j < tournaments[t].size()/2; j++)
-	    {
-	      uint32_t id = node++;
-	      uint32_t left = tournaments[t][2*j];
-	      uint32_t right = tournaments[t][2*j+1];
-	      
-	      direction d = {id,t,0,0,left,right, false};
-	      e.directions.push_back(d);
-	      uint32_t direction_index = (uint32_t)e.directions.size()-1;
-		if (e.directions[left].tournament == t)
-		  e.directions[left].winner = direction_index;
-		else
-		  e.directions[left].loser = direction_index;
-		if (e.directions[right].tournament == t)
-		  e.directions[right].winner = direction_index;
-		else
-		  e.directions[right].loser = direction_index;
-		if (e.directions[left].last == true)
-		  e.directions[left].winner = direction_index;
-		
-		if (tournaments[t].size() == 2 && (t == 0 || tournaments[t-1].size() == 0))
-		  {
-		    e.directions[direction_index].last = true;
-		    if (t+1 < tournaments.size())
-		      new_tournaments[t+1].push_back(id);
-		    else // winner eliminated.
-		      e.directions[direction_index].winner = 0;
-		    e.final_nodes.push_back((uint32_t)(e.directions.size()- 1));
-		  }
-		else
-		  new_tournaments[t].push_back(id);
-		if (t+1 < tournaments.size())
-		  new_tournaments[t+1].push_back(id);
-		else // loser eliminated.
-		  e.directions[direction_index].loser = 0;
-	      }
-	    if (tournaments[t].size() % 2 == 1)
-	      new_tournaments[t].push_back(tournaments[t].last());
-	  }
-	e.all_levels.push_back(new_tournaments);
-	level++;
-      }
+      v_array<uint32_t> empty = v_init<uint32_t>();
+      new_tournaments.push_back(empty);
+    }
 
-    e.last_pair = (max_label - 1)*(eliminations);
-    
-    if ( max_label > 1)
-      e.tree_height = final_depth(eliminations);
-
-    return e.last_pair + (eliminations-1);
-  }
-
-  uint32_t ect_predict(ect& e, base_learner& base, example& ec)
-  {
-    if (e.k == (size_t)1)
-      return 1;
-
-    uint32_t finals_winner = 0;
-    
-    //Binary final elimination tournament first
-    ec.l.simple = {FLT_MAX, 0., 0.};
-
-    for (size_t i = e.tree_height-1; i != (size_t)0 -1; i--)
+    for (size_t t = 0; t < tournaments.size(); t++)
+    {
+      for (size_t j = 0; j < tournaments[t].size()/2; j++)
       {
-        if ((finals_winner | (((size_t)1) << i)) <= e.errors)
-          {// a real choice exists
-            uint32_t problem_number = e.last_pair + (finals_winner | (((uint32_t)1) << i)) - 1; //This is unique.
-	  
-            base.learn(ec, problem_number);
-	  
-	    if (ec.pred.scalar > 0.)
-              finals_winner = finals_winner | (((size_t)1) << i);
-          }
-      }
+        uint32_t id = node++;
+        uint32_t left = tournaments[t][2*j];
+        uint32_t right = tournaments[t][2*j+1];
 
-    uint32_t id = e.final_nodes[finals_winner];
-    while (id >= e.k)
-      {
-	base.learn(ec, id - e.k);
+        direction d = {id,t,0,0,left,right, false};
+        e.directions.push_back(d);
+        uint32_t direction_index = (uint32_t)e.directions.size()-1;
+        if (e.directions[left].tournament == t)
+          e.directions[left].winner = direction_index;
+        else
+          e.directions[left].loser = direction_index;
+        if (e.directions[right].tournament == t)
+          e.directions[right].winner = direction_index;
+        else
+          e.directions[right].loser = direction_index;
+        if (e.directions[left].last == true)
+          e.directions[left].winner = direction_index;
 
-	if (ec.pred.scalar > 0.)
-	  id = e.directions[id].right;
-	else
-	  id = e.directions[id].left;
+        if (tournaments[t].size() == 2 && (t == 0 || tournaments[t-1].size() == 0))
+        {
+          e.directions[direction_index].last = true;
+          if (t+1 < tournaments.size())
+            new_tournaments[t+1].push_back(id);
+          else // winner eliminated.
+            e.directions[direction_index].winner = 0;
+          e.final_nodes.push_back((uint32_t)(e.directions.size()- 1));
+        }
+        else
+          new_tournaments[t].push_back(id);
+        if (t+1 < tournaments.size())
+          new_tournaments[t+1].push_back(id);
+        else // loser eliminated.
+          e.directions[direction_index].loser = 0;
       }
-    return id+1;
+      if (tournaments[t].size() % 2 == 1)
+        new_tournaments[t].push_back(tournaments[t].last());
+    }
+    e.all_levels.push_back(new_tournaments);
+    level++;
   }
 
-  bool member(size_t t, v_array<size_t> ar)
+  e.last_pair = (max_label - 1)*(eliminations);
+
+  if ( max_label > 1)
+    e.tree_height = final_depth(eliminations);
+
+  return e.last_pair + (eliminations-1);
+}
+
+uint32_t ect_predict(ect& e, base_learner& base, example& ec)
+{
+  if (e.k == (size_t)1)
+    return 1;
+
+  uint32_t finals_winner = 0;
+
+  //Binary final elimination tournament first
+  ec.l.simple = {FLT_MAX, 0., 0.};
+
+  for (size_t i = e.tree_height-1; i != (size_t)0 -1; i--)
   {
-    for (size_t i = 0; i < ar.size(); i++)
-      if (ar[i] == t)
-        return true;
-    return false;
+    if ((finals_winner | (((size_t)1) << i)) <= e.errors)
+    { // a real choice exists
+      uint32_t problem_number = e.last_pair + (finals_winner | (((uint32_t)1) << i)) - 1; //This is unique.
+
+      base.learn(ec, problem_number);
+
+      if (ec.pred.scalar > 0.)
+        finals_winner = finals_winner | (((size_t)1) << i);
+    }
   }
 
-  void ect_train(ect& e, base_learner& base, example& ec)
+  uint32_t id = e.final_nodes[finals_winner];
+  while (id >= e.k)
   {
-    if (e.k == 1)//nothing to do
-      return;
-    MULTICLASS::label_t mc = ec.l.multi;
-  
-    label_data simple_temp;
+    base.learn(ec, id - e.k);
 
-    simple_temp.initial = 0.;
-    simple_temp.weight = mc.weight;
-    
-    e.tournaments_won.erase();
-
-    uint32_t id = e.directions[mc.label - 1].winner;
-    bool left = e.directions[id].left == mc.label - 1;
-    do
-      {
-	if (left)
-	  simple_temp.label = -1;
-	else
-	  simple_temp.label = 1;
-	
-	ec.l.simple = simple_temp;
-	base.learn(ec, id-e.k);
-	ec.l.simple.weight = 0.;
-	base.learn(ec, id-e.k);//inefficient, we should extract final prediction exactly.
-
-	bool won = ec.pred.scalar * simple_temp.label > 0;
-
-	if (won)
-	  {
-	    if (!e.directions[id].last)
-	      left = e.directions[e.directions[id].winner].left == id;
-	    else
-	      e.tournaments_won.push_back(true);
-	    id = e.directions[id].winner;
-	  }
-	else
-	  {
-	    if (!e.directions[id].last)
-	      {
-		left = e.directions[e.directions[id].loser].left == id;
-		if (e.directions[id].loser == 0)
-		  e.tournaments_won.push_back(false);
-	      }
-	    else
-	      e.tournaments_won.push_back(false);
-	    id = e.directions[id].loser;
-	  }
-      }
-    while(id != 0);
-      
-    if (e.tournaments_won.size() < 1)
-      cout << "badness!" << endl;
-
-    //tournaments_won is a bit vector determining which tournaments the label won.
-    for (size_t i = 0; i < e.tree_height; i++)
-      {
-        for (uint32_t j = 0; j < e.tournaments_won.size()/2; j++)
-          {
-            bool left = e.tournaments_won[j*2];
-            bool right = e.tournaments_won[j*2+1];
-            if (left == right)//no query to do
-              e.tournaments_won[j] = left;
-            else //query to do
-              {
-                if (left) 
-                  simple_temp.label = -1;
-                else
-                  simple_temp.label = 1;
-		simple_temp.weight = (float)(1 << (e.tree_height -i -1));
-                ec.l.simple = simple_temp;
-	      
-                uint32_t problem_number = e.last_pair + j*(1 << (i+1)) + (1 << i) -1;
-		
-		base.learn(ec, problem_number);
-		
-		if (ec.pred.scalar > 0.)
-                  e.tournaments_won[j] = right;
-                else
-                  e.tournaments_won[j] = left;
-              }
-            if (e.tournaments_won.size() %2 == 1)
-              e.tournaments_won[e.tournaments_won.size()/2] = e.tournaments_won[e.tournaments_won.size()-1];
-            e.tournaments_won.end = e.tournaments_won.begin+(1+e.tournaments_won.size())/2;
-          }
-      }
+    if (ec.pred.scalar > 0.)
+      id = e.directions[id].right;
+    else
+      id = e.directions[id].left;
   }
+  return id+1;
+}
 
-  void predict(ect& e, base_learner& base, example& ec) {
-    MULTICLASS::label_t mc = ec.l.multi;
-    if (mc.label == 0 || (mc.label > e.k && mc.label != (uint32_t)-1))
-      cout << "label " << mc.label << " is not in {1,"<< e.k << "} This won't work right." << endl;
-    ec.pred.multiclass = ect_predict(e, base, ec);
-    ec.l.multi = mc;
-  }
+bool member(size_t t, v_array<size_t> ar)
+{
+  for (size_t i = 0; i < ar.size(); i++)
+    if (ar[i] == t)
+      return true;
+  return false;
+}
 
-  void learn(ect& e, base_learner& base, example& ec)
+void ect_train(ect& e, base_learner& base, example& ec)
+{
+  if (e.k == 1)//nothing to do
+    return;
+  MULTICLASS::label_t mc = ec.l.multi;
+
+  label_data simple_temp;
+
+  simple_temp.initial = 0.;
+  simple_temp.weight = mc.weight;
+
+  e.tournaments_won.erase();
+
+  uint32_t id = e.directions[mc.label - 1].winner;
+  bool left = e.directions[id].left == mc.label - 1;
+  do
   {
-    MULTICLASS::label_t mc = ec.l.multi;
-    predict(e, base, ec);
-    uint32_t pred = ec.pred.multiclass;
+    if (left)
+      simple_temp.label = -1;
+    else
+      simple_temp.label = 1;
 
-    if (mc.label != (uint32_t)-1)
-      ect_train(e, base, ec);
-    ec.l.multi = mc;
-    ec.pred.multiclass = pred;
-  }
+    ec.l.simple = simple_temp;
+    base.learn(ec, id-e.k);
+    ec.l.simple.weight = 0.;
+    base.learn(ec, id-e.k);//inefficient, we should extract final prediction exactly.
 
-  void finish(ect& e)
-  {
-    for (size_t l = 0; l < e.all_levels.size(); l++)
+    bool won = ec.pred.scalar * simple_temp.label > 0;
+
+    if (won)
+    {
+      if (!e.directions[id].last)
+        left = e.directions[e.directions[id].winner].left == id;
+      else
+        e.tournaments_won.push_back(true);
+      id = e.directions[id].winner;
+    }
+    else
+    {
+      if (!e.directions[id].last)
       {
-	for (size_t t = 0; t < e.all_levels[l].size(); t++)
-	  e.all_levels[l][t].delete_v();
-	e.all_levels[l].delete_v();
+        left = e.directions[e.directions[id].loser].left == id;
+        if (e.directions[id].loser == 0)
+          e.tournaments_won.push_back(false);
       }
-    e.final_nodes.delete_v();
-
-    e.up_directions.delete_v();
-
-    e.directions.delete_v();
-
-    e.down_directions.delete_v();
-
-    e.tournaments_won.delete_v();
+      else
+        e.tournaments_won.push_back(false);
+      id = e.directions[id].loser;
+    }
   }
+  while(id != 0);
+
+  if (e.tournaments_won.size() < 1)
+    cout << "badness!" << endl;
+
+  //tournaments_won is a bit vector determining which tournaments the label won.
+  for (size_t i = 0; i < e.tree_height; i++)
+  {
+    for (uint32_t j = 0; j < e.tournaments_won.size()/2; j++)
+    {
+      bool left = e.tournaments_won[j*2];
+      bool right = e.tournaments_won[j*2+1];
+      if (left == right)//no query to do
+        e.tournaments_won[j] = left;
+      else //query to do
+      {
+        if (left)
+          simple_temp.label = -1;
+        else
+          simple_temp.label = 1;
+        simple_temp.weight = (float)(1 << (e.tree_height -i -1));
+        ec.l.simple = simple_temp;
+
+        uint32_t problem_number = e.last_pair + j*(1 << (i+1)) + (1 << i) -1;
+
+        base.learn(ec, problem_number);
+
+        if (ec.pred.scalar > 0.)
+          e.tournaments_won[j] = right;
+        else
+          e.tournaments_won[j] = left;
+      }
+      if (e.tournaments_won.size() %2 == 1)
+        e.tournaments_won[e.tournaments_won.size()/2] = e.tournaments_won[e.tournaments_won.size()-1];
+      e.tournaments_won.end = e.tournaments_won.begin+(1+e.tournaments_won.size())/2;
+    }
+  }
+}
+
+void predict(ect& e, base_learner& base, example& ec) {
+  MULTICLASS::label_t mc = ec.l.multi;
+  if (mc.label == 0 || (mc.label > e.k && mc.label != (uint32_t)-1))
+    cout << "label " << mc.label << " is not in {1,"<< e.k << "} This won't work right." << endl;
+  ec.pred.multiclass = ect_predict(e, base, ec);
+  ec.l.multi = mc;
+}
+
+void learn(ect& e, base_learner& base, example& ec)
+{
+  MULTICLASS::label_t mc = ec.l.multi;
+  predict(e, base, ec);
+  uint32_t pred = ec.pred.multiclass;
+
+  if (mc.label != (uint32_t)-1)
+    ect_train(e, base, ec);
+  ec.l.multi = mc;
+  ec.pred.multiclass = pred;
+}
+
+void finish(ect& e)
+{
+  for (size_t l = 0; l < e.all_levels.size(); l++)
+  {
+    for (size_t t = 0; t < e.all_levels[l].size(); t++)
+      e.all_levels[l][t].delete_v();
+    e.all_levels[l].delete_v();
+  }
+  e.final_nodes.delete_v();
+
+  e.up_directions.delete_v();
+
+  e.directions.delete_v();
+
+  e.down_directions.delete_v();
+
+  e.tournaments_won.delete_v();
+}
 
 base_learner* ect_setup(vw& all)
 {
   if (missing_option<size_t, true>(all, "ect", "Error correcting tournament with <k> labels"))
     return nullptr;
   new_options(all, "Error Correcting Tournament options")
-    ("error", po::value<size_t>()->default_value(0), "error in ECT");
+  ("error", po::value<size_t>()->default_value(0), "error in ECT");
   add_options(all);
-  
+
   ect& data = calloc_or_die<ect>();
   data.k = (int)all.vm["ect"].as<size_t>();
   data.errors = (uint32_t)all.vm["error"].as<size_t>();
   //append error flag to options_from_file so it is saved in regressor file later
   *all.file_options << " --error " << data.errors;
-  
+
   size_t wpp = create_circuit(data, data.k, data.errors+1);
-  
+
   learner<ect>& l = init_multiclass_learner(&data, setup_base(all), learn, predict, all.p, wpp);
   l.set_finish(finish);
   return make_base(l);

--- a/vowpalwabbit/example.cc
+++ b/vowpalwabbit/example.cc
@@ -4,34 +4,34 @@ individual contributors. All rights reserved.  Released under a BSD (revised)
 license as described in the file LICENSE.
  */
 #include <stdint.h>
-#include "gd.h"  
-  
-int compare_feature(const void* p1, const void* p2) {  
-  feature* f1 = (feature*) p1;  
-  feature* f2 = (feature*) p2;  
+#include "gd.h"
+
+int compare_feature(const void* p1, const void* p2) {
+  feature* f1 = (feature*) p1;
+  feature* f2 = (feature*) p2;
   if(f1->weight_index < f2->weight_index) return -1;
   else if(f1->weight_index > f2->weight_index) return 1;
   else return 0;
-}  
-  
-float collision_cleanup(feature* feature_map, size_t& len) {  
-    
- int pos = 0;  
- float sum_sq = 0.;  
-  
- for(uint32_t i = 1;i < len;i++) {  
-    if(feature_map[i].weight_index == feature_map[pos].weight_index)   
-      feature_map[pos].x += feature_map[i].x;  
-    else {  
-      sum_sq += feature_map[pos].x*feature_map[pos].x;  
-      feature_map[++pos] = feature_map[i];            
-    }  
-  }  
-  sum_sq += feature_map[pos].x*feature_map[pos].x;  
+}
+
+float collision_cleanup(feature* feature_map, size_t& len) {
+
+  int pos = 0;
+  float sum_sq = 0.;
+
+  for(uint32_t i = 1; i < len; i++) {
+    if(feature_map[i].weight_index == feature_map[pos].weight_index)
+      feature_map[pos].x += feature_map[i].x;
+    else {
+      sum_sq += feature_map[pos].x*feature_map[pos].x;
+      feature_map[++pos] = feature_map[i];
+    }
+  }
+  sum_sq += feature_map[pos].x*feature_map[pos].x;
   len = pos+1;
-  return sum_sq;  
-}  
-  
+  return sum_sq;
+}
+
 audit_data copy_audit_data(audit_data &src) {
   audit_data dst;
   if (src.space != NULL) {
@@ -66,7 +66,7 @@ void copy_example_data(bool audit, example* dst, example* src)
   //  for (size_t i=0; i<256; i++)
   for (unsigned char*c = src->indices.begin; c != src->indices.end; ++c)
     copy_array(dst->atomics[*c], src->atomics[*c]);
-    //copy_array(dst->atomics[i], src->atomics[i]);
+  //copy_array(dst->atomics[i], src->atomics[i]);
   dst->ft_offset = src->ft_offset;
 
   if (audit)
@@ -78,7 +78,7 @@ void copy_example_data(bool audit, example* dst, example* src)
         }
       copy_array(dst->audit_features[i], src->audit_features[i], copy_audit_data);
     }
-  
+
   dst->num_features = src->num_features;
   dst->partial_prediction = src->partial_prediction;
   copy_array(dst->topic_predictions, src->topic_predictions);
@@ -90,7 +90,8 @@ void copy_example_data(bool audit, example* dst, example* src)
   dst->test_only = src->test_only;
   dst->end_pass = src->end_pass;
   dst->sorted = src->sorted;
-  dst->in_use = src->in_use;}
+  dst->in_use = src->in_use;
+}
 
 void copy_example_data(bool audit, example* dst, example* src, size_t label_size, void(*copy_label)(void*,void*)) {
   copy_example_data(audit, dst, src);
@@ -99,80 +100,80 @@ void copy_example_data(bool audit, example* dst, example* src, size_t label_size
 
 }
 
-struct features_and_source 
+struct features_and_source
 {
-  v_array<feature> feature_map; //map to store sparse feature vectors  
+  v_array<feature> feature_map; //map to store sparse feature vectors
   uint32_t stride_shift;
   uint32_t mask;
   weight* base;
   vw* all;
 };
 
-void vec_store(features_and_source& p, float fx, uint32_t fi) {    
+void vec_store(features_and_source& p, float fx, uint32_t fi) {
   feature f = {fx, (uint32_t)(fi >> p.stride_shift) & p.mask};
   p.feature_map.push_back(f);
-}  
+}
 
 namespace VW {
-  feature* get_features(vw& all, example* ec, size_t& feature_map_len)
+feature* get_features(vw& all, example* ec, size_t& feature_map_len)
 {
-	features_and_source fs;
-	fs.stride_shift = all.reg.stride_shift;
-	fs.mask = (uint32_t)all.reg.weight_mask >> all.reg.stride_shift;
-	fs.base = all.reg.weight_vector;
-	fs.all = &all;
-	fs.feature_map = v_init<feature>();
-	GD::foreach_feature<features_and_source, uint32_t, vec_store>(all, *ec, fs); 		
-	feature_map_len = fs.feature_map.size();
-	return fs.feature_map.begin;
+  features_and_source fs;
+  fs.stride_shift = all.reg.stride_shift;
+  fs.mask = (uint32_t)all.reg.weight_mask >> all.reg.stride_shift;
+  fs.base = all.reg.weight_vector;
+  fs.all = &all;
+  fs.feature_map = v_init<feature>();
+  GD::foreach_feature<features_and_source, uint32_t, vec_store>(all, *ec, fs);
+  feature_map_len = fs.feature_map.size();
+  return fs.feature_map.begin;
 }
 
 void return_features(feature* f)
 {
-	if (f != nullptr)
-		free(f);
+  if (f != nullptr)
+    free(f);
 }
 }
 
-flat_example* flatten_example(vw& all, example *ec) 
+flat_example* flatten_example(vw& all, example *ec)
 {
-  flat_example& fec = calloc_or_die<flat_example>();  
-	fec.l = ec->l;
+  flat_example& fec = calloc_or_die<flat_example>();
+  fec.l = ec->l;
 
-	fec.tag_len = ec->tag.size();
-	if (fec.tag_len >0)
-	  {
-	    fec.tag = calloc_or_die<char>(fec.tag_len+1);
-	    memcpy(fec.tag,ec->tag.begin, fec.tag_len);
-	  }
+  fec.tag_len = ec->tag.size();
+  if (fec.tag_len >0)
+  {
+    fec.tag = calloc_or_die<char>(fec.tag_len+1);
+    memcpy(fec.tag,ec->tag.begin, fec.tag_len);
+  }
 
-	fec.example_counter = ec->example_counter;  
-	fec.ft_offset = ec->ft_offset;  
-	fec.num_features = ec->num_features;  
-        
-	fec.feature_map = VW::get_features(all, ec, fec.feature_map_len);
+  fec.example_counter = ec->example_counter;
+  fec.ft_offset = ec->ft_offset;
+  fec.num_features = ec->num_features;
 
-	return &fec;  
+  fec.feature_map = VW::get_features(all, ec, fec.feature_map_len);
+
+  return &fec;
 }
 
-flat_example* flatten_sort_example(vw& all, example *ec) 
+flat_example* flatten_sort_example(vw& all, example *ec)
 {
   flat_example* fec = flatten_example(all, ec);
-  qsort(fec->feature_map, fec->feature_map_len, sizeof(feature), compare_feature);  
+  qsort(fec->feature_map, fec->feature_map_len, sizeof(feature), compare_feature);
   fec->total_sum_feat_sq = collision_cleanup(fec->feature_map, fec->feature_map_len);
   return fec;
 }
 
-void free_flatten_example(flat_example* fec) 
-{  //note: The label memory should be freed by by freeing the original example.
+void free_flatten_example(flat_example* fec)
+{ //note: The label memory should be freed by by freeing the original example.
   if (fec)
-    {
-      if (fec->feature_map_len > 0)
-	free(fec->feature_map);
-      if (fec->tag_len > 0)
-	free(fec->tag);
-      free(fec);
-    }
+  {
+    if (fec->feature_map_len > 0)
+      free(fec->feature_map);
+    if (fec->tag_len > 0)
+      free(fec->tag);
+    free(fec);
+  }
 }
 
 namespace VW {
@@ -197,25 +198,25 @@ void dealloc_example(void(*delete_label)(void*), example&ec, void(*delete_predic
     delete_prediction(&ec.pred);
 
   ec.tag.delete_v();
-      
+
   ec.topic_predictions.delete_v();
 
   for (size_t j = 0; j < 256; j++)
-    {
-      ec.atomics[j].delete_v();
+  {
+    ec.atomics[j].delete_v();
 
-      if (ec.audit_features[j].begin != ec.audit_features[j].end_array)
-        {
-          for (audit_data* temp = ec.audit_features[j].begin; 
-               temp != ec.audit_features[j].end; temp++)
-            if (temp->alloced) {
-              free(temp->space);
-              free(temp->feature);
-              temp->alloced = false;
-            }
-	  ec.audit_features[j].delete_v();
+    if (ec.audit_features[j].begin != ec.audit_features[j].end_array)
+    {
+      for (audit_data* temp = ec.audit_features[j].begin;
+           temp != ec.audit_features[j].end; temp++)
+        if (temp->alloced) {
+          free(temp->space);
+          free(temp->feature);
+          temp->alloced = false;
         }
+      ec.audit_features[j].delete_v();
     }
+  }
   ec.indices.delete_v();
 }
 }

--- a/vowpalwabbit/example.h
+++ b/vowpalwabbit/example.h
@@ -26,7 +26,9 @@ const size_t dictionary_namespace  = 135; // this is \x87
 struct feature {
   float x;
   uint32_t weight_index;
-  bool operator==(feature j){return weight_index == j.weight_index;}
+  bool operator==(feature j) {
+    return weight_index == j.weight_index;
+  }
 };
 
 struct audit_data {
@@ -53,7 +55,7 @@ typedef union {
 } polyprediction;
 
 struct example // core example datatype.
-{//output prediction
+{ //output prediction
   polyprediction pred;
 
   // input fields
@@ -63,9 +65,9 @@ struct example // core example datatype.
   v_array<unsigned char> indices;
   v_array<feature> atomics[256]; // raw parsed data
   uint32_t ft_offset;
-  
+
   //helpers
-  v_array<audit_data> audit_features[256];  
+  v_array<audit_data> audit_features[256];
   size_t num_features;//precomputed, cause it's fast&easy.
   float partial_prediction;//shared data for prediction.
   float updated_prediction;//estimated post-update prediction.
@@ -82,23 +84,23 @@ struct example // core example datatype.
   bool in_use; //in use or not (for the parser)
 };
 
- struct vw;  
- 
-struct flat_example 
+struct vw;
+
+struct flat_example
 {
   polylabel l;
 
   size_t tag_len;
-  char* tag;//An identifier for the example.  
-  
-  size_t example_counter;  
-  uint32_t ft_offset;  
+  char* tag;//An identifier for the example.
+
+  size_t example_counter;
+  uint32_t ft_offset;
   float global_weight;
-  
-  size_t num_features;//precomputed, cause it's fast&easy.  
+
+  size_t num_features;//precomputed, cause it's fast&easy.
   float total_sum_feat_sq;//precomputed, cause it's kind of fast & easy.
   size_t feature_map_len;
-  feature* feature_map; //map to store sparse feature vectors  
+  feature* feature_map; //map to store sparse feature vectors
 };
 
 flat_example* flatten_example(vw& all, example *ec);
@@ -108,12 +110,12 @@ void free_flatten_example(flat_example* fec);
 inline int example_is_newline(example& ec)
 {
   // if only index is constant namespace or no index
-  return ((ec.indices.size() == 0) || 
+  return ((ec.indices.size() == 0) ||
           ((ec.indices.size() == 1) &&
            (ec.indices.last() == constant_namespace)));
 }
 
 inline bool valid_ns(char c)
 {
-	return !(c == '|' || c == ':');
+  return !(c == '|' || c == ':');
 }

--- a/vowpalwabbit/expreplay.h
+++ b/vowpalwabbit/expreplay.h
@@ -5,7 +5,7 @@
 #include "rand48.h"
 
 namespace ExpReplay {
-  
+
 struct expreplay {
   vw* all;
   size_t N;      //how big is the buffer?
@@ -27,7 +27,7 @@ void predict_or_learn(expreplay& er, LEARNER::base_learner& base, example& ec) {
     if (er.filled[n])
       base.learn(er.buf[n]);
   }
-  
+
   size_t n = (size_t)(frand48() * (float)er.N);
   if (er.filled[n])
     base.learn(er.buf[n]);
@@ -67,7 +67,8 @@ void finish(expreplay& er) {
 
 template<char er_level, label_parser& lp>
 LEARNER::base_learner* expreplay_setup(vw& all) {
-  string replay_string = "replay_"; replay_string += er_level;
+  string replay_string = "replay_";
+  replay_string += er_level;
   if (missing_option<size_t, true>(all, replay_string.c_str(), "use experience replay at a specified level [b=classification/regression, m=multiclass, c=cost sensitive] with specified buffer size"))
     return nullptr;
 
@@ -77,10 +78,10 @@ LEARNER::base_learner* expreplay_setup(vw& all) {
 
   string replay_count_string = replay_string;
   replay_count_string += "_count";
-  
+
   size_t rc = 1;
   new_options(all, "Experience Replay options")
-      (replay_count_string.c_str(), po::value<size_t>(&rc)->default_value(1), "how many times (in expectation) should each example be played (default: 1 = permuting)");
+  (replay_count_string.c_str(), po::value<size_t>(&rc)->default_value(1), "how many times (in expectation) should each example be played (default: 1 = permuting)");
   add_options(all);
 
   if (N == 0) return nullptr;
@@ -96,10 +97,10 @@ LEARNER::base_learner* expreplay_setup(vw& all) {
 
   er.filled = calloc_or_die<bool>(er.N);
   er.replay_count = rc;
-    
+
   if (! all.quiet)
     cerr << "experience replay level=" << er_level << ", buffer=" << er.N << ", replay count=" << er.replay_count << endl;
-  
+
   LEARNER::base_learner* base = setup_base(all);
   LEARNER::learner<expreplay>* l = &init_learner(&er, base, predict_or_learn<true,lp>, predict_or_learn<false,lp>);
   l->set_finish(finish<lp>);

--- a/vowpalwabbit/ezexample.h
+++ b/vowpalwabbit/ezexample.h
@@ -8,12 +8,13 @@ typedef uint32_t fid;
 
 struct vw_namespace {
   char namespace_letter;
-public: vw_namespace(const char c) : namespace_letter(c) {}
+public:
+  vw_namespace(const char c) : namespace_letter(c) {}
 };
 
 
 class ezexample {
- private:
+private:
   vw*vw_ref;
   vw*vw_par_ref;   // an extra parser if we're multithreaded
   bool is_multiline;
@@ -61,7 +62,8 @@ class ezexample {
     vw_par_ref = (this_vw_parser == nullptr) ? this_vw : this_vw_parser;
     is_multiline = multiline;
 
-    str[0] = 0; str[1] = 0;
+    str[0] = 0;
+    str[1] = 0;
     current_seed = 0;
     current_ns = 0;
 
@@ -73,7 +75,7 @@ class ezexample {
     example_changed_since_prediction = true;
   }
 
-  
+
   void setup_for_predict() {
     static example* empty_example = is_multiline ? VW::read_example(*vw_par_ref, (char*)"") : nullptr;
     if (example_changed_since_prediction) {
@@ -84,13 +86,13 @@ class ezexample {
     }
   }
 
- public:
+public:
 
   // REAL FUNCTIONALITY
   // create a new ezexample by asking the vw parser for an example
   ezexample(vw*this_vw, bool multiline=false, vw*this_vw_parser=nullptr) {
     setup_new_ezexample(this_vw, multiline, this_vw_parser);
-    example_copies = v_init<example*>();    
+    example_copies = v_init<example*>();
     ec = get_new_example();
     we_create_ec = true;
 
@@ -116,7 +118,7 @@ class ezexample {
       current_seed = VW::hash_space(*vw_ref, str);
     }
   }
-  
+
   ~ezexample() { // calls finish_example *only* if we created our own example!
     if (ec->in_use)
       VW::finish_example(*vw_par_ref, ec);
@@ -181,7 +183,9 @@ class ezexample {
     return fint;
   }
 
-  inline fid addf(fid fint, float v) { return addf(current_ns, fint, v); }
+  inline fid addf(fid fint, float v) {
+    return addf(current_ns, fint, v);
+  }
 
   // copy an entire namespace from this other example, you can even give it a new namespace name if you want!
   void add_other_example_ns(example& other, char other_ns, char to_ns) {
@@ -198,8 +202,12 @@ class ezexample {
     add_other_example_ns(other, ns, ns);
   }
 
-  void add_other_example_ns(ezexample& other, char other_ns, char to_ns) { add_other_example_ns(*other.ec, other_ns, to_ns); }
-  void add_other_example_ns(ezexample& other, char ns                  ) { add_other_example_ns(*other.ec, ns); }
+  void add_other_example_ns(ezexample& other, char other_ns, char to_ns) {
+    add_other_example_ns(*other.ec, other_ns, to_ns);
+  }
+  void add_other_example_ns(ezexample& other, char ns                  ) {
+    add_other_example_ns(*other.ec, ns);
+  }
 
   inline ezexample& set_label(string label) {
     VW::parse_example_label(*vw_par_ref, *ec, label);
@@ -220,24 +228,26 @@ class ezexample {
 
     for (vector<string>::iterator i = vw_ref->pairs.begin(); i != vw_ref->pairs.end(); i++) {
       quadratic_features_num
-        += (ec->atomics[(int)(*i)[0]].end - ec->atomics[(int)(*i)[0]].begin)
-        *  (ec->atomics[(int)(*i)[1]].end - ec->atomics[(int)(*i)[1]].begin);
+      += (ec->atomics[(int)(*i)[0]].end - ec->atomics[(int)(*i)[0]].begin)
+         *  (ec->atomics[(int)(*i)[1]].end - ec->atomics[(int)(*i)[1]].begin);
       quadratic_features_sqr
-        += ec->sum_feat_sq[(int)(*i)[0]]
-        *  ec->sum_feat_sq[(int)(*i)[1]];
+      += ec->sum_feat_sq[(int)(*i)[0]]
+         *  ec->sum_feat_sq[(int)(*i)[1]];
     }
     ec->num_features      += quadratic_features_num;
     ec->total_sum_feat_sq += quadratic_features_sqr;
   }
 
-  size_t get_num_features() { return ec->num_features; }
+  size_t get_num_features() {
+    return ec->num_features;
+  }
 
   example* get() {
     if (example_changed_since_prediction)
       mini_setup_example();
     return ec;
   }
-  
+
   float predict() {
     setup_for_predict();
     return ec->pred.scalar;
@@ -284,46 +294,124 @@ class ezexample {
       example_copies.erase();
     }
   }
-    
+
 
   // HELPER FUNCTIONALITY
 
-  inline fid hash(string fstr)         { return VW::hash_feature(*vw_ref, fstr, current_seed); }
-  inline fid hash(char*  fstr)         { return VW::hash_feature_cstr(*vw_ref, fstr, current_seed); }
-  inline fid hash(char c, string fstr) { str[0] = c; return VW::hash_feature(*vw_ref, fstr, VW::hash_space(*vw_ref, str)); }
-  inline fid hash(char c, char*  fstr) { str[0] = c; return VW::hash_feature_cstr(*vw_ref, fstr, VW::hash_space(*vw_ref, str)); }
+  inline fid hash(string fstr)         {
+    return VW::hash_feature(*vw_ref, fstr, current_seed);
+  }
+  inline fid hash(char*  fstr)         {
+    return VW::hash_feature_cstr(*vw_ref, fstr, current_seed);
+  }
+  inline fid hash(char c, string fstr) {
+    str[0] = c;
+    return VW::hash_feature(*vw_ref, fstr, VW::hash_space(*vw_ref, str));
+  }
+  inline fid hash(char c, char*  fstr) {
+    str[0] = c;
+    return VW::hash_feature_cstr(*vw_ref, fstr, VW::hash_space(*vw_ref, str));
+  }
 
-  inline fid addf(fid    fint           ) { return addf(fint      , 1.0); }
-  inline fid addf(string fstr, float val) { return addf(hash(fstr), val); }
-  inline fid addf(string fstr           ) { return addf(hash(fstr), 1.0); }
+  inline fid addf(fid    fint           ) {
+    return addf(fint      , 1.0);
+  }
+  inline fid addf(string fstr, float val) {
+    return addf(hash(fstr), val);
+  }
+  inline fid addf(string fstr           ) {
+    return addf(hash(fstr), 1.0);
+  }
 
-  inline fid addf(char ns, fid    fint           ) { return addf(ns, fint          , 1.0); }
-  inline fid addf(char ns, string fstr, float val) { return addf(ns, hash(ns, fstr), val); }
-  inline fid addf(char ns, string fstr           ) { return addf(ns, hash(ns, fstr), 1.0); }
+  inline fid addf(char ns, fid    fint           ) {
+    return addf(ns, fint          , 1.0);
+  }
+  inline fid addf(char ns, string fstr, float val) {
+    return addf(ns, hash(ns, fstr), val);
+  }
+  inline fid addf(char ns, string fstr           ) {
+    return addf(ns, hash(ns, fstr), 1.0);
+  }
 
-  inline ezexample& operator()(const vw_namespace&n) { addns(n.namespace_letter); return *this; }
-  
-  inline ezexample& operator()(fid         fint           ) { addf(fint, 1.0); return *this; }
-  inline ezexample& operator()(string      fstr           ) { addf(fstr, 1.0); return *this; }
-  inline ezexample& operator()(const char* fstr           ) { addf(fstr, 1.0); return *this; }
-  inline ezexample& operator()(fid         fint, float val) { addf(fint, val); return *this; }
-  inline ezexample& operator()(string      fstr, float val) { addf(fstr, val); return *this; }
-  inline ezexample& operator()(const char* fstr, float val) { addf(fstr, val); return *this; }
+  inline ezexample& operator()(const vw_namespace&n) {
+    addns(n.namespace_letter);
+    return *this;
+  }
 
-  inline ezexample& operator()(char ns, fid         fint           ) { addf(ns, fint, 1.0); return *this; }
-  inline ezexample& operator()(char ns, string      fstr           ) { addf(ns, fstr, 1.0); return *this; }
-  inline ezexample& operator()(char ns, const char* fstr           ) { addf(ns, fstr, 1.0); return *this; }
-  inline ezexample& operator()(char ns, fid         fint, float val) { addf(ns, fint, val); return *this; }
-  inline ezexample& operator()(char ns, string      fstr, float val) { addf(ns, fstr, val); return *this; }
-  inline ezexample& operator()(char ns, const char* fstr, float val) { addf(ns, fstr, val); return *this; }
+  inline ezexample& operator()(fid         fint           ) {
+    addf(fint, 1.0);
+    return *this;
+  }
+  inline ezexample& operator()(string      fstr           ) {
+    addf(fstr, 1.0);
+    return *this;
+  }
+  inline ezexample& operator()(const char* fstr           ) {
+    addf(fstr, 1.0);
+    return *this;
+  }
+  inline ezexample& operator()(fid         fint, float val) {
+    addf(fint, val);
+    return *this;
+  }
+  inline ezexample& operator()(string      fstr, float val) {
+    addf(fstr, val);
+    return *this;
+  }
+  inline ezexample& operator()(const char* fstr, float val) {
+    addf(fstr, val);
+    return *this;
+  }
 
-  inline ezexample& operator()(  example&other, char other_ns, char to_ns) { add_other_example_ns(other, other_ns, to_ns); return *this; }
-  inline ezexample& operator()(  example&other, char ns                  ) { add_other_example_ns(other, ns);              return *this; }
-  inline ezexample& operator()(ezexample&other, char other_ns, char to_ns) { add_other_example_ns(other, other_ns, to_ns); return *this; }
-  inline ezexample& operator()(ezexample&other, char ns                  ) { add_other_example_ns(other, ns);              return *this; }
+  inline ezexample& operator()(char ns, fid         fint           ) {
+    addf(ns, fint, 1.0);
+    return *this;
+  }
+  inline ezexample& operator()(char ns, string      fstr           ) {
+    addf(ns, fstr, 1.0);
+    return *this;
+  }
+  inline ezexample& operator()(char ns, const char* fstr           ) {
+    addf(ns, fstr, 1.0);
+    return *this;
+  }
+  inline ezexample& operator()(char ns, fid         fint, float val) {
+    addf(ns, fint, val);
+    return *this;
+  }
+  inline ezexample& operator()(char ns, string      fstr, float val) {
+    addf(ns, fstr, val);
+    return *this;
+  }
+  inline ezexample& operator()(char ns, const char* fstr, float val) {
+    addf(ns, fstr, val);
+    return *this;
+  }
+
+  inline ezexample& operator()(  example&other, char other_ns, char to_ns) {
+    add_other_example_ns(other, other_ns, to_ns);
+    return *this;
+  }
+  inline ezexample& operator()(  example&other, char ns                  ) {
+    add_other_example_ns(other, ns);
+    return *this;
+  }
+  inline ezexample& operator()(ezexample&other, char other_ns, char to_ns) {
+    add_other_example_ns(other, other_ns, to_ns);
+    return *this;
+  }
+  inline ezexample& operator()(ezexample&other, char ns                  ) {
+    add_other_example_ns(other, ns);
+    return *this;
+  }
 
 
-  inline ezexample& operator--() { remns(); return *this; }
+  inline ezexample& operator--() {
+    remns();
+    return *this;
+  }
 
-  inline float      operator()() { return predict(); }
+  inline float      operator()() {
+    return predict();
+  }
 };

--- a/vowpalwabbit/ftrl.cc
+++ b/vowpalwabbit/ftrl.cc
@@ -24,12 +24,12 @@ struct update_data {
 };
 
 struct ftrl {
-  vw* all; //features, finalize, l1, l2, 
+  vw* all; //features, finalize, l1, l2,
   float ftrl_alpha;
   float ftrl_beta;
-  struct update_data data;  
+  struct update_data data;
 };
-  
+
 void predict(ftrl& b, base_learner&, example& ec) {
   ec.partial_prediction = GD::inline_predict(*b.all, ec);
   ec.pred.scalar = GD::finalize_prediction(b.all->sd, ec.partial_prediction);
@@ -49,7 +49,10 @@ void multipredict(ftrl& b, base_learner&, example& ec, size_t count, size_t step
       pred[c].scalar = GD::finalize_prediction(all.sd, pred[c].scalar);
 }
 
-inline float sign(float w){ if (w < 0.) return -1.; else  return 1.;}
+inline float sign(float w) {
+  if (w < 0.) return -1.;
+  else  return 1.;
+}
 
 void inner_update_proximal(update_data& d, float x, float& wref) {
   float* w = &wref;
@@ -63,7 +66,7 @@ void inner_update_proximal(update_data& d, float x, float& wref) {
   sqrt_wW_G2 = sqrt_ng2;
   float flag = sign(w[W_ZT]);
   float fabs_zt = w[W_ZT] * flag;
-  if (fabs_zt <= d.l1_lambda) 
+  if (fabs_zt <= d.l1_lambda)
     w[W_XT] = 0.;
   else {
     float step = 1/(d.l2_lambda + (d.ftrl_beta + sqrt_wW_G2)/d.ftrl_alpha);
@@ -73,29 +76,29 @@ void inner_update_proximal(update_data& d, float x, float& wref) {
 
 void inner_update_pistol_state_and_predict(update_data& d, float x, float& wref) {
   float* w = &wref;
-  
+
   float fabs_x = fabs(x);
-  if (fabs_x > w[W_MX]) 
+  if (fabs_x > w[W_MX])
     w[W_MX]=fabs_x;
-  
+
   float squared_theta = w[W_ZT] * w[W_ZT];
   float tmp = 1.f / (d.ftrl_alpha * w[W_MX] * (w[W_G2] + w[W_MX]));
   w[W_XT] = sqrt(w[W_G2]) * d.ftrl_beta * w[W_ZT] * exp(squared_theta / 2 * tmp) * tmp;
-  
+
   d.predict +=  w[W_XT]*x;
 }
 
 void inner_update_pistol_post(update_data& d, float x, float& wref) {
   float* w = &wref;
   float gradient = d.update * x;
-  
+
   w[W_ZT] += -gradient;
   w[W_G2] += fabs(gradient);
 }
 
 void update_state_and_predict_pistol(ftrl& b, base_learner&, example& ec) {
   b.data.predict = 0;
-  
+
   GD::foreach_feature<update_data, inner_update_pistol_state_and_predict>(*b.all, ec, b.data);
   ec.partial_prediction = b.data.predict;
   ec.pred.scalar = GD::finalize_prediction(b.all->sd, ec.partial_prediction);
@@ -103,34 +106,34 @@ void update_state_and_predict_pistol(ftrl& b, base_learner&, example& ec) {
 
 void update_after_prediction_proximal(ftrl& b, example& ec) {
   b.data.update = b.all->loss->first_derivative(b.all->sd, ec.pred.scalar, ec.l.simple.label)
-    *ec.l.simple.weight;
-  
+                  *ec.l.simple.weight;
+
   GD::foreach_feature<update_data, inner_update_proximal>(*b.all, ec, b.data);
 }
 
 void update_after_prediction_pistol(ftrl& b, example& ec) {
   b.data.update = b.all->loss->first_derivative(b.all->sd, ec.pred.scalar, ec.l.simple.label)
-    *ec.l.simple.weight;
-  
-  GD::foreach_feature<update_data, inner_update_pistol_post>(*b.all, ec, b.data);  
+                  *ec.l.simple.weight;
+
+  GD::foreach_feature<update_data, inner_update_pistol_post>(*b.all, ec, b.data);
 }
 
 void learn_proximal(ftrl& a, base_learner& base, example& ec) {
   assert(ec.in_use);
-  
+
   // predict
   predict(a, base, ec);
-  
+
   //update state based on the prediction
   update_after_prediction_proximal(a,ec);
 }
 
 void learn_pistol(ftrl& a, base_learner& base, example& ec) {
   assert(ec.in_use);
-  
+
   // update state based on the example and predict
   update_state_and_predict_pistol(a, base, ec);
-  
+
   //update state based on the prediction
   update_after_prediction_pistol(a,ec);
 }
@@ -139,14 +142,14 @@ void save_load(ftrl& b, io_buf& model_file, bool read, bool text) {
   vw* all = b.all;
   if (read)
     initialize_regressor(*all);
-  
+
   if (model_file.files.size() > 0) {
     bool resume = all->save_resume;
     char buff[512];
     uint32_t text_len = sprintf(buff, ":%d\n", resume);
     bin_text_read_write_fixed(model_file,(char *)&resume, sizeof (resume), "", read, buff, text_len, text);
-    
-    if (resume) 
+
+    if (resume)
       GD::save_load_online_state(*all, model_file, read, text);
     else
       GD::save_load_regressor(*all, model_file, read, text);
@@ -157,19 +160,19 @@ base_learner* ftrl_setup(vw& all) {
   if (missing_option(all, false, "ftrl", "FTRL: Follow the Proximal Regularized Leader") &&
       missing_option(all, false, "pistol", "FTRL: Parameter-free Stochastic Learning"))
     return nullptr;
-  
+
   new_options(all, "FTRL options")
-    ("ftrl_alpha", po::value<float>(), "Learning rate for FTRL optimization")
-    ("ftrl_beta", po::value<float>(), "FTRL beta parameter");
+  ("ftrl_alpha", po::value<float>(), "Learning rate for FTRL optimization")
+  ("ftrl_beta", po::value<float>(), "FTRL beta parameter");
   add_options(all);
 
   po::variables_map& vm = all.vm;
-  
+
   ftrl& b = calloc_or_die<ftrl>();
   b.all = &all;
-  
+
   void (*learn_ptr)(ftrl&, base_learner&, example&) = nullptr;
-  
+
   string algorithm_name;
   if (vm.count("ftrl")) {
     algorithm_name = "Proximal-FTRL";
@@ -181,7 +184,7 @@ base_learner* ftrl_setup(vw& all) {
     if (vm.count("ftrl_beta"))
       b.ftrl_beta = vm["ftrl_beta"].as<float>();
     else
-      b.ftrl_beta = 0.1f;    
+      b.ftrl_beta = 0.1f;
   } else if (vm.count("pistol")) {
     algorithm_name = "PiSTOL";
     learn_ptr=learn_pistol;
@@ -192,22 +195,22 @@ base_learner* ftrl_setup(vw& all) {
     if (vm.count("ftrl_beta"))
       b.ftrl_beta = vm["ftrl_beta"].as<float>();
     else
-      b.ftrl_beta = 0.5f;  
+      b.ftrl_beta = 0.5f;
   }
   b.data.ftrl_alpha = b.ftrl_alpha;
   b.data.ftrl_beta = b.ftrl_beta;
   b.data.l1_lambda = b.all->l1_lambda;
   b.data.l2_lambda = b.all->l2_lambda;
-  
+
   all.reg.stride_shift = 2; // NOTE: for more parameter storage
-  
+
   if (!all.quiet) {
     cerr << "Enabling FTRL based optimization" << endl;
     cerr << "Algorithm used: " << algorithm_name << endl;
     cerr << "ftrl_alpha = " << b.ftrl_alpha << endl;
     cerr << "ftrl_beta = " << b.ftrl_beta << endl;
   }
-  
+
   learner<ftrl>& l = init_learner(&b, learn_ptr, 1 << all.reg.stride_shift);
   l.set_predict(predict);
   l.set_multipredict(multipredict);

--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -27,273 +27,276 @@ license as described in the file LICENSE.
 
 using namespace std;
 using namespace LEARNER;
-//todo: 
+//todo:
 //4. Factor various state out of vw&
 namespace GD
 {
-  struct gd {
-    //double normalized_sum_norm_x;
-    double total_weight;
-    size_t no_win_counter;
-    size_t early_stop_thres;
-    float initial_constant;
-    float neg_norm_power;
-    float neg_power_t;
-    float sparse_l2;
-    float update_multiplier;
-    void (*predict)(gd&, base_learner&, example&);
-    void (*learn)(gd&, base_learner&, example&);
-    void (*update)(gd&, base_learner&, example&);
-    void (*multipredict)(gd&, base_learner&, example&, size_t, size_t, polyprediction*, bool);
-    bool normalized;
-    bool adaptive;
+struct gd {
+  //double normalized_sum_norm_x;
+  double total_weight;
+  size_t no_win_counter;
+  size_t early_stop_thres;
+  float initial_constant;
+  float neg_norm_power;
+  float neg_power_t;
+  float sparse_l2;
+  float update_multiplier;
+  void (*predict)(gd&, base_learner&, example&);
+  void (*learn)(gd&, base_learner&, example&);
+  void (*update)(gd&, base_learner&, example&);
+  void (*multipredict)(gd&, base_learner&, example&, size_t, size_t, polyprediction*, bool);
+  bool normalized;
+  bool adaptive;
 
-    vw* all; //parallel, features, parameters
-  };
+  vw* all; //parallel, features, parameters
+};
 
-  void sync_weights(vw& all);
+void sync_weights(vw& all);
 
-  inline float quake_InvSqrt(float x)
-  {    // Carmack/Quake/SGI fast method:
-	  float xhalf = 0.5f * x;
-	  int i = *(int*)&x; // store floating-point bits in integer
-	  i = 0x5f3759d5 - (i >> 1); // initial guess for Newton's method
-	  x = *(float*)&i; // convert new bits into float
-	  x = x*(1.5f - xhalf*x*x); // One round of Newton's method
-	  return x;
-  }
+inline float quake_InvSqrt(float x)
+{ // Carmack/Quake/SGI fast method:
+  float xhalf = 0.5f * x;
+  int i = *(int*)&x; // store floating-point bits in integer
+  i = 0x5f3759d5 - (i >> 1); // initial guess for Newton's method
+  x = *(float*)&i; // convert new bits into float
+  x = x*(1.5f - xhalf*x*x); // One round of Newton's method
+  return x;
+}
 
-  static inline float InvSqrt(float x)
-  {
+static inline float InvSqrt(float x)
+{
 #if !defined(VW_NO_INLINE_SIMD)
 #  if defined(__ARM_NEON__)
-    // Propagate into vector
-    float32x2_t v1 = vdup_n_f32(x);
-    // Estimate
-    float32x2_t e1 = vrsqrte_f32(v1);
-    // N-R iteration 1
-    float32x2_t e2 = vmul_f32(e1, vrsqrts_f32(v1, vmul_f32(e1, e1)));
-    // N-R iteration 2
-    float32x2_t e3 = vmul_f32(e2, vrsqrts_f32(v1, vmul_f32(e2, e2)));
-    // Extract result
-    return vget_lane_f32(e3, 0);
+  // Propagate into vector
+  float32x2_t v1 = vdup_n_f32(x);
+  // Estimate
+  float32x2_t e1 = vrsqrte_f32(v1);
+  // N-R iteration 1
+  float32x2_t e2 = vmul_f32(e1, vrsqrts_f32(v1, vmul_f32(e1, e1)));
+  // N-R iteration 2
+  float32x2_t e3 = vmul_f32(e2, vrsqrts_f32(v1, vmul_f32(e2, e2)));
+  // Extract result
+  return vget_lane_f32(e3, 0);
 #  elif (defined(__SSE2__) || defined(_M_AMD64) || defined(_M_X64))
-    __m128 eta = _mm_load_ss(&x);
-    eta = _mm_rsqrt_ss(eta);
-    _mm_store_ss(&x, eta);
+  __m128 eta = _mm_load_ss(&x);
+  eta = _mm_rsqrt_ss(eta);
+  _mm_store_ss(&x, eta);
 #else
-	  x = quake_InvSqrt(x);
+  x = quake_InvSqrt(x);
 #  endif
 #else
-	  x = quake_InvSqrt(x);
+  x = quake_InvSqrt(x);
 #endif
 
-    return x;
-  }
-  
-  template<bool sqrt_rate, bool feature_mask_off, size_t adaptive, size_t normalized, size_t spare>
-  inline void update_feature(float& update, float x, float& fw)
-  {
-    weight* w = &fw;
-    if(feature_mask_off || fw != 0.)
-      {
-	if (spare != 0)
-	  x *= w[spare];
-	w[0] += update * x;
-      }
-  }
+  return x;
+}
 
-  //this deals with few nonzero features vs. all nonzero features issues.  
-  template<bool sqrt_rate, size_t adaptive, size_t normalized>
-  float average_update(gd& g)
+template<bool sqrt_rate, bool feature_mask_off, size_t adaptive, size_t normalized, size_t spare>
+inline void update_feature(float& update, float x, float& fw)
+{
+  weight* w = &fw;
+  if(feature_mask_off || fw != 0.)
   {
-    if (normalized) {
-      if (sqrt_rate) 
-	{
-	  float avg_norm = (float) g.total_weight / (float) g.all->normalized_sum_norm_x;
-	  if (adaptive)
-	    return sqrt(avg_norm);
-	  else
-	    return avg_norm;
-	}
-      else 
-	return powf( (float) g.all->normalized_sum_norm_x / (float) g.total_weight, g.neg_norm_power);
+    if (spare != 0)
+      x *= w[spare];
+    w[0] += update * x;
+  }
+}
+
+//this deals with few nonzero features vs. all nonzero features issues.
+template<bool sqrt_rate, size_t adaptive, size_t normalized>
+float average_update(gd& g)
+{
+  if (normalized) {
+    if (sqrt_rate)
+    {
+      float avg_norm = (float) g.total_weight / (float) g.all->normalized_sum_norm_x;
+      if (adaptive)
+        return sqrt(avg_norm);
+      else
+        return avg_norm;
     }
-    return 1.f;
+    else
+      return powf( (float) g.all->normalized_sum_norm_x / (float) g.total_weight, g.neg_norm_power);
   }
-  
-  template<bool sqrt_rate, bool feature_mask_off, size_t adaptive, size_t normalized, size_t spare>
-  void train(gd& g, example& ec, float update)
-  {
-    if (normalized)
-      update *= g.update_multiplier;
+  return 1.f;
+}
 
-    foreach_feature<float, update_feature<sqrt_rate, feature_mask_off, adaptive, normalized, spare> >(*g.all, ec, update);
-  }
+template<bool sqrt_rate, bool feature_mask_off, size_t adaptive, size_t normalized, size_t spare>
+void train(gd& g, example& ec, float update)
+{
+  if (normalized)
+    update *= g.update_multiplier;
 
-  void end_pass(gd& g)
-  {
-    vw& all = *g.all;
-    
-    sync_weights(all);
-    if(all.span_server != "") {
-      if(all.adaptive)
-	accumulate_weighted_avg(all, all.span_server, all.reg);
-      else 
-        accumulate_avg(all, all.span_server, all.reg, 0);	      
-    }
-    all.eta *= all.eta_decay_rate;
-    if (all.save_per_pass)
-      save_predictor(all, all.final_regressor_name, all.current_pass);   
-    
-    all.current_pass++;
-    
-    if(!all.holdout_set_off)
-      {
-        if(summarize_holdout_set(all, g.no_win_counter))
-          finalize_regressor(all, all.final_regressor_name);
-        if((g.early_stop_thres == g.no_win_counter) &&
-           ((all.check_holdout_every_n_passes <= 1) ||
-            ((all.current_pass % all.check_holdout_every_n_passes) == 0)))
-	  set_done(all);
-      }
+  foreach_feature<float, update_feature<sqrt_rate, feature_mask_off, adaptive, normalized, spare> >(*g.all, ec, update);
+}
+
+void end_pass(gd& g)
+{
+  vw& all = *g.all;
+
+  sync_weights(all);
+  if(all.span_server != "") {
+    if(all.adaptive)
+      accumulate_weighted_avg(all, all.span_server, all.reg);
+    else
+      accumulate_avg(all, all.span_server, all.reg, 0);
   }
+  all.eta *= all.eta_decay_rate;
+  if (all.save_per_pass)
+    save_predictor(all, all.final_regressor_name, all.current_pass);
+
+  all.current_pass++;
+
+  if(!all.holdout_set_off)
+  {
+    if(summarize_holdout_set(all, g.no_win_counter))
+      finalize_regressor(all, all.final_regressor_name);
+    if((g.early_stop_thres == g.no_win_counter) &&
+        ((all.check_holdout_every_n_passes <= 1) ||
+         ((all.current_pass % all.check_holdout_every_n_passes) == 0)))
+      set_done(all);
+  }
+}
 
 
 
 #include <algorithm>
 
-  struct string_value {
-    float v;
-    string s;
-    friend bool operator<(const string_value& first, const string_value& second);
-  };
+struct string_value {
+  float v;
+  string s;
+  friend bool operator<(const string_value& first, const string_value& second);
+};
 
-  inline float sign(float w){ if (w < 0.) return -1.; else  return 1.;}
+inline float sign(float w) {
+  if (w < 0.) return -1.;
+  else  return 1.;
+}
 
-  inline float trunc_weight(const float w, const float gravity){
-     return (gravity < fabsf(w)) ? w - sign(w) * gravity : 0.f;
-   }
+inline float trunc_weight(const float w, const float gravity) {
+  return (gravity < fabsf(w)) ? w - sign(w) * gravity : 0.f;
+}
 
-  bool operator<(const string_value& first, const string_value& second)
+bool operator<(const string_value& first, const string_value& second)
+{
+  return fabsf(first.v) > fabsf(second.v);
+}
+
+struct audit_results
+{
+  vw& all;
+  const size_t offset;
+  vector<string> ns_pre;
+  vector<string_value> results;
+  audit_results(vw& p_all, const size_t p_offset):all(p_all), offset(p_offset) {}
+};
+
+
+inline void audit_interaction(audit_results& dat, const audit_data* f)
+{
+  if (f == nullptr)
   {
-    return fabsf(first.v) > fabsf(second.v);
+    dat.ns_pre.pop_back();
+    return;
   }
 
-  struct audit_results
+  string ns_pre;
+  if (!dat.ns_pre.empty())
+    ns_pre += '*';
+
+  if (f->space && (*(f->space) != ' '))
   {
-      vw& all;
-      const size_t offset;
-      vector<string> ns_pre;
-      vector<string_value> results;
-      audit_results(vw& p_all, const size_t p_offset):all(p_all), offset(p_offset) {}
-  };
+    ns_pre.append((const char*)f->space);
+    ns_pre += '^';
+  }
+  ns_pre.append(f->feature);
+  dat.ns_pre.push_back(ns_pre);
+}
 
+inline void audit_feature(audit_results& dat, const float ft_weight, const uint32_t ft_idx)
+{
+  size_t index = ft_idx & dat.all.reg.weight_mask;
+  weight* weights = dat.all.reg.weight_vector;
+  size_t stride_shift = dat.all.reg.stride_shift;
 
-  inline void audit_interaction(audit_results& dat, const audit_data* f)
+  string ns_pre;
+  for (vector<string>::const_iterator s = dat.ns_pre.begin(); s != dat.ns_pre.end(); ++s) ns_pre += *s;
+
+  if(dat.all.audit)
   {
-      if (f == nullptr)
-      {
-          dat.ns_pre.pop_back();
-          return;
-      }
+    ostringstream tempstream;
+    tempstream << ':' << (index >> stride_shift) << ':' << ft_weight
+               << ':' << trunc_weight(weights[index], (float)dat.all.sd->gravity) * (float)dat.all.sd->contraction;
 
-      string ns_pre;
-      if (!dat.ns_pre.empty())
-          ns_pre += '*';
+    if(dat.all.adaptive)
+      tempstream << '@' << weights[index+1];
 
-      if (f->space && (*(f->space) != ' '))
-      {
-          ns_pre.append((const char*)f->space);
-          ns_pre += '^';
-      }
-      ns_pre.append(f->feature);
-      dat.ns_pre.push_back(ns_pre);
+
+    string_value sv = {weights[index]*ft_weight, ns_pre+tempstream.str()};
+    dat.results.push_back(sv);
   }
 
-  inline void audit_feature(audit_results& dat, const float ft_weight, const uint32_t ft_idx)
-  {
-      size_t index = ft_idx & dat.all.reg.weight_mask;
-      weight* weights = dat.all.reg.weight_vector;
-      size_t stride_shift = dat.all.reg.stride_shift;
+  if(dat.all.current_pass == 0 && dat.all.hash_inv)
+  { //for invert_hash
 
-      string ns_pre;
-      for (vector<string>::const_iterator s = dat.ns_pre.begin(); s != dat.ns_pre.end(); ++s) ns_pre += *s;
+    if (dat.offset != 0)
+    { // otherwise --oaa output no features for class > 0.
+      ostringstream tempstream;
+      tempstream << '[' << (dat.offset >> stride_shift) << ']';
+      ns_pre += tempstream.str();
+    }
 
-      if(dat.all.audit)
-      {
-        ostringstream tempstream;
-        tempstream << ':' << (index >> stride_shift) << ':' << ft_weight
-                   << ':' << trunc_weight(weights[index], (float)dat.all.sd->gravity) * (float)dat.all.sd->contraction;
-
-        if(dat.all.adaptive)
-          tempstream << '@' << weights[index+1];
-
-
-        string_value sv = {weights[index]*ft_weight, ns_pre+tempstream.str()};
-        dat.results.push_back(sv);
-      }
-
-      if(dat.all.current_pass == 0 && dat.all.hash_inv)
-      { //for invert_hash
-
-          if (dat.offset != 0)
-          {   // otherwise --oaa output no features for class > 0.
-              ostringstream tempstream;
-              tempstream << '[' << (dat.offset >> stride_shift) << ']';
-              ns_pre += tempstream.str();
-          }
-
-          if(!dat.all.name_index_map.count(ns_pre))
-              dat.all.name_index_map.insert(std::map< std::string, size_t>::value_type(ns_pre, index >> stride_shift));
-      }
-
+    if(!dat.all.name_index_map.count(ns_pre))
+      dat.all.name_index_map.insert(std::map< std::string, size_t>::value_type(ns_pre, index >> stride_shift));
   }
+
+}
 
 void print_features(vw& all, example& ec)
 {
   weight* weights = all.reg.weight_vector;
-  
+
   if (all.lda > 0)
-    {
-      size_t count = 0;
-      for (unsigned char* i = ec.indices.begin; i != ec.indices.end; i++)
-	count += ec.atomics[*i].size();
-      for (unsigned char* i = ec.indices.begin; i != ec.indices.end; i++) 
-	for (audit_data *f = ec.audit_features[*i].begin; f != ec.audit_features[*i].end; f++)
-	  {
-	    cout << '\t' << f->space << '^' << f->feature << ':' << ((f->weight_index >> all.reg.stride_shift) & all.parse_mask) << ':' << f->x;
-	    for (size_t k = 0; k < all.lda; k++)
-	      cout << ':' << weights[(f->weight_index+k) & all.reg.weight_mask];
-	  }
-      cout << " total of " << count << " features." << endl;
-    }
-  else
-    {
-
-      audit_results dat(all,ec.ft_offset);
-
-      for (unsigned char* i = ec.indices.begin; i != ec.indices.end; ++i)
+  {
+    size_t count = 0;
+    for (unsigned char* i = ec.indices.begin; i != ec.indices.end; i++)
+      count += ec.atomics[*i].size();
+    for (unsigned char* i = ec.indices.begin; i != ec.indices.end; i++)
+      for (audit_data *f = ec.audit_features[*i].begin; f != ec.audit_features[*i].end; f++)
       {
-          v_array<audit_data>& ns =  ec.audit_features[(size_t)*i];
-        for (audit_data* a = ns.begin; a != ns.end; ++a)
-        {
-            audit_interaction(dat, a);
-            audit_feature(dat, a->x, (uint32_t)a->weight_index + ec.ft_offset);
-            audit_interaction(dat, NULL);
-        }
+        cout << '\t' << f->space << '^' << f->feature << ':' << ((f->weight_index >> all.reg.stride_shift) & all.parse_mask) << ':' << f->x;
+        for (size_t k = 0; k < all.lda; k++)
+          cout << ':' << weights[(f->weight_index+k) & all.reg.weight_mask];
       }
+    cout << " total of " << count << " features." << endl;
+  }
+  else
+  {
 
-      INTERACTIONS::generate_interactions<audit_results, const uint32_t, audit_feature, audit_data, audit_interaction >(all, ec, dat, ec.audit_features);
+    audit_results dat(all,ec.ft_offset);
 
-      sort(dat.results.begin(),dat.results.end());
-      if(all.audit){
-        for (vector<string_value>::const_iterator sv = dat.results.begin(); sv!= dat.results.end(); ++sv)
-            cout << '\t' << (*sv).s;
-        cout << endl;
+    for (unsigned char* i = ec.indices.begin; i != ec.indices.end; ++i)
+    {
+      v_array<audit_data>& ns =  ec.audit_features[(size_t)*i];
+      for (audit_data* a = ns.begin; a != ns.end; ++a)
+      {
+        audit_interaction(dat, a);
+        audit_feature(dat, a->x, (uint32_t)a->weight_index + ec.ft_offset);
+        audit_interaction(dat, NULL);
       }
-
     }
+
+    INTERACTIONS::generate_interactions<audit_results, const uint32_t, audit_feature, audit_data, audit_interaction >(all, ec, dat, ec.audit_features);
+
+    sort(dat.results.begin(),dat.results.end());
+    if(all.audit) {
+      for (vector<string_value>::const_iterator sv = dat.results.begin(); sv!= dat.results.end(); ++sv)
+        cout << '\t' << (*sv).s;
+      cout << endl;
+    }
+
+  }
 }
 
 void print_audit_features(vw& all, example& ec)
@@ -304,16 +307,16 @@ void print_audit_features(vw& all, example& ec)
   print_features(all, ec);
 }
 
-float finalize_prediction(shared_data* sd, float ret) 
+float finalize_prediction(shared_data* sd, float ret)
 {
   if ( nanpattern(ret))
-    {
-      float ret = 0.;
-      if (ret > sd->max_label) ret = (float)sd->max_label;
-      if (ret < sd->min_label) ret = (float)sd->min_label;
-      cerr << "NAN prediction in example " << sd->example_number + 1 << ", forcing " << ret << endl;
-      return ret;
-    }
+  {
+    float ret = 0.;
+    if (ret > sd->max_label) ret = (float)sd->max_label;
+    if (ret < sd->min_label) ret = (float)sd->min_label;
+    cerr << "NAN prediction in example " << sd->example_number + 1 << ", forcing " << ret << endl;
+    return ret;
+  }
   if ( ret > sd->max_label )
     return (float)sd->max_label;
   if (ret < sd->min_label)
@@ -321,38 +324,38 @@ float finalize_prediction(shared_data* sd, float ret)
   return ret;
 }
 
- struct trunc_data {
-   float prediction;
-   float gravity;
- };
- 
- inline void vec_add_trunc(trunc_data& p, const float fx, float& fw) {
-   p.prediction += trunc_weight(fw, p.gravity) * fx;
- }
+struct trunc_data {
+  float prediction;
+  float gravity;
+};
 
- inline float trunc_predict(vw& all, example& ec, double gravity)
- {
-   trunc_data temp = {ec.l.simple.initial, (float)gravity};
-   foreach_feature<trunc_data, vec_add_trunc>(all, ec, temp);
-   return temp.prediction;
- }
+inline void vec_add_trunc(trunc_data& p, const float fx, float& fw) {
+  p.prediction += trunc_weight(fw, p.gravity) * fx;
+}
 
-  inline void vec_add_print(float&p, const float fx, float& fw) {
-    p += fw * fx;
-    cerr << " + " << fw << "*" << fx;
-  }
-  
-  
+inline float trunc_predict(vw& all, example& ec, double gravity)
+{
+  trunc_data temp = {ec.l.simple.initial, (float)gravity};
+  foreach_feature<trunc_data, vec_add_trunc>(all, ec, temp);
+  return temp.prediction;
+}
+
+inline void vec_add_print(float&p, const float fx, float& fw) {
+  p += fw * fx;
+  cerr << " + " << fw << "*" << fx;
+}
+
+
 template<bool l1, bool audit>
 void predict(gd& g, base_learner&, example& ec)
 {
   vw& all = *g.all;
-  
+
   if (l1)
     ec.partial_prediction = trunc_predict(all, ec, all.sd->gravity);
   else
-    ec.partial_prediction = inline_predict(all, ec);    
-  
+    ec.partial_prediction = inline_predict(all, ec);
+
   ec.partial_prediction *= (float)all.sd->contraction;
   ec.pred.scalar = finalize_prediction(all.sd, ec.partial_prediction);
   if (audit)
@@ -366,7 +369,7 @@ inline void vec_add_trunc_multipredict(multipredict_info& mp, const float fx, ui
     w += mp.step;
   }
 }
-  
+
 template<bool l1, bool audit>
 void multipredict(gd& g, base_learner&, example& ec, size_t count, size_t step, polyprediction*pred, bool finalize_predictions) {
   vw& all = *g.all;
@@ -391,50 +394,50 @@ void multipredict(gd& g, base_learner&, example& ec, size_t count, size_t step, 
   }
 }
 
-  
-  struct power_data {
-    float minus_power_t;
-    float neg_norm_power;
-  };
 
-  template<bool sqrt_rate, size_t adaptive, size_t normalized>
-  inline float compute_rate_decay(power_data& s, float& fw)
-  {
-    weight* w = &fw;
-    float rate_decay = 1.f;
-    if(adaptive) {
-      if (sqrt_rate)
-	{  
-	  rate_decay = InvSqrt(w[adaptive]);
-	  }
-      else
-	rate_decay = powf(w[adaptive],s.minus_power_t);
+struct power_data {
+  float minus_power_t;
+  float neg_norm_power;
+};
+
+template<bool sqrt_rate, size_t adaptive, size_t normalized>
+inline float compute_rate_decay(power_data& s, float& fw)
+{
+  weight* w = &fw;
+  float rate_decay = 1.f;
+  if(adaptive) {
+    if (sqrt_rate)
+    {
+      rate_decay = InvSqrt(w[adaptive]);
     }
-    if(normalized) {
-      if (sqrt_rate)
-	{
-	  float inv_norm = 1.f / w[normalized];
-	  if (adaptive)
-	    rate_decay *= inv_norm;
-	  else
-	    rate_decay *= inv_norm*inv_norm;
-	}
-      else
-	rate_decay *= powf(w[normalized]*w[normalized], s.neg_norm_power);
-    }
-	return rate_decay;
+    else
+      rate_decay = powf(w[adaptive],s.minus_power_t);
   }
+  if(normalized) {
+    if (sqrt_rate)
+    {
+      float inv_norm = 1.f / w[normalized];
+      if (adaptive)
+        rate_decay *= inv_norm;
+      else
+        rate_decay *= inv_norm*inv_norm;
+    }
+    else
+      rate_decay *= powf(w[normalized]*w[normalized], s.neg_norm_power);
+  }
+  return rate_decay;
+}
 
-  struct norm_data {
-    float grad_squared;
-    float pred_per_update;
-    float norm_x;
-    power_data pd;
-  };
+struct norm_data {
+  float grad_squared;
+  float pred_per_update;
+  float norm_x;
+  power_data pd;
+};
 
 template<bool sqrt_rate, bool feature_mask_off, size_t adaptive, size_t normalized, size_t spare>
 inline void pred_per_update_feature(norm_data& nd, float x, float& fw) {
-  if(feature_mask_off || fw != 0.){
+  if(feature_mask_off || fw != 0.) {
     weight* w = &fw;
     float x2 = x * x;
     if(adaptive)
@@ -442,17 +445,17 @@ inline void pred_per_update_feature(norm_data& nd, float x, float& fw) {
     if(normalized) {
       float x_abs = fabsf(x);
       if( x_abs > w[normalized] ) {// new scale discovered
-	if( w[normalized] > 0. ) {//If the normalizer is > 0 then rescale the weight so it's as if the new scale was the old scale.
-	  if (sqrt_rate) {
-	    float rescale = w[normalized]/x_abs;	    
-	    w[0] *= (adaptive ? rescale : rescale*rescale);
-	  }
-	  else {
-	    float rescale = x_abs/w[normalized];	    
-	    w[0] *= powf(rescale*rescale, nd.pd.neg_norm_power);
-	  }
-	}
-	w[normalized] = x_abs;
+        if( w[normalized] > 0. ) {//If the normalizer is > 0 then rescale the weight so it's as if the new scale was the old scale.
+          if (sqrt_rate) {
+            float rescale = w[normalized]/x_abs;
+            w[0] *= (adaptive ? rescale : rescale*rescale);
+          }
+          else {
+            float rescale = x_abs/w[normalized];
+            w[0] *= powf(rescale*rescale, nd.pd.neg_norm_power);
+          }
+        }
+        w[normalized] = x_abs;
       }
       nd.norm_x += x2 / (w[normalized] * w[normalized]);
     }
@@ -460,89 +463,89 @@ inline void pred_per_update_feature(norm_data& nd, float x, float& fw) {
     nd.pred_per_update += x2 * w[spare];
   }
 }
-  
-  bool global_print_features = false;
+
+bool global_print_features = false;
 template<bool sqrt_rate, bool feature_mask_off, size_t adaptive, size_t normalized, size_t spare>
-  float get_pred_per_update(gd& g, example& ec)
-  {//We must traverse the features in _precisely_ the same order as during training.
-    label_data& ld = ec.l.simple;
-    vw& all = *g.all;
-    float grad_squared = all.loss->getSquareGrad(ec.pred.scalar, ld.label) * ld.weight;
-    if (grad_squared == 0) return 1.;
-    
-    norm_data nd = {grad_squared, 0., 0., {g.neg_power_t, g.neg_norm_power}};
-    
-    foreach_feature<norm_data,pred_per_update_feature<sqrt_rate, feature_mask_off, adaptive, normalized, spare> >(all, ec, nd);
-
-    if(normalized) {
-      g.all->normalized_sum_norm_x += ld.weight * nd.norm_x;
-      g.total_weight += ld.weight;
-
-      g.update_multiplier = average_update<sqrt_rate, adaptive, normalized>(g);
-      nd.pred_per_update *= g.update_multiplier;
-    }
-    
-    return nd.pred_per_update;
-  }
-
-  template<bool sparse_l2, bool invariant, bool sqrt_rate, bool feature_mask_off, size_t adaptive, size_t normalized, size_t spare>
-float compute_update(gd& g, example& ec)
-{//invariant: not a test label, importance weight > 0
+float get_pred_per_update(gd& g, example& ec)
+{ //We must traverse the features in _precisely_ the same order as during training.
   label_data& ld = ec.l.simple;
   vw& all = *g.all;
-  
+  float grad_squared = all.loss->getSquareGrad(ec.pred.scalar, ld.label) * ld.weight;
+  if (grad_squared == 0) return 1.;
+
+  norm_data nd = {grad_squared, 0., 0., {g.neg_power_t, g.neg_norm_power}};
+
+  foreach_feature<norm_data,pred_per_update_feature<sqrt_rate, feature_mask_off, adaptive, normalized, spare> >(all, ec, nd);
+
+  if(normalized) {
+    g.all->normalized_sum_norm_x += ld.weight * nd.norm_x;
+    g.total_weight += ld.weight;
+
+    g.update_multiplier = average_update<sqrt_rate, adaptive, normalized>(g);
+    nd.pred_per_update *= g.update_multiplier;
+  }
+
+  return nd.pred_per_update;
+}
+
+template<bool sparse_l2, bool invariant, bool sqrt_rate, bool feature_mask_off, size_t adaptive, size_t normalized, size_t spare>
+float compute_update(gd& g, example& ec)
+{ //invariant: not a test label, importance weight > 0
+  label_data& ld = ec.l.simple;
+  vw& all = *g.all;
+
   float update = 0.;
   ec.updated_prediction = ec.pred.scalar;
   if (all.loss->getLoss(all.sd, ec.pred.scalar, ld.label) > 0.)
+  {
+    float pred_per_update;
+    if(adaptive || normalized)
+      pred_per_update = get_pred_per_update<sqrt_rate, feature_mask_off, adaptive, normalized, spare>(g,ec);
+    else
+      pred_per_update = ec.total_sum_feat_sq;
+    float delta_pred = pred_per_update * all.eta * ld.weight;
+    if(!adaptive)
     {
-      float pred_per_update;
-      if(adaptive || normalized)
-	pred_per_update = get_pred_per_update<sqrt_rate, feature_mask_off, adaptive, normalized, spare>(g,ec);
-      else
-	pred_per_update = ec.total_sum_feat_sq;
-      float delta_pred = pred_per_update * all.eta * ld.weight;
-      if(!adaptive) 
-	{
-	  float t = (float)(ec.example_t - all.sd->weighted_holdout_examples);
-	  delta_pred *= powf(t, g.neg_power_t);
-	}
-      if(invariant)
-	update = all.loss->getUpdate(ec.pred.scalar, ld.label, delta_pred, pred_per_update);
-      else
-	update = all.loss->getUnsafeUpdate(ec.pred.scalar, ld.label, delta_pred, pred_per_update);
-
-      // changed from ec.partial_prediction to ld.prediction
-      ec.updated_prediction += pred_per_update * update;
-      
-      if (all.reg_mode && fabs(update) > 1e-8) {
-	double dev1 = all.loss->first_derivative(all.sd, ec.pred.scalar, ld.label);
-	double eta_bar = (fabs(dev1) > 1e-8) ? (-update / dev1) : 0.0;
-	if (fabs(dev1) > 1e-8)
-	  all.sd->contraction *= (1. - all.l2_lambda * eta_bar);
-	update /= (float)all.sd->contraction;
-	all.sd->gravity += eta_bar * all.l1_lambda;
-      }
+      float t = (float)(ec.example_t - all.sd->weighted_holdout_examples);
+      delta_pred *= powf(t, g.neg_power_t);
     }
-  
+    if(invariant)
+      update = all.loss->getUpdate(ec.pred.scalar, ld.label, delta_pred, pred_per_update);
+    else
+      update = all.loss->getUnsafeUpdate(ec.pred.scalar, ld.label, delta_pred, pred_per_update);
+
+    // changed from ec.partial_prediction to ld.prediction
+    ec.updated_prediction += pred_per_update * update;
+
+    if (all.reg_mode && fabs(update) > 1e-8) {
+      double dev1 = all.loss->first_derivative(all.sd, ec.pred.scalar, ld.label);
+      double eta_bar = (fabs(dev1) > 1e-8) ? (-update / dev1) : 0.0;
+      if (fabs(dev1) > 1e-8)
+        all.sd->contraction *= (1. - all.l2_lambda * eta_bar);
+      update /= (float)all.sd->contraction;
+      all.sd->gravity += eta_bar * all.l1_lambda;
+    }
+  }
+
   if (sparse_l2)
     update -= g.sparse_l2 * ec.pred.scalar;
   return update;
 }
 
-  template<bool sparse_l2, bool invariant, bool sqrt_rate, bool feature_mask_off, size_t adaptive, size_t normalized, size_t spare>
+template<bool sparse_l2, bool invariant, bool sqrt_rate, bool feature_mask_off, size_t adaptive, size_t normalized, size_t spare>
 void update(gd& g, base_learner&, example& ec)
-{//invariant: not a test label, importance weight > 0
+{ //invariant: not a test label, importance weight > 0
   float update;
   if ( (update = compute_update<sparse_l2, invariant, sqrt_rate, feature_mask_off, adaptive, normalized, spare> (g, ec)) != 0.)
     train<sqrt_rate, feature_mask_off, adaptive, normalized, spare>(g, ec, update);
-  
+
   if (g.all->sd->contraction < 1e-10)  // updating weights now to avoid numerical instability
     sync_weights(*g.all);
 }
 
-  template<bool sparse_l2, bool invariant, bool sqrt_rate, bool feature_mask_off, size_t adaptive, size_t normalized, size_t spare>
-  void learn(gd& g, base_learner& base, example& ec)
-  {//invariant: not a test label, importance weight > 0
+template<bool sparse_l2, bool invariant, bool sqrt_rate, bool feature_mask_off, size_t adaptive, size_t normalized, size_t spare>
+void learn(gd& g, base_learner& base, example& ec)
+{ //invariant: not a test label, importance weight > 0
   assert(ec.in_use);
   assert(ec.l.simple.label != FLT_MAX);
   assert(ec.l.simple.weight > 0.);
@@ -570,280 +573,280 @@ void save_load_regressor(vw& all, io_buf& model_file, bool read, bool text)
   uint32_t i = 0;
   size_t brw = 1;
 
-  if(all.print_invert){ //write readable model with feature names           
+  if(all.print_invert) { //write readable model with feature names
     weight* v;
     char buff[512];
-    int text_len; 
-    typedef std::map< std::string, size_t> str_int_map;  
-        
-    for(str_int_map::iterator it = all.name_index_map.begin(); it != all.name_index_map.end(); ++it){              
+    int text_len;
+    typedef std::map< std::string, size_t> str_int_map;
+
+    for(str_int_map::iterator it = all.name_index_map.begin(); it != all.name_index_map.end(); ++it) {
       v = &(all.reg.weight_vector[stride*it->second]);
-      if(*v != 0.){
+      if(*v != 0.) {
         text_len = sprintf(buff, "%s", (char*)it->first.c_str());
         brw = bin_text_write_fixed(model_file, (char*)it->first.c_str(), sizeof(*it->first.c_str()),
-					 buff, text_len, true);
+                                   buff, text_len, true);
         text_len = sprintf(buff, ":%ld:%f\n", it->second, *v);
         brw+= bin_text_write_fixed(model_file,(char *)v, sizeof (*v),
-					 buff, text_len, true);
-      }	
+                                   buff, text_len, true);
+      }
     }
     return;
-  } 
+  }
 
-  do 
+  do
+  {
+    brw = 1;
+    weight* v;
+    if (read)
     {
-      brw = 1;
-      weight* v;
-      if (read)
-	{
-	  c++;
-	  brw = bin_read_fixed(model_file, (char*)&i, sizeof(i),"");
-	  if (brw > 0)
-	    {
-	      assert (i< length);		
-	      v = &(all.reg.weight_vector[stride*i]);
-	      brw += bin_read_fixed(model_file, (char*)v, sizeof(*v), "");
-	    }
-	}
-      else// write binary or text
-	{
-                      
-         v = &(all.reg.weight_vector[stride*i]);
-	 if (*v != 0.)
-	    {
-	      c++;
-	      char buff[512];
-	      int text_len;
-
-	      text_len = sprintf(buff, "%d", i);
-	      brw = bin_text_write_fixed(model_file,(char *)&i, sizeof (i),
-					 buff, text_len, text);
-	      
-              text_len = sprintf(buff, ":%f\n", *v);
-	      brw+= bin_text_write_fixed(model_file,(char *)v, sizeof (*v),
-					 buff, text_len, text);
-	    }
-	}
- 
-      if (!read)
-	i++;
+      c++;
+      brw = bin_read_fixed(model_file, (char*)&i, sizeof(i),"");
+      if (brw > 0)
+      {
+        assert (i< length);
+        v = &(all.reg.weight_vector[stride*i]);
+        brw += bin_read_fixed(model_file, (char*)v, sizeof(*v), "");
+      }
     }
-  while ((!read && i < length) || (read && brw >0));  
+    else// write binary or text
+    {
+
+      v = &(all.reg.weight_vector[stride*i]);
+      if (*v != 0.)
+      {
+        c++;
+        char buff[512];
+        int text_len;
+
+        text_len = sprintf(buff, "%d", i);
+        brw = bin_text_write_fixed(model_file,(char *)&i, sizeof (i),
+                                   buff, text_len, text);
+
+        text_len = sprintf(buff, ":%f\n", *v);
+        brw+= bin_text_write_fixed(model_file,(char *)v, sizeof (*v),
+                                   buff, text_len, text);
+      }
+    }
+
+    if (!read)
+      i++;
+  }
+  while ((!read && i < length) || (read && brw >0));
 }
 
 void save_load_online_state(vw& all, io_buf& model_file, bool read, bool text, gd* g)
 {
   //vw& all = *g.all;
-  
+
   char buff[512];
-  
+
   uint32_t text_len = sprintf(buff, "initial_t %f\n", all.initial_t);
-  bin_text_read_write_fixed(model_file,(char*)&all.initial_t, sizeof(all.initial_t), 
-			    "", read, 
-			    buff, text_len, text);
+  bin_text_read_write_fixed(model_file,(char*)&all.initial_t, sizeof(all.initial_t),
+                            "", read,
+                            buff, text_len, text);
 
   text_len = sprintf(buff, "norm normalizer %f\n", all.normalized_sum_norm_x);
-  bin_text_read_write_fixed(model_file,(char*)&all.normalized_sum_norm_x, sizeof(all.normalized_sum_norm_x), 
-  			    "", read, 
-  			    buff, text_len, text);
+  bin_text_read_write_fixed(model_file,(char*)&all.normalized_sum_norm_x, sizeof(all.normalized_sum_norm_x),
+                            "", read,
+                            buff, text_len, text);
 
   text_len = sprintf(buff, "t %f\n", all.sd->t);
-  bin_text_read_write_fixed(model_file,(char*)&all.sd->t, sizeof(all.sd->t), 
-			    "", read, 
-			    buff, text_len, text);
+  bin_text_read_write_fixed(model_file,(char*)&all.sd->t, sizeof(all.sd->t),
+                            "", read,
+                            buff, text_len, text);
 
   text_len = sprintf(buff, "sum_loss %f\n", all.sd->sum_loss);
-  bin_text_read_write_fixed(model_file,(char*)&all.sd->sum_loss, sizeof(all.sd->sum_loss), 
-			    "", read, 
-			    buff, text_len, text);
+  bin_text_read_write_fixed(model_file,(char*)&all.sd->sum_loss, sizeof(all.sd->sum_loss),
+                            "", read,
+                            buff, text_len, text);
 
   text_len = sprintf(buff, "sum_loss_since_last_dump %f\n", all.sd->sum_loss_since_last_dump);
-  bin_text_read_write_fixed(model_file,(char*)&all.sd->sum_loss_since_last_dump, sizeof(all.sd->sum_loss_since_last_dump), 
-			    "", read, 
-			    buff, text_len, text);
+  bin_text_read_write_fixed(model_file,(char*)&all.sd->sum_loss_since_last_dump, sizeof(all.sd->sum_loss_since_last_dump),
+                            "", read,
+                            buff, text_len, text);
 
   text_len = sprintf(buff, "dump_interval %f\n", all.sd->dump_interval);
-  bin_text_read_write_fixed(model_file,(char*)&all.sd->dump_interval, sizeof(all.sd->dump_interval), 
-			    "", read, 
-			    buff, text_len, text);
+  bin_text_read_write_fixed(model_file,(char*)&all.sd->dump_interval, sizeof(all.sd->dump_interval),
+                            "", read,
+                            buff, text_len, text);
 
   text_len = sprintf(buff, "min_label %f\n", all.sd->min_label);
-  bin_text_read_write_fixed(model_file,(char*)&all.sd->min_label, sizeof(all.sd->min_label), 
-			    "", read, 
-			    buff, text_len, text);
+  bin_text_read_write_fixed(model_file,(char*)&all.sd->min_label, sizeof(all.sd->min_label),
+                            "", read,
+                            buff, text_len, text);
 
   text_len = sprintf(buff, "max_label %f\n", all.sd->max_label);
-  bin_text_read_write_fixed(model_file,(char*)&all.sd->max_label, sizeof(all.sd->max_label), 
-			    "", read, 
-			    buff, text_len, text);
+  bin_text_read_write_fixed(model_file,(char*)&all.sd->max_label, sizeof(all.sd->max_label),
+                            "", read,
+                            buff, text_len, text);
 
   text_len = sprintf(buff, "weighted_examples %f\n", all.sd->weighted_examples);
-  bin_text_read_write_fixed(model_file,(char*)&all.sd->weighted_examples, sizeof(all.sd->weighted_examples), 
-			    "", read, 
-			    buff, text_len, text);
+  bin_text_read_write_fixed(model_file,(char*)&all.sd->weighted_examples, sizeof(all.sd->weighted_examples),
+                            "", read,
+                            buff, text_len, text);
 
   text_len = sprintf(buff, "weighted_labels %f\n", all.sd->weighted_labels);
-  bin_text_read_write_fixed(model_file,(char*)&all.sd->weighted_labels, sizeof(all.sd->weighted_labels), 
-			    "", read, 
-			    buff, text_len, text);
+  bin_text_read_write_fixed(model_file,(char*)&all.sd->weighted_labels, sizeof(all.sd->weighted_labels),
+                            "", read,
+                            buff, text_len, text);
 
   text_len = sprintf(buff, "weighted_unlabeled_examples %f\n", all.sd->weighted_unlabeled_examples);
-  bin_text_read_write_fixed(model_file,(char*)&all.sd->weighted_unlabeled_examples, sizeof(all.sd->weighted_unlabeled_examples), 
-			    "", read, 
-			    buff, text_len, text);
-  
+  bin_text_read_write_fixed(model_file,(char*)&all.sd->weighted_unlabeled_examples, sizeof(all.sd->weighted_unlabeled_examples),
+                            "", read,
+                            buff, text_len, text);
+
   text_len = sprintf(buff, "example_number %u\n", (uint32_t)all.sd->example_number);
-  bin_text_read_write_fixed(model_file,(char*)&all.sd->example_number, sizeof(all.sd->example_number), 
-			    "", read, 
-			    buff, text_len, text);
+  bin_text_read_write_fixed(model_file,(char*)&all.sd->example_number, sizeof(all.sd->example_number),
+                            "", read,
+                            buff, text_len, text);
 
   text_len = sprintf(buff, "total_features %u\n", (uint32_t)all.sd->total_features);
-  bin_text_read_write_fixed(model_file,(char*)&all.sd->total_features, sizeof(all.sd->total_features), 
-			    "", read, 
-			    buff, text_len, text);
+  bin_text_read_write_fixed(model_file,(char*)&all.sd->total_features, sizeof(all.sd->total_features),
+                            "", read,
+                            buff, text_len, text);
 
   if (!read || all.model_file_ver >= VERSION_SAVE_RESUME_FIX)
   { // restore some data to allow --save_resume work more accurate
 
-      // fix average loss
-      double total_weight = 0.; //value holder as g* may be null
-      if (!read && g != nullptr) total_weight = g->total_weight;
-      text_len = sprintf(buff, "gd::total_weight %f\n", total_weight);
-      bin_text_read_write_fixed(model_file,(char*)&total_weight, sizeof(total_weight),
-                                "", read,
-                                buff, text_len, text);
-      if (read && g != nullptr) g->total_weight = total_weight;
+    // fix average loss
+    double total_weight = 0.; //value holder as g* may be null
+    if (!read && g != nullptr) total_weight = g->total_weight;
+    text_len = sprintf(buff, "gd::total_weight %f\n", total_weight);
+    bin_text_read_write_fixed(model_file,(char*)&total_weight, sizeof(total_weight),
+                              "", read,
+                              buff, text_len, text);
+    if (read && g != nullptr) g->total_weight = total_weight;
 
-      // fix "loss since last" for first printed out example details
-      text_len = sprintf(buff, "sd::old_weighted_examples %f\n", all.sd->old_weighted_examples);
-      bin_text_read_write_fixed(model_file,(char*)&all.sd->old_weighted_examples, sizeof(all.sd->old_weighted_examples),
-                                "", read,
-                                buff, text_len, text);
+    // fix "loss since last" for first printed out example details
+    text_len = sprintf(buff, "sd::old_weighted_examples %f\n", all.sd->old_weighted_examples);
+    bin_text_read_write_fixed(model_file,(char*)&all.sd->old_weighted_examples, sizeof(all.sd->old_weighted_examples),
+                              "", read,
+                              buff, text_len, text);
 
-      // fix "number of examples per pass"
-      text_len = sprintf(buff, "current_pass %u\n", (uint32_t)all.current_pass);
-      bin_text_read_write_fixed(model_file,(char*)&all.current_pass, sizeof(all.current_pass),
-                                "", read,
-                                buff, text_len, text);
+    // fix "number of examples per pass"
+    text_len = sprintf(buff, "current_pass %u\n", (uint32_t)all.current_pass);
+    bin_text_read_write_fixed(model_file,(char*)&all.current_pass, sizeof(all.current_pass),
+                              "", read,
+                              buff, text_len, text);
   }
 
   if (!all.training) // reset various things so that we report test set performance properly
-    {
-      all.sd->sum_loss = 0;
-      all.sd->sum_loss_since_last_dump = 0;
-      all.sd->dump_interval = 1.;
-      all.sd->weighted_examples = 0.;
-      all.sd->weighted_labels = 0.;
-      all.sd->weighted_unlabeled_examples = 0.;
-      all.sd->example_number = 0;
-      all.sd->total_features = 0;
-    }
-  
+  {
+    all.sd->sum_loss = 0;
+    all.sd->sum_loss_since_last_dump = 0;
+    all.sd->dump_interval = 1.;
+    all.sd->weighted_examples = 0.;
+    all.sd->weighted_labels = 0.;
+    all.sd->weighted_unlabeled_examples = 0.;
+    all.sd->example_number = 0;
+    all.sd->total_features = 0;
+  }
+
   uint32_t length = 1 << all.num_bits;
   uint32_t stride = 1 << all.reg.stride_shift;
   int c = 0;
   uint32_t i = 0;
   size_t brw = 1;
-  do 
+  do
+  {
+    brw = 1;
+    weight* v;
+    if (read)
     {
-      brw = 1;
-      weight* v; 
-      if (read)
-	{
-	  c++;
-	  brw = bin_read_fixed(model_file, (char*)&i, sizeof(i),"");
-	  if (brw > 0)
-	    {
-	      assert (i< length);		
-	      v = &(all.reg.weight_vector[stride*i]);
-	      if (g == NULL || (! g->adaptive && ! g->normalized))
-		brw += bin_read_fixed(model_file, (char*)v, sizeof(*v), "");
-	      else if ((g->adaptive && !g->normalized) || (!g->adaptive && g->normalized))
-		brw += bin_read_fixed(model_file, (char*)v, sizeof(*v)*2, "");
-	      else //adaptive and normalized
-		brw += bin_read_fixed(model_file, (char*)v, sizeof(*v)*3, "");	
-	      if (!all.training)
-		v[1]=v[2]=0.;
-	    }
-	}
-      else // write binary or text
-	{
-	  v = &(all.reg.weight_vector[stride*i]);
-	  if (*v != 0.)
-	    {
-	      c++;
-	      char buff[512];
-	      int text_len = sprintf(buff, "%d", i);
-	      brw = bin_text_write_fixed(model_file,(char *)&i, sizeof (i),
-					 buff, text_len, text);
-	      if (g == NULL || (! g->adaptive && ! g->normalized))
-		{
-		  text_len = sprintf(buff, ":%f\n", *v);
-		  brw+= bin_text_write_fixed(model_file,(char *)v, sizeof (*v),
-					     buff, text_len, text);
-		}
-	      else if ((g->adaptive && !g->normalized) || (!g->adaptive && g->normalized))
-		{//either adaptive or normalized
-		  text_len = sprintf(buff, ":%f %f\n", *v, *(v+1));
-		  brw+= bin_text_write_fixed(model_file,(char *)v, 2*sizeof (*v),
-					     buff, text_len, text);
-		}
-	      else
-		{//adaptive and normalized
-		  text_len = sprintf(buff, ":%f %f %f\n", *v, *(v+1), *(v+2));
-		  brw+= bin_text_write_fixed(model_file,(char *)v, 3*sizeof (*v),
-					     buff, text_len, text);
-		}
-	    }
-	}
-      if (!read)
-	i++;
+      c++;
+      brw = bin_read_fixed(model_file, (char*)&i, sizeof(i),"");
+      if (brw > 0)
+      {
+        assert (i< length);
+        v = &(all.reg.weight_vector[stride*i]);
+        if (g == NULL || (! g->adaptive && ! g->normalized))
+          brw += bin_read_fixed(model_file, (char*)v, sizeof(*v), "");
+        else if ((g->adaptive && !g->normalized) || (!g->adaptive && g->normalized))
+          brw += bin_read_fixed(model_file, (char*)v, sizeof(*v)*2, "");
+        else //adaptive and normalized
+          brw += bin_read_fixed(model_file, (char*)v, sizeof(*v)*3, "");
+        if (!all.training)
+          v[1]=v[2]=0.;
+      }
     }
-  while ((!read && i < length) || (read && brw >0));  
+    else // write binary or text
+    {
+      v = &(all.reg.weight_vector[stride*i]);
+      if (*v != 0.)
+      {
+        c++;
+        char buff[512];
+        int text_len = sprintf(buff, "%d", i);
+        brw = bin_text_write_fixed(model_file,(char *)&i, sizeof (i),
+                                   buff, text_len, text);
+        if (g == NULL || (! g->adaptive && ! g->normalized))
+        {
+          text_len = sprintf(buff, ":%f\n", *v);
+          brw+= bin_text_write_fixed(model_file,(char *)v, sizeof (*v),
+                                     buff, text_len, text);
+        }
+        else if ((g->adaptive && !g->normalized) || (!g->adaptive && g->normalized))
+        { //either adaptive or normalized
+          text_len = sprintf(buff, ":%f %f\n", *v, *(v+1));
+          brw+= bin_text_write_fixed(model_file,(char *)v, 2*sizeof (*v),
+                                     buff, text_len, text);
+        }
+        else
+        { //adaptive and normalized
+          text_len = sprintf(buff, ":%f %f %f\n", *v, *(v+1), *(v+2));
+          brw+= bin_text_write_fixed(model_file,(char *)v, 3*sizeof (*v),
+                                     buff, text_len, text);
+        }
+      }
+    }
+    if (!read)
+      i++;
+  }
+  while ((!read && i < length) || (read && brw >0));
 }
 
 void save_load(gd& g, io_buf& model_file, bool read, bool text)
 {
   vw& all = *g.all;
   if(read)
-    {
-      initialize_regressor(all);
+  {
+    initialize_regressor(all);
 
-      if(all.adaptive && all.initial_t > 0)
-	{
-	  uint32_t length = 1 << all.num_bits;
-	  uint32_t stride = 1 << all.reg.stride_shift;
-	  for (size_t j = 1; j < stride*length; j+=stride)
-	    {
-	      all.reg.weight_vector[j] = all.initial_t;   //for adaptive update, we interpret initial_t as previously seeing initial_t fake datapoints, all with squared gradient=1
-	      //NOTE: this is not invariant to the scaling of the data (i.e. when combined with normalized). Since scaling the data scales the gradient, this should ideally be 
-	      //feature_range*initial_t, or something like that. We could potentially fix this by just adding this base quantity times the current range to the sum of gradients 
-	      //stored in memory at each update, and always start sum of gradients to 0, at the price of additional additions and multiplications during the update...
-	    }
-	}
-      
-      if (g.initial_constant != 0.0)
-        VW::set_weight(all, constant, 0, g.initial_constant);
+    if(all.adaptive && all.initial_t > 0)
+    {
+      uint32_t length = 1 << all.num_bits;
+      uint32_t stride = 1 << all.reg.stride_shift;
+      for (size_t j = 1; j < stride*length; j+=stride)
+      {
+        all.reg.weight_vector[j] = all.initial_t;   //for adaptive update, we interpret initial_t as previously seeing initial_t fake datapoints, all with squared gradient=1
+        //NOTE: this is not invariant to the scaling of the data (i.e. when combined with normalized). Since scaling the data scales the gradient, this should ideally be
+        //feature_range*initial_t, or something like that. We could potentially fix this by just adding this base quantity times the current range to the sum of gradients
+        //stored in memory at each update, and always start sum of gradients to 0, at the price of additional additions and multiplications during the update...
+      }
     }
+
+    if (g.initial_constant != 0.0)
+      VW::set_weight(all, constant, 0, g.initial_constant);
+  }
 
   if (model_file.files.size() > 0)
+  {
+    bool resume = all.save_resume;
+    char buff[512];
+    uint32_t text_len = sprintf(buff, ":%d\n", resume);
+    bin_text_read_write_fixed(model_file,(char *)&resume, sizeof (resume),
+                              "", read,
+                              buff, text_len, text);
+    if (resume)
     {
-      bool resume = all.save_resume;
-      char buff[512];
-      uint32_t text_len = sprintf(buff, ":%d\n", resume);
-      bin_text_read_write_fixed(model_file,(char *)&resume, sizeof (resume),
-				"", read,
-				buff, text_len, text);
-      if (resume)
-      {
-          if (read && all.model_file_ver < VERSION_SAVE_RESUME_FIX)
-           cerr << endl << "WARNING: --save_resume functionality is known to have inaccuracy in model files version less than " << VERSION_SAVE_RESUME_FIX << endl << endl;
-     // save_load_online_state(g, model_file, read, text);
-        save_load_online_state(all, model_file, read, text, &g);
-      }
-      else
-	save_load_regressor(all, model_file, read, text);
+      if (read && all.model_file_ver < VERSION_SAVE_RESUME_FIX)
+        cerr << endl << "WARNING: --save_resume functionality is known to have inaccuracy in model files version less than " << VERSION_SAVE_RESUME_FIX << endl << endl;
+      // save_load_online_state(g, model_file, read, text);
+      save_load_online_state(all, model_file, read, text, &g);
     }
+    else
+      save_load_regressor(all, model_file, read, text);
+  }
 }
 
 template<bool sparse_l2, bool invariant, bool sqrt_rate, uint32_t adaptive, uint32_t normalized, uint32_t spare, uint32_t next>
@@ -851,17 +854,17 @@ uint32_t set_learn(vw& all, bool feature_mask_off, gd& g)
 {
   all.normalized_idx = normalized;
   if (feature_mask_off)
-    {
-      g.learn = learn<sparse_l2, invariant, sqrt_rate, true, adaptive, normalized, spare>;
-      g.update = update<sparse_l2, invariant, sqrt_rate, true, adaptive, normalized, spare>;
-      return next;
-    }
+  {
+    g.learn = learn<sparse_l2, invariant, sqrt_rate, true, adaptive, normalized, spare>;
+    g.update = update<sparse_l2, invariant, sqrt_rate, true, adaptive, normalized, spare>;
+    return next;
+  }
   else
-    {
-      g.learn = learn<sparse_l2, invariant, sqrt_rate, false, adaptive, normalized, spare>;
-      g.update = update<sparse_l2, invariant, sqrt_rate, false, adaptive, normalized, spare>;
-      return next;
-    }
+  {
+    g.learn = learn<sparse_l2, invariant, sqrt_rate, false, adaptive, normalized, spare>;
+    g.update = update<sparse_l2, invariant, sqrt_rate, false, adaptive, normalized, spare>;
+    return next;
+  }
 }
 
 template<bool invariant, bool sqrt_rate, uint32_t adaptive, uint32_t normalized, uint32_t spare, uint32_t next>
@@ -905,18 +908,18 @@ uint32_t ceil_log_2(uint32_t v)
 {
   if (v==0)
     return 0;
-  else 
+  else
     return 1 + ceil_log_2(v >> 1);
 }
 
 base_learner* setup(vw& all)
 {
   new_options(all, "Gradient Descent options")
-    ("sgd", "use regular stochastic gradient descent update.")
-    ("adaptive", "use adaptive, individual learning rates.")
-    ("invariant", "use safe/importance aware updates.")
-    ("normalized", "use per feature normalized updates")
-    ("sparse_l2", po::value<float>()->default_value(0.f), "use per feature normalized updates");
+  ("sgd", "use regular stochastic gradient descent update.")
+  ("adaptive", "use adaptive, individual learning rates.")
+  ("invariant", "use safe/importance aware updates.")
+  ("normalized", "use per feature normalized updates")
+  ("sparse_l2", po::value<float>()->default_value(0.f), "use per feature normalized updates");
   add_options(all);
   po::variables_map& vm = all.vm;
   gd& g = calloc_or_die<gd>();
@@ -930,10 +933,10 @@ base_learner* setup(vw& all)
   g.neg_power_t = - all.power_t;
 
   if(all.initial_t > 0)//for the normalized update: if initial_t is bigger than 1 we interpret this as if we had seen (all.initial_t) previous fake datapoints all with norm 1
-    {
-      g.all->normalized_sum_norm_x = all.initial_t;
-      g.total_weight = all.initial_t;
-    }
+  {
+    g.all->normalized_sum_norm_x = all.initial_t;
+    g.total_weight = all.initial_t;
+  }
 
   bool feature_mask_off = true;
   if(vm.count("feature_mask"))
@@ -942,51 +945,59 @@ base_learner* setup(vw& all)
   if(!all.holdout_set_off)
   {
     all.sd->holdout_best_loss = FLT_MAX;
-    if(vm.count("early_terminate"))      
-      g.early_stop_thres = vm["early_terminate"].as< size_t>();     
+    if(vm.count("early_terminate"))
+      g.early_stop_thres = vm["early_terminate"].as< size_t>();
   }
 
   if (vm.count("constant")) {
-      g.initial_constant = vm["constant"].as<float>();     
+    g.initial_constant = vm["constant"].as<float>();
   }
 
   if( !all.training || ( ( vm.count("sgd") || vm.count("adaptive") || vm.count("invariant") || vm.count("normalized") ) ) )
-    {//nondefault
-      all.adaptive = all.training && vm.count("adaptive");
-      g.adaptive = all.adaptive;
-      all.invariant_updates = all.training && vm.count("invariant");
-      all.normalized_updates = all.training && vm.count("normalized");
-      g.normalized = all.normalized_updates;
-      
-      if(!vm.count("learning_rate") && !vm.count("l") && !(all.adaptive && all.normalized_updates))
-	all.eta = 10; //default learning rate to 10 for non default update rule
-      
-      //if not using normalized or adaptive, default initial_t to 1 instead of 0
-      if(!all.adaptive && !all.normalized_updates){
-	if (!vm.count("initial_t")) {
-	  all.sd->t = 1.f;
-	  all.sd->weighted_unlabeled_examples = 1.f;
-	  all.initial_t = 1.f;
-	}
-	all.eta *= powf((float)(all.sd->t), all.power_t);
+  { //nondefault
+    all.adaptive = all.training && vm.count("adaptive");
+    g.adaptive = all.adaptive;
+    all.invariant_updates = all.training && vm.count("invariant");
+    all.normalized_updates = all.training && vm.count("normalized");
+    g.normalized = all.normalized_updates;
+
+    if(!vm.count("learning_rate") && !vm.count("l") && !(all.adaptive && all.normalized_updates))
+      all.eta = 10; //default learning rate to 10 for non default update rule
+
+    //if not using normalized or adaptive, default initial_t to 1 instead of 0
+    if(!all.adaptive && !all.normalized_updates) {
+      if (!vm.count("initial_t")) {
+        all.sd->t = 1.f;
+        all.sd->weighted_unlabeled_examples = 1.f;
+        all.initial_t = 1.f;
       }
+      all.eta *= powf((float)(all.sd->t), all.power_t);
     }
-  
+  }
+
   if (pow((double)all.eta_decay_rate, (double)all.numpasses) < 0.0001 )
     cerr << "Warning: the learning rate for the last pass is multiplied by: " << pow((double)all.eta_decay_rate, (double)all.numpasses)
-	 << " adjust --decay_learning_rate larger to avoid this." << endl;
+         << " adjust --decay_learning_rate larger to avoid this." << endl;
 
 
-  
+
   if (all.reg_mode % 2)
     if (all.audit || all.hash_inv) {
-      g.predict = predict<true, true>;   g.multipredict = multipredict<true, true>; }
+      g.predict = predict<true, true>;
+      g.multipredict = multipredict<true, true>;
+    }
     else {
-      g.predict = predict<true, false>;  g.multipredict = multipredict<true, false>; }
+      g.predict = predict<true, false>;
+      g.multipredict = multipredict<true, false>;
+    }
   else if (all.audit || all.hash_inv) {
-    g.predict = predict<false, true>;    g.multipredict = multipredict<false, true>; }
+    g.predict = predict<false, true>;
+    g.multipredict = multipredict<false, true>;
+  }
   else {
-    g.predict = predict<false, false>;   g.multipredict = multipredict<false, false>; }
+    g.predict = predict<false, false>;
+    g.multipredict = multipredict<false, false>;
+  }
 
   uint32_t stride;
   if (all.power_t == 0.5)

--- a/vowpalwabbit/gd.h
+++ b/vowpalwabbit/gd.h
@@ -12,80 +12,88 @@
 #include "constant.h"
 #include "interactions.h"
 
-namespace GD{
-  LEARNER::base_learner* setup(vw& all);
+namespace GD {
+LEARNER::base_learner* setup(vw& all);
 
-  struct gd;
+struct gd;
 
-  float finalize_prediction(shared_data* sd, float ret);
-  void print_audit_features(vw&, example& ec);
-  void save_load_regressor(vw& all, io_buf& model_file, bool read, bool text);
-  void save_load_online_state(vw& all, io_buf& model_file, bool read, bool text, GD::gd *g = nullptr);
+float finalize_prediction(shared_data* sd, float ret);
+void print_audit_features(vw&, example& ec);
+void save_load_regressor(vw& all, io_buf& model_file, bool read, bool text);
+void save_load_online_state(vw& all, io_buf& model_file, bool read, bool text, GD::gd *g = nullptr);
 
-  struct multipredict_info { size_t count; size_t step; polyprediction* pred; regressor* reg; /* & for l1: */ float gravity; };
+struct multipredict_info {
+  size_t count;
+  size_t step;
+  polyprediction* pred;
+  regressor* reg; /* & for l1: */
+  float gravity;
+};
 
-  inline void vec_add_multipredict(multipredict_info& mp, const float fx, uint32_t fi) {
-    if ((-1e-10 < fx) && (fx < 1e-10)) return;
-    weight*w    = mp.reg->weight_vector;
-    size_t mask = mp.reg->weight_mask;
-    polyprediction* p = mp.pred;
+inline void vec_add_multipredict(multipredict_info& mp, const float fx, uint32_t fi) {
+  if ((-1e-10 < fx) && (fx < 1e-10)) return;
+  weight*w    = mp.reg->weight_vector;
+  size_t mask = mp.reg->weight_mask;
+  polyprediction* p = mp.pred;
 
-    fi &= mask;
-    uint32_t top = fi + (uint32_t)((mp.count-1) * mp.step); 
-    if (top <= mask) {
-      weight* last = w + top;
-      w += fi;
-      for (; w <= last; w += mp.step, ++p)
-        p->scalar += fx * *w;
-    } else  // TODO: this could be faster by unrolling into two loops
-      for (size_t c=0; c<mp.count; ++c, fi += (uint32_t)mp.step, ++p) {
-        fi &= mask;
-        p->scalar += fx * w[fi];
-      }
-  }
-  
-  // iterate through one namespace (or its part), callback function T(some_data_R, feature_value_x, feature_weight)
-  template <class R, void (*T)(R&, const float, float&)>
-  inline void foreach_feature(weight* weight_vector, size_t weight_mask, feature* begin, feature* end, R& dat, uint32_t offset=0, float mult=1.)
-  {
-    for (feature* f = begin; f != end; ++f)
-      T(dat, mult*f->x, weight_vector[(f->weight_index + offset) & weight_mask]);
-  }
+  fi &= mask;
+  uint32_t top = fi + (uint32_t)((mp.count-1) * mp.step);
+  if (top <= mask) {
+    weight* last = w + top;
+    w += fi;
+    for (; w <= last; w += mp.step, ++p)
+      p->scalar += fx * *w;
+  } else  // TODO: this could be faster by unrolling into two loops
+    for (size_t c=0; c<mp.count; ++c, fi += (uint32_t)mp.step, ++p) {
+      fi &= mask;
+      p->scalar += fx * w[fi];
+    }
+}
 
-  // iterate through one namespace (or its part), callback function T(some_data_R, feature_value_x, feature_index)
-  template <class R, void (*T)(R&, float, uint32_t)>
-   void foreach_feature(weight* /*weight_vector*/, size_t /*weight_mask*/, feature* begin, feature* end, R&dat, uint32_t offset=0, float mult=1.)
-   {
-     for (feature* f = begin; f != end; ++f)
-       T(dat, mult*f->x, f->weight_index + offset);
-   }
- 
-  // iterate through all namespaces and quadratic&cubic features, callback function T(some_data_R, feature_value_x, S)
-  // where S is EITHER float& feature_weight OR uint32_t feature_index
-  template <class R, class S, void (*T)(R&, float, S)>
-  inline void foreach_feature(vw& all, example& ec, R& dat)
-  {
-    uint32_t offset = ec.ft_offset;
+// iterate through one namespace (or its part), callback function T(some_data_R, feature_value_x, feature_weight)
+template <class R, void (*T)(R&, const float, float&)>
+inline void foreach_feature(weight* weight_vector, size_t weight_mask, feature* begin, feature* end, R& dat, uint32_t offset=0, float mult=1.)
+{
+  for (feature* f = begin; f != end; ++f)
+    T(dat, mult*f->x, weight_vector[(f->weight_index + offset) & weight_mask]);
+}
 
-    for (unsigned char* i = ec.indices.begin; i != ec.indices.end; i++)
-      foreach_feature<R,T>(all.reg.weight_vector, all.reg.weight_mask, ec.atomics[*i].begin, ec.atomics[*i].end, dat, offset);
-     
-    INTERACTIONS::generate_interactions<R,S,T>(all, ec, dat);
-  }
+// iterate through one namespace (or its part), callback function T(some_data_R, feature_value_x, feature_index)
+template <class R, void (*T)(R&, float, uint32_t)>
+void foreach_feature(weight* /*weight_vector*/, size_t /*weight_mask*/, feature* begin, feature* end, R&dat, uint32_t offset=0, float mult=1.)
+{
+  for (feature* f = begin; f != end; ++f)
+    T(dat, mult*f->x, f->weight_index + offset);
+}
 
-  // iterate through all namespaces and quadratic&cubic features, callback function T(some_data_R, feature_value_x, feature_weight)
-  template <class R, void (*T)(R&, float, float&)>
-  inline void foreach_feature(vw& all, example& ec, R& dat)
-  {
-    foreach_feature<R,float&,T>(all, ec, dat);
-  }
+// iterate through all namespaces and quadratic&cubic features, callback function T(some_data_R, feature_value_x, S)
+// where S is EITHER float& feature_weight OR uint32_t feature_index
+template <class R, class S, void (*T)(R&, float, S)>
+inline void foreach_feature(vw& all, example& ec, R& dat)
+{
+  uint32_t offset = ec.ft_offset;
 
- inline void vec_add(float& p, const float fx, float& fw) { p += fw * fx; }
+  for (unsigned char* i = ec.indices.begin; i != ec.indices.end; i++)
+    foreach_feature<R,T>(all.reg.weight_vector, all.reg.weight_mask, ec.atomics[*i].begin, ec.atomics[*i].end, dat, offset);
 
-  inline float inline_predict(vw& all, example& ec)
-  {
-    float temp = ec.l.simple.initial;
-    foreach_feature<float, vec_add>(all, ec, temp);
-    return temp;
-  }
+  INTERACTIONS::generate_interactions<R,S,T>(all, ec, dat);
+}
+
+// iterate through all namespaces and quadratic&cubic features, callback function T(some_data_R, feature_value_x, feature_weight)
+template <class R, void (*T)(R&, float, float&)>
+inline void foreach_feature(vw& all, example& ec, R& dat)
+{
+  foreach_feature<R,float&,T>(all, ec, dat);
+}
+
+inline void vec_add(float& p, const float fx, float& fw) {
+  p += fw * fx;
+}
+
+inline float inline_predict(vw& all, example& ec)
+{
+  float temp = ec.l.simple.initial;
+  foreach_feature<float, vec_add>(all, ec, temp);
+  return temp;
+}
 }

--- a/vowpalwabbit/gd_mf.cc
+++ b/vowpalwabbit/gd_mf.cc
@@ -34,45 +34,45 @@ void mf_print_offset_features(gdmf& d, example& ec, size_t offset)
   vw& all = *d.all;
   weight* weights = all.reg.weight_vector;
   size_t mask = all.reg.weight_mask;
-  for (unsigned char* i = ec.indices.begin; i != ec.indices.end; i++) 
+  for (unsigned char* i = ec.indices.begin; i != ec.indices.end; i++)
     if (ec.audit_features[*i].begin != ec.audit_features[*i].end)
       for (audit_data *f = ec.audit_features[*i].begin; f != ec.audit_features[*i].end; f++)
-	{
-	  cout << '\t' << f->space << '^' << f->feature << ':' << f->weight_index <<"(" << ((f->weight_index + offset) & mask)  << ")" << ':' << f->x;
+      {
+        cout << '\t' << f->space << '^' << f->feature << ':' << f->weight_index <<"(" << ((f->weight_index + offset) & mask)  << ")" << ':' << f->x;
 
-	  cout << ':' << weights[(f->weight_index + offset) & mask];
-	}
+        cout << ':' << weights[(f->weight_index + offset) & mask];
+      }
     else
       for (feature *f = ec.atomics[*i].begin; f != ec.atomics[*i].end; f++)
-	{
-	  size_t index = (f->weight_index + offset) & all.reg.weight_mask;
-	  
-	  cout << "\tConstant:";
-	  cout << ((index >> all.reg.stride_shift) & all.parse_mask) << ':' << f->x;
-	  cout  << ':' << weights[index];
-	}
-  for (vector<string>::iterator i = all.pairs.begin(); i != all.pairs.end();i++) 
-    if (ec.atomics[(int)(*i)[0]].size() > 0 && ec.atomics[(int)(*i)[1]].size() > 0)
       {
-	/* print out nsk^feature:hash:value:weight:nsk^feature^:hash:value:weight:prod_weights */
-	for (size_t k = 1; k <= d.rank; k++)
-	  {
-	    for (audit_data* f = ec.audit_features[(int)(*i)[0]].begin; f!= ec.audit_features[(int)(*i)[0]].end; f++)
-	      for (audit_data* f2 = ec.audit_features[(int)(*i)[1]].begin; f2!= ec.audit_features[(int)(*i)[1]].end; f2++)
-		{
-		  cout << '\t' << f->space << k << '^' << f->feature << ':' << ((f->weight_index+k)&mask) 
-		       <<"(" << ((f->weight_index + offset +k) & mask)  << ")" << ':' << f->x;
-		  cout << ':' << weights[(f->weight_index + offset + k) & mask];
-		  
-		  cout << ':' << f2->space << k << '^' << f2->feature << ':' << ((f2->weight_index+k+d.rank)&mask) 
-		       <<"(" << ((f2->weight_index + offset +k+d.rank) & mask)  << ")" << ':' << f2->x;
-		  cout << ':' << weights[(f2->weight_index + offset + k+d.rank) & mask];
-		  
-		  cout << ':' <<  weights[(f->weight_index + offset + k) & mask] * weights[(f2->weight_index + offset + k + d.rank) & mask];
-		}
-	  }
+        size_t index = (f->weight_index + offset) & all.reg.weight_mask;
+
+        cout << "\tConstant:";
+        cout << ((index >> all.reg.stride_shift) & all.parse_mask) << ':' << f->x;
+        cout  << ':' << weights[index];
       }
-  if (all.triples.begin() != all.triples.end()) 
+  for (vector<string>::iterator i = all.pairs.begin(); i != all.pairs.end(); i++)
+    if (ec.atomics[(int)(*i)[0]].size() > 0 && ec.atomics[(int)(*i)[1]].size() > 0)
+    {
+      /* print out nsk^feature:hash:value:weight:nsk^feature^:hash:value:weight:prod_weights */
+      for (size_t k = 1; k <= d.rank; k++)
+      {
+        for (audit_data* f = ec.audit_features[(int)(*i)[0]].begin; f!= ec.audit_features[(int)(*i)[0]].end; f++)
+          for (audit_data* f2 = ec.audit_features[(int)(*i)[1]].begin; f2!= ec.audit_features[(int)(*i)[1]].end; f2++)
+          {
+            cout << '\t' << f->space << k << '^' << f->feature << ':' << ((f->weight_index+k)&mask)
+                 <<"(" << ((f->weight_index + offset +k) & mask)  << ")" << ':' << f->x;
+            cout << ':' << weights[(f->weight_index + offset + k) & mask];
+
+            cout << ':' << f2->space << k << '^' << f2->feature << ':' << ((f2->weight_index+k+d.rank)&mask)
+                 <<"(" << ((f2->weight_index + offset +k+d.rank) & mask)  << ")" << ':' << f2->x;
+            cout << ':' << weights[(f2->weight_index + offset + k+d.rank) & mask];
+
+            cout << ':' <<  weights[(f->weight_index + offset + k) & mask] * weights[(f2->weight_index + offset + k + d.rank) & mask];
+          }
+      }
+    }
+  if (all.triples.begin() != all.triples.end())
     THROW("cannot use triples in matrix factorization");
   cout << endl;
 }
@@ -89,220 +89,222 @@ float mf_predict(gdmf& d, example& ec)
   label_data& ld = ec.l.simple;
   float prediction = ld.initial;
 
-  for (vector<string>::iterator i = d.all->pairs.begin(); i != d.all->pairs.end();i++)
-    {
-      ec.num_features -= ec.atomics[(int)(*i)[0]].size() * ec.atomics[(int)(*i)[1]].size();
-      ec.num_features += ec.atomics[(int)(*i)[0]].size() * d.rank;
-      ec.num_features += ec.atomics[(int)(*i)[1]].size() * d.rank;
-    }
+  for (vector<string>::iterator i = d.all->pairs.begin(); i != d.all->pairs.end(); i++)
+  {
+    ec.num_features -= ec.atomics[(int)(*i)[0]].size() * ec.atomics[(int)(*i)[1]].size();
+    ec.num_features += ec.atomics[(int)(*i)[0]].size() * d.rank;
+    ec.num_features += ec.atomics[(int)(*i)[1]].size() * d.rank;
+  }
 
   // clear stored predictions
   ec.topic_predictions.erase();
 
   float linear_prediction = 0.;
   // linear terms
-  for (unsigned char* i = ec.indices.begin; i != ec.indices.end; i++) 
+  for (unsigned char* i = ec.indices.begin; i != ec.indices.end; i++)
     GD::foreach_feature<float, GD::vec_add>(all.reg.weight_vector, all.reg.weight_mask, ec.atomics[*i].begin, ec.atomics[*i].end, linear_prediction);
 
   // store constant + linear prediction
   // note: constant is now automatically added
   ec.topic_predictions.push_back(linear_prediction);
-  
+
   prediction += linear_prediction;
 
   // interaction terms
-  for (vector<string>::iterator i = all.pairs.begin(); i != all.pairs.end();i++) 
+  for (vector<string>::iterator i = all.pairs.begin(); i != all.pairs.end(); i++)
+  {
+    if (ec.atomics[(int)(*i)[0]].size() > 0 && ec.atomics[(int)(*i)[1]].size() > 0)
     {
-      if (ec.atomics[(int)(*i)[0]].size() > 0 && ec.atomics[(int)(*i)[1]].size() > 0)
-	{
-	  for (uint32_t k = 1; k <= d.rank; k++)
-	    {
-	      // x_l * l^k
-	      // l^k is from index+1 to index+d.rank
-	      //float x_dot_l = sd_offset_add(weights, mask, ec.atomics[(int)(*i)[0]].begin, ec.atomics[(int)(*i)[0]].end, k);
-              float x_dot_l = 0.;
-	      GD::foreach_feature<float, GD::vec_add>(all.reg.weight_vector, all.reg.weight_mask, ec.atomics[(int)(*i)[0]].begin, ec.atomics[(int)(*i)[0]].end, x_dot_l, k);
-	      // x_r * r^k
-	      // r^k is from index+d.rank+1 to index+2*d.rank
-	      //float x_dot_r = sd_offset_add(weights, mask, ec.atomics[(int)(*i)[1]].begin, ec.atomics[(int)(*i)[1]].end, k+d.rank);
-              float x_dot_r = 0.;
-	      GD::foreach_feature<float,GD::vec_add>(all.reg.weight_vector, all.reg.weight_mask, ec.atomics[(int)(*i)[1]].begin, ec.atomics[(int)(*i)[1]].end, x_dot_r, k+d.rank);
+      for (uint32_t k = 1; k <= d.rank; k++)
+      {
+        // x_l * l^k
+        // l^k is from index+1 to index+d.rank
+        //float x_dot_l = sd_offset_add(weights, mask, ec.atomics[(int)(*i)[0]].begin, ec.atomics[(int)(*i)[0]].end, k);
+        float x_dot_l = 0.;
+        GD::foreach_feature<float, GD::vec_add>(all.reg.weight_vector, all.reg.weight_mask, ec.atomics[(int)(*i)[0]].begin, ec.atomics[(int)(*i)[0]].end, x_dot_l, k);
+        // x_r * r^k
+        // r^k is from index+d.rank+1 to index+2*d.rank
+        //float x_dot_r = sd_offset_add(weights, mask, ec.atomics[(int)(*i)[1]].begin, ec.atomics[(int)(*i)[1]].end, k+d.rank);
+        float x_dot_r = 0.;
+        GD::foreach_feature<float,GD::vec_add>(all.reg.weight_vector, all.reg.weight_mask, ec.atomics[(int)(*i)[1]].begin, ec.atomics[(int)(*i)[1]].end, x_dot_r, k+d.rank);
 
-	      prediction += x_dot_l * x_dot_r;
+        prediction += x_dot_l * x_dot_r;
 
-	      // store prediction from interaction terms
-	      ec.topic_predictions.push_back(x_dot_l);
-	      ec.topic_predictions.push_back(x_dot_r);
-	    }
-	}
+        // store prediction from interaction terms
+        ec.topic_predictions.push_back(x_dot_l);
+        ec.topic_predictions.push_back(x_dot_r);
+      }
     }
+  }
 
-  if (all.triples.begin() != all.triples.end()) 
+  if (all.triples.begin() != all.triples.end())
     THROW("cannot use triples in matrix factorization");
 
-  // ec.topic_predictions has linear, x_dot_l_1, x_dot_r_1, x_dot_l_2, x_dot_r_2, ... 
+  // ec.topic_predictions has linear, x_dot_l_1, x_dot_r_1, x_dot_l_2, x_dot_r_2, ...
 
   ec.partial_prediction = prediction;
 
   all.set_minmax(all.sd, ld.label);
 
   ec.pred.scalar = GD::finalize_prediction(all.sd, ec.partial_prediction);
-  
+
   if (ld.label != FLT_MAX)
     ec.loss = all.loss->getLoss(all.sd, ec.pred.scalar, ld.label) * ld.weight;
-  
+
   if (all.audit)
     mf_print_audit_features(d, ec, 0);
-  
+
   return ec.pred.scalar;
 }
 
 
 void sd_offset_update(weight* weights, size_t mask, feature* begin, feature* end, size_t offset, float update, float regularization)
 {
-  for (feature* f = begin; f!= end; f++) 
+  for (feature* f = begin; f!= end; f++)
     weights[(f->weight_index + offset) & mask] += update * f->x - regularization * weights[(f->weight_index + offset) & mask];
 }
 
-  void mf_train(gdmf& d, example& ec)
+void mf_train(gdmf& d, example& ec)
+{
+  vw& all = *d.all;
+  weight* weights = all.reg.weight_vector;
+  size_t mask = all.reg.weight_mask;
+  label_data& ld = ec.l.simple;
+
+  // use final prediction to get update size
+  // update = eta_t*(y-y_hat) where eta_t = eta/(3*t^p) * importance weight
+  float eta_t = all.eta/pow(ec.example_t,all.power_t) / 3.f * ld.weight;
+  float update = all.loss->getUpdate(ec.pred.scalar, ld.label, eta_t, 1.); //ec.total_sum_feat_sq);
+
+  float regularization = eta_t * all.l2_lambda;
+
+  // linear update
+  for (unsigned char* i = ec.indices.begin; i != ec.indices.end; i++)
+    sd_offset_update(weights, mask, ec.atomics[*i].begin, ec.atomics[*i].end, 0, update, regularization);
+
+  // quadratic update
+  for (vector<string>::iterator i = all.pairs.begin(); i != all.pairs.end(); i++)
   {
-    vw& all = *d.all;
-    weight* weights = all.reg.weight_vector;
-    size_t mask = all.reg.weight_mask;
-    label_data& ld = ec.l.simple;
-    
-    // use final prediction to get update size
-      // update = eta_t*(y-y_hat) where eta_t = eta/(3*t^p) * importance weight
-    float eta_t = all.eta/pow(ec.example_t,all.power_t) / 3.f * ld.weight;
-    float update = all.loss->getUpdate(ec.pred.scalar, ld.label, eta_t, 1.); //ec.total_sum_feat_sq);
-    
-    float regularization = eta_t * all.l2_lambda;
-    
-    // linear update
-    for (unsigned char* i = ec.indices.begin; i != ec.indices.end; i++) 
-      sd_offset_update(weights, mask, ec.atomics[*i].begin, ec.atomics[*i].end, 0, update, regularization);
-    
-    // quadratic update
-    for (vector<string>::iterator i = all.pairs.begin(); i != all.pairs.end();i++) 
+    if (ec.atomics[(int)(*i)[0]].size() > 0 && ec.atomics[(int)(*i)[1]].size() > 0)
+    {
+
+      // update l^k weights
+      for (size_t k = 1; k <= d.rank; k++)
       {
-	if (ec.atomics[(int)(*i)[0]].size() > 0 && ec.atomics[(int)(*i)[1]].size() > 0)
-	  {
-	    
-	    // update l^k weights
-	    for (size_t k = 1; k <= d.rank; k++)
-	      {
-		// r^k \cdot x_r
-		float r_dot_x = ec.topic_predictions[2*k];
-		// l^k <- l^k + update * (r^k \cdot x_r) * x_l
-		sd_offset_update(weights, mask, ec.atomics[(int)(*i)[0]].begin, ec.atomics[(int)(*i)[0]].end, k, update*r_dot_x, regularization);
-	      }
-	    // update r^k weights
-	    for (size_t k = 1; k <= d.rank; k++)
-	      {
-		// l^k \cdot x_l
-		float l_dot_x = ec.topic_predictions[2*k-1];
-		// r^k <- r^k + update * (l^k \cdot x_l) * x_r
-		sd_offset_update(weights, mask, ec.atomics[(int)(*i)[1]].begin, ec.atomics[(int)(*i)[1]].end, k+d.rank, update*l_dot_x, regularization);
-	      }
-	    
-	  }
+        // r^k \cdot x_r
+        float r_dot_x = ec.topic_predictions[2*k];
+        // l^k <- l^k + update * (r^k \cdot x_r) * x_l
+        sd_offset_update(weights, mask, ec.atomics[(int)(*i)[0]].begin, ec.atomics[(int)(*i)[0]].end, k, update*r_dot_x, regularization);
       }
-    if (all.triples.begin() != all.triples.end()) 
-      THROW("cannot use triples in matrix factorization");
-  }  
-  
-  void save_load(gdmf& d, io_buf& model_file, bool read, bool text)
+      // update r^k weights
+      for (size_t k = 1; k <= d.rank; k++)
+      {
+        // l^k \cdot x_l
+        float l_dot_x = ec.topic_predictions[2*k-1];
+        // r^k <- r^k + update * (l^k \cdot x_l) * x_r
+        sd_offset_update(weights, mask, ec.atomics[(int)(*i)[1]].begin, ec.atomics[(int)(*i)[1]].end, k+d.rank, update*l_dot_x, regularization);
+      }
+
+    }
+  }
+  if (all.triples.begin() != all.triples.end())
+    THROW("cannot use triples in matrix factorization");
+}
+
+void save_load(gdmf& d, io_buf& model_file, bool read, bool text)
 {
   vw* all = d.all;
   uint32_t length = 1 << all->num_bits;
   uint32_t stride_shift = all->reg.stride_shift;
 
   if(read)
-    {
-      initialize_regressor(*all);
-      if(all->random_weights)
-	for (size_t j = 0; j < (length << stride_shift); j++)
-	  all->reg.weight_vector[j] = (float) (0.1 * frand48()); 
-    }
+  {
+    initialize_regressor(*all);
+    if(all->random_weights)
+      for (size_t j = 0; j < (length << stride_shift); j++)
+        all->reg.weight_vector[j] = (float) (0.1 * frand48());
+  }
 
   if (model_file.files.size() > 0)
+  {
+    uint32_t i = 0;
+    uint32_t text_len;
+    char buff[512];
+    size_t brw = 1;
+
+    do
     {
-      uint32_t i = 0;
-      uint32_t text_len;
-      char buff[512];
-      size_t brw = 1;
+      brw = 0;
+      size_t K = d.rank*2+1;
 
-      do 
-	{
-	  brw = 0;
-	  size_t K = d.rank*2+1;
-	  
-	  text_len = sprintf(buff, "%d ", i);
-	  brw += bin_text_read_write_fixed(model_file,(char *)&i, sizeof (i),
-					   "", read,
-					   buff, text_len, text);
-	  if (brw != 0)
-	    for (uint32_t k = 0; k < K; k++)
-	      {
-		uint32_t ndx = (i << stride_shift)+k;
-		
-		weight* v = &(all->reg.weight_vector[ndx]);
-		text_len = sprintf(buff, "%f ", *v);
-		brw += bin_text_read_write_fixed(model_file,(char *)v, sizeof (*v),
-						 "", read,
-						 buff, text_len, text);
-		
-	      }
-	  if (text)
-	    brw += bin_text_read_write_fixed(model_file,buff,0,
-					     "", read,
-					     "\n",1,text);
-	  
-	  if (!read)
-	    i++;
-	}  
-      while ((!read && i < length) || (read && brw >0));
+      text_len = sprintf(buff, "%d ", i);
+      brw += bin_text_read_write_fixed(model_file,(char *)&i, sizeof (i),
+                                       "", read,
+                                       buff, text_len, text);
+      if (brw != 0)
+        for (uint32_t k = 0; k < K; k++)
+        {
+          uint32_t ndx = (i << stride_shift)+k;
+
+          weight* v = &(all->reg.weight_vector[ndx]);
+          text_len = sprintf(buff, "%f ", *v);
+          brw += bin_text_read_write_fixed(model_file,(char *)v, sizeof (*v),
+                                           "", read,
+                                           buff, text_len, text);
+
+        }
+      if (text)
+        brw += bin_text_read_write_fixed(model_file,buff,0,
+                                         "", read,
+                                         "\n",1,text);
+
+      if (!read)
+        i++;
     }
+    while ((!read && i < length) || (read && brw >0));
+  }
 }
-  
-  void end_pass(gdmf& d)
+
+void end_pass(gdmf& d)
+{
+  vw* all = d.all;
+
+  all->eta *= all->eta_decay_rate;
+  if (all->save_per_pass)
+    save_predictor(*all, all->final_regressor_name, all->current_pass);
+
+  all->current_pass++;
+
+  if(!all->holdout_set_off)
   {
-    vw* all = d.all;
-    
-    all->eta *= all->eta_decay_rate;
-    if (all->save_per_pass)
-      save_predictor(*all, all->final_regressor_name, all->current_pass);
-    
-    all->current_pass++;
-
-    if(!all->holdout_set_off)
-      {
-        if(summarize_holdout_set(*all, d.no_win_counter))
-          finalize_regressor(*all, all->final_regressor_name);
-        if((d.early_stop_thres == d.no_win_counter) &&
-           ((all->check_holdout_every_n_passes <= 1) ||
-            ((all->current_pass % all->check_holdout_every_n_passes) == 0)))
-	  set_done(*all);
-      }
+    if(summarize_holdout_set(*all, d.no_win_counter))
+      finalize_regressor(*all, all->final_regressor_name);
+    if((d.early_stop_thres == d.no_win_counter) &&
+        ((all->check_holdout_every_n_passes <= 1) ||
+         ((all->current_pass % all->check_holdout_every_n_passes) == 0)))
+      set_done(*all);
   }
+}
 
-  void predict(gdmf& d, base_learner&, example& ec) { mf_predict(d,ec); }
+void predict(gdmf& d, base_learner&, example& ec) {
+  mf_predict(d,ec);
+}
 
-  void learn(gdmf& d, base_learner&, example& ec)
-  {
-    vw& all = *d.all;
- 
-    mf_predict(d, ec);
-    if (all.training && ec.l.simple.label != FLT_MAX)
-      mf_train(d, ec);
-  }
+void learn(gdmf& d, base_learner&, example& ec)
+{
+  vw& all = *d.all;
+
+  mf_predict(d, ec);
+  if (all.training && ec.l.simple.label != FLT_MAX)
+    mf_train(d, ec);
+}
 
 base_learner* gd_mf_setup(vw& all)
 {
   if (missing_option<uint32_t, true>(all, "rank", "rank for matrix factorization."))
     return nullptr;
-  
-  gdmf& data = calloc_or_die<gdmf>(); 
+
+  gdmf& data = calloc_or_die<gdmf>();
   data.all = &all;
   data.rank = all.vm["rank"].as<uint32_t>();
   data.no_win_counter = 0;
@@ -312,7 +314,7 @@ base_learner* gd_mf_setup(vw& all)
   float temp = ceilf(logf((float)(data.rank*2+1)) / logf (2.f));
   all.reg.stride_shift = (size_t) temp;
   all.random_weights = true;
-  
+
   if (all.vm.count("adaptive"))
     THROW("adaptive is not implemented for matrix factorization");
   if (all.vm.count("normalized"))
@@ -325,13 +327,13 @@ base_learner* gd_mf_setup(vw& all)
   if(!all.holdout_set_off)
   {
     all.sd->holdout_best_loss = FLT_MAX;
-    if(all.vm.count("early_terminate"))      
-      data.early_stop_thres = all.vm["early_terminate"].as< size_t>();     
+    if(all.vm.count("early_terminate"))
+      data.early_stop_thres = all.vm["early_terminate"].as< size_t>();
   }
-  
+
   if(!all.vm.count("learning_rate") && !all.vm.count("l"))
     all.eta = 10; //default learning rate to 10 for non default update rule
-  
+
   //default initial_t to 1 instead of 0
   if(!all.vm.count("initial_t")) {
     all.sd->t = 1.f;
@@ -339,11 +341,11 @@ base_learner* gd_mf_setup(vw& all)
     all.initial_t = 1.f;
   }
   all.eta *= powf((float)(all.sd->t), all.power_t);
-  
+
   learner<gdmf>& l = init_learner(&data, learn, 1 << all.reg.stride_shift);
   l.set_predict(predict);
   l.set_save_load(save_load);
   l.set_end_pass(end_pass);
-  
+
   return make_base(l);
 }

--- a/vowpalwabbit/global_data.cc
+++ b/vowpalwabbit/global_data.cc
@@ -28,26 +28,25 @@ size_t really_read(int sock, void* in, size_t count)
   size_t done = 0;
   int r = 0;
   while (done < count)
-    {
-      if ((r =
+  {
+    if ((r =
 #ifdef _WIN32
-		  recv(sock,buf,(unsigned int)(count-done),0)
+           recv(sock,buf,(unsigned int)(count-done),0)
 #else
-		  read(sock,buf,(unsigned int)(count-done))
+           read(sock,buf,(unsigned int)(count-done))
 #endif
-		  ) == 0)
-	return 0;
-      else
-	if (r < 0)
-	  {
-	    THROWERRNO("read(" << sock << "," << count << "-" << done << ")");
-	  }
-	else
-	  {
-	    done += r;
-	    buf += r;
-	  }
+        ) == 0)
+      return 0;
+    else if (r < 0)
+    {
+      THROWERRNO("read(" << sock << "," << count << "-" << done << ")");
     }
+    else
+    {
+      done += r;
+      buf += r;
+    }
+  }
   return done;
 }
 
@@ -63,26 +62,26 @@ void send_prediction(int sock, global_prediction p)
 {
   if (
 #ifdef _WIN32
-	  send(sock, reinterpret_cast<const char*>(&p), sizeof(p), 0)
+    send(sock, reinterpret_cast<const char*>(&p), sizeof(p), 0)
 #else
-	  write(sock, &p, sizeof(p))
+    write(sock, &p, sizeof(p))
 #endif
-	  < (int)sizeof(p))
+    < (int)sizeof(p))
     THROWERRNO("send_prediction write(" << sock << ")");
 }
 
 void binary_print_result(int f, float res, float weight, v_array<char>)
 {
   if (f >= 0)
-    {
-      global_prediction ps = {res, weight};
-      send_prediction(f, ps);
-    }
+  {
+    global_prediction ps = {res, weight};
+    send_prediction(f, ps);
+  }
 }
 
 int print_tag(std::stringstream& ss, v_array<char> tag)
 {
-  if (tag.begin != tag.end){
+  if (tag.begin != tag.end) {
     ss << ' ';
     ss.write(tag.begin, sizeof(char)*tag.size());
   }
@@ -92,20 +91,20 @@ int print_tag(std::stringstream& ss, v_array<char> tag)
 void print_result(int f, float res, float, v_array<char> tag)
 {
   if (f >= 0)
+  {
+    char temp[30];
+    sprintf(temp, "%f", res);
+    std::stringstream ss;
+    ss << temp;
+    print_tag(ss, tag);
+    ss << '\n';
+    ssize_t len = ss.str().size();
+    ssize_t t = io_buf::write_file_or_socket(f, ss.str().c_str(), (unsigned int)len);
+    if (t != len)
     {
-      char temp[30];
-      sprintf(temp, "%f", res);
-      std::stringstream ss;
-      ss << temp;
-      print_tag(ss, tag);
-      ss << '\n';
-      ssize_t len = ss.str().size();
-      ssize_t t = io_buf::write_file_or_socket(f, ss.str().c_str(), (unsigned int)len);
-      if (t != len)
-        {
-          cerr << "write error: " << strerror(errno) << endl;
-        }
+      cerr << "write error: " << strerror(errno) << endl;
     }
+  }
 }
 
 void print_raw_text(int f, string s, v_array<char> tag)
@@ -120,30 +119,30 @@ void print_raw_text(int f, string s, v_array<char> tag)
   ssize_t len = ss.str().size();
   ssize_t t = io_buf::write_file_or_socket(f, ss.str().c_str(), (unsigned int)len);
   if (t != len)
-    {
-      cerr << "write error: " << strerror(errno) << endl;
-    }
+  {
+    cerr << "write error: " << strerror(errno) << endl;
+  }
 }
 
 void print_lda_result(vw& all, int f, float* res, float, v_array<char> tag)
 {
   if (f >= 0)
+  {
+    std::stringstream ss;
+    char temp[30];
+    for (size_t k = 0; k < all.lda; k++)
     {
-      std::stringstream ss;
-      char temp[30];
-      for (size_t k = 0; k < all.lda; k++)
-	{
-	  sprintf(temp, "%f ", res[k]);
-          ss << temp;
-	}
-      print_tag(ss, tag);
-      ss << '\n';
-      ssize_t len = ss.str().size();
-      ssize_t t = io_buf::write_file_or_socket(f, ss.str().c_str(), (unsigned int)len);
-
-      if (t != len)
-        cerr << "write error: " << strerror(errno) << endl;
+      sprintf(temp, "%f ", res[k]);
+      ss << temp;
     }
+    print_tag(ss, tag);
+    ss << '\n';
+    ssize_t len = ss.str().size();
+    ssize_t t = io_buf::write_file_or_socket(f, ss.str().c_str(), (unsigned int)len);
+
+    if (t != len)
+      cerr << "write error: " << strerror(errno) << endl;
+  }
 }
 
 void set_mm(shared_data* sd, float label)
@@ -164,49 +163,49 @@ void vw::learn(example* ec)
 void compile_gram(vector<string> grams, uint32_t* dest, char* descriptor, bool quiet)
 {
   for (size_t i = 0; i < grams.size(); i++)
+  {
+    string ngram = grams[i];
+    if ( isdigit(ngram[0]) )
     {
-      string ngram = grams[i];
-      if ( isdigit(ngram[0]) )
-	{
-	  int n = atoi(ngram.c_str());
-	  if (!quiet)
-	    cerr << "Generating " << n << "-" << descriptor << " for all namespaces." << endl;
-	  for (size_t j = 0; j < 256; j++)
-	    dest[j] = n;
-	}
-      else if ( ngram.size() == 1)
-	cout << "You must specify the namespace index before the n" << endl;
-      else {
-	int n = atoi(ngram.c_str()+1);
-	dest[(uint32_t)ngram[0]] = n;
-	if (!quiet)
-	  cerr << "Generating " << n << "-" << descriptor << " for " << ngram[0] << " namespaces." << endl;
-      }
+      int n = atoi(ngram.c_str());
+      if (!quiet)
+        cerr << "Generating " << n << "-" << descriptor << " for all namespaces." << endl;
+      for (size_t j = 0; j < 256; j++)
+        dest[j] = n;
     }
+    else if ( ngram.size() == 1)
+      cout << "You must specify the namespace index before the n" << endl;
+    else {
+      int n = atoi(ngram.c_str()+1);
+      dest[(uint32_t)ngram[0]] = n;
+      if (!quiet)
+        cerr << "Generating " << n << "-" << descriptor << " for " << ngram[0] << " namespaces." << endl;
+    }
+  }
 }
 
 void compile_limits(vector<string> limits, uint32_t* dest, bool quiet)
 {
   for (size_t i = 0; i < limits.size(); i++)
+  {
+    string limit = limits[i];
+    if ( isdigit(limit[0]) )
     {
-      string limit = limits[i];
-      if ( isdigit(limit[0]) )
-	{
-	  int n = atoi(limit.c_str());
-	  if (!quiet)
-	    cerr << "limiting to " << n << "features for each namespace." << endl;
-	  for (size_t j = 0; j < 256; j++)
-	    dest[j] = n;
-	}
-      else if ( limit.size() == 1)
-	cout << "You must specify the namespace index before the n" << endl;
-      else {
-	int n = atoi(limit.c_str()+1);
-	dest[(uint32_t)limit[0]] = n;
-	if (!quiet)
-	  cerr << "limiting to " << n << " for namespaces " << limit[0] << endl;
-      }
+      int n = atoi(limit.c_str());
+      if (!quiet)
+        cerr << "limiting to " << n << "features for each namespace." << endl;
+      for (size_t j = 0; j < 256; j++)
+        dest[j] = n;
     }
+    else if ( limit.size() == 1)
+      cout << "You must specify the namespace index before the n" << endl;
+    else {
+      int n = atoi(limit.c_str()+1);
+      dest[(uint32_t)limit[0]] = n;
+      if (!quiet)
+        cerr << "limiting to " << n << " for namespaces " << limit[0] << endl;
+    }
+  }
 }
 
 void add_options(vw& all, po::options_description& opts)
@@ -214,11 +213,11 @@ void add_options(vw& all, po::options_description& opts)
   all.opts.add(opts);
   //parse local opts once for notifications.
   po::parsed_options parsed = po::command_line_parser(all.args).
-    style(po::command_line_style::default_style ^ po::command_line_style::allow_guessing).
-    options(opts).allow_unregistered().run();
+                              style(po::command_line_style::default_style ^ po::command_line_style::allow_guessing).
+                              options(opts).allow_unregistered().run();
   po::variables_map new_vm;
   po::store(parsed, new_vm);
-  po::notify(new_vm); 
+  po::notify(new_vm);
 
   for (po::variables_map::iterator it=new_vm.begin(); it!=new_vm.end(); ++it)
     all.vm.insert(*it);
@@ -234,15 +233,15 @@ bool no_new_options(vw& all)
 {
   //parse local opts once for notifications.
   po::parsed_options parsed = po::command_line_parser(all.args).
-    style(po::command_line_style::default_style ^ po::command_line_style::allow_guessing).
-    options(*all.new_opts).allow_unregistered().run();
+                              style(po::command_line_style::default_style ^ po::command_line_style::allow_guessing).
+                              options(*all.new_opts).allow_unregistered().run();
   po::variables_map new_vm;
   po::store(parsed, new_vm);
   all.opts.add(*all.new_opts);
   delete all.new_opts;
   for (po::variables_map::iterator it=new_vm.begin(); it!=new_vm.end(); ++it)
     all.vm.insert(*it);
-  
+
   if (new_vm.size() == 0) // required are missing;
     return true;
   else
@@ -309,11 +308,11 @@ vw::vw()
   per_feature_regularizer_output = "";
   per_feature_regularizer_text = "";
 
-  #ifdef _WIN32
+#ifdef _WIN32
   stdout_fileno = _fileno(stdout);
-  #else
+#else
   stdout_fileno = fileno(stdout);
-  #endif
+#endif
 
   searchstr = nullptr;
 
@@ -330,13 +329,13 @@ vw::vw()
   node = 0;
 
   for (size_t i = 0; i < 256; i++)
-    {
-      ngram[i] = 0;
-      skips[i] = 0;
-      limit[i] = INT_MAX;
-      affix_features[i] = 0;
-      spelling_features[i] = 0;
-    }
+  {
+    ngram[i] = 0;
+    skips[i] = 0;
+    limit[i] = INT_MAX;
+    affix_features[i] = 0;
+    spelling_features[i] = 0;
+  }
 
   interactions = v_init<v_string>();
 

--- a/vowpalwabbit/global_data.h
+++ b/vowpalwabbit/global_data.h
@@ -468,7 +468,7 @@ struct vw {
   bool     spelling_features[256]; // generate spelling features for which namespace
   vector<string> dictionary_path;  // where to look for dictionaries
   vector<feature_dict*> namespace_dictionaries[256]; // each namespace has a list of dictionaries attached to it
-  vector<dictionary_info> read_dictionaries; // which dictionaries have we read?
+  vector<dictionary_info> loaded_dictionaries; // which dictionaries have we loaded from a file to memory?
   
   bool multilabel_prediction;
   bool audit;//should I print lots of debugging information?

--- a/vowpalwabbit/global_data.h
+++ b/vowpalwabbit/global_data.h
@@ -62,7 +62,7 @@ struct version_struct {
     version_struct v_tmp(v_str);
     return (*this != v_tmp);
   }
-  bool operator>=(version_struct v){
+  bool operator>=(version_struct v) {
     if(major < v.major) return false;
     if(major > v.major) return true;
     if(minor < v.minor) return false;
@@ -131,13 +131,13 @@ struct dictionary_info {
 };
 
 class namedlabels {
-  private:
+private:
 
   v_array<substring> id2name;
   v_hashmap<substring,uint32_t> name2id;
   uint32_t K;
 
-  public:
+public:
 
   namedlabels(string label_list) {
     id2name = v_init<substring>();
@@ -151,7 +151,7 @@ class namedlabels {
       substring& l = id2name[k];
       size_t hash = uniform_hash((unsigned char*)l.begin, l.end-l.begin, 378401);
       uint32_t id = name2id.get(l, hash);
-      if (id != 0) 
+      if (id != 0)
         THROW("error: label dictionary initialized with multiple occurances of: " << l);
       size_t len = l.end - l.begin;
       substring l_copy = { calloc_or_die<char>(len), nullptr };
@@ -167,8 +167,10 @@ class namedlabels {
     id2name.delete_v();
   }
 
-  uint32_t getK() { return K; }
-  
+  uint32_t getK() {
+    return K;
+  }
+
   uint32_t get(substring& s) {
     size_t hash = uniform_hash((unsigned char*)s.begin, s.end-s.begin, 378401);
     uint32_t v  =  name2id.get(s, hash);
@@ -209,7 +211,7 @@ struct shared_data {
   float max_label;//maximum label encountered
 
   namedlabels* ldict;
-  
+
   //for holdout
   double weighted_holdout_examples;
   double weighted_holdout_examples_since_last_dump;
@@ -238,76 +240,76 @@ struct shared_data {
   void update(bool test_example, float loss, float weight, size_t num_features)
   {
     if(test_example)
-      {
-	weighted_holdout_examples += weight;//test weight seen
-	weighted_holdout_examples_since_last_dump += weight;
-	weighted_holdout_examples_since_last_pass += weight;
-	holdout_sum_loss += loss;
-	holdout_sum_loss_since_last_dump += loss;
-	holdout_sum_loss_since_last_pass += loss;//since last pass
-      }
+    {
+      weighted_holdout_examples += weight;//test weight seen
+      weighted_holdout_examples_since_last_dump += weight;
+      weighted_holdout_examples_since_last_pass += weight;
+      holdout_sum_loss += loss;
+      holdout_sum_loss_since_last_dump += loss;
+      holdout_sum_loss_since_last_pass += loss;//since last pass
+    }
     else
-      {
-	weighted_examples += weight;
-	sum_loss += loss;
-	sum_loss_since_last_dump += loss;
-	total_features += num_features;
-	example_number++;
-      }
+    {
+      weighted_examples += weight;
+      sum_loss += loss;
+      sum_loss_since_last_dump += loss;
+      total_features += num_features;
+      example_number++;
+    }
   }
 
   inline void update_dump_interval(bool progress_add, float progress_arg) {
     sum_loss_since_last_dump = 0.0;
     old_weighted_examples = weighted_examples;
-    if (progress_add)  
+    if (progress_add)
       dump_interval = (float)weighted_examples + progress_arg;
-    else 
+    else
       dump_interval = (float)weighted_examples * progress_arg;
   }
 
   void print_update(bool holdout_set_off, size_t current_pass, float label, float prediction,
-		    size_t num_features, bool progress_add, float progress_arg)
+                    size_t num_features, bool progress_add, float progress_arg)
   {
     std::ostringstream label_buf, pred_buf;
 
     label_buf << std::setw(col_current_label)
               << std::setfill(' ');
     if (label < FLT_MAX)
-	label_buf << std::setprecision(prec_current_label) << std::fixed << std::right << label;
+      label_buf << std::setprecision(prec_current_label) << std::fixed << std::right << label;
     else
-	label_buf << std::left << " unknown";
+      label_buf << std::left << " unknown";
 
     pred_buf << std::setw(col_current_predict) << std::setprecision(prec_current_predict)
-	     << std::fixed << std::right
+             << std::fixed << std::right
              << std::setfill(' ')
-	     << prediction;
+             << prediction;
 
     print_update(holdout_set_off, current_pass, label_buf.str(), pred_buf.str(), num_features,
-		 progress_add, progress_arg);
+                 progress_add, progress_arg);
   }
 
   void print_update(bool holdout_set_off, size_t current_pass, uint32_t label, uint32_t prediction,
-		    size_t num_features, bool progress_add, float progress_arg)
+                    size_t num_features, bool progress_add, float progress_arg)
   {
     std::ostringstream label_buf, pred_buf;
 
     label_buf << std::setw(col_current_label)
               << std::setfill(' ');
     if (label < INT_MAX)
-	label_buf << std::right << label;
+      label_buf << std::right << label;
     else
-	label_buf << std::left << " unknown";
-    
-    pred_buf << std::setw(col_current_predict) << std::right 
+      label_buf << std::left << " unknown";
+
+    pred_buf << std::setw(col_current_predict) << std::right
              << std::setfill(' ')
              << prediction;
 
     print_update(holdout_set_off, current_pass, label_buf.str(), pred_buf.str(), num_features,
-		 progress_add, progress_arg);
+                 progress_add, progress_arg);
   }
 
   void print_update(bool holdout_set_off, size_t current_pass, const std::string &label, uint32_t prediction,
-		    size_t num_features, bool progress_add, float progress_arg)
+                    size_t num_features, bool progress_add, float progress_arg)
   {
     std::ostringstream pred_buf;
 
@@ -315,11 +317,11 @@ struct shared_data {
              << prediction;
 
     print_update(holdout_set_off, current_pass, label, pred_buf.str(), num_features,
-		 progress_add, progress_arg);
+                 progress_add, progress_arg);
   }
 
   void print_update(bool holdout_set_off, size_t current_pass, const std::string &label, const std::string &prediction,
-		    size_t num_features, bool progress_add, float progress_arg)
+                    size_t num_features, bool progress_add, float progress_arg)
   {
     std::streamsize saved_w = std::cerr.width();
     std::streamsize saved_prec = std::cerr.precision();
@@ -327,48 +329,48 @@ struct shared_data {
     bool holding_out = false;
 
     if(!holdout_set_off && current_pass >= 1)
-      {
-	if(holdout_sum_loss == 0. && weighted_holdout_examples == 0.)
-	  std::cerr << std::setw(col_avg_loss) << std::left << " unknown";
-	else
-	  std::cerr << std::setw(col_avg_loss) << std::setprecision(prec_avg_loss) << std::fixed << std::right
-		    << (holdout_sum_loss / weighted_holdout_examples);
+    {
+      if(holdout_sum_loss == 0. && weighted_holdout_examples == 0.)
+        std::cerr << std::setw(col_avg_loss) << std::left << " unknown";
+      else
+        std::cerr << std::setw(col_avg_loss) << std::setprecision(prec_avg_loss) << std::fixed << std::right
+                  << (holdout_sum_loss / weighted_holdout_examples);
 
-	std::cerr << " ";
+      std::cerr << " ";
 
-	if(holdout_sum_loss_since_last_dump == 0. && weighted_holdout_examples_since_last_dump == 0.)
-	  std::cerr << std::setw(col_since_last) << std::left << " unknown";
-	else
-	  std::cerr << std::setw(col_since_last) << std::setprecision(prec_since_last) << std::fixed << std::right
-		    << (holdout_sum_loss_since_last_dump/weighted_holdout_examples_since_last_dump);
-	
-	weighted_holdout_examples_since_last_dump = 0;
-	holdout_sum_loss_since_last_dump = 0.0;
+      if(holdout_sum_loss_since_last_dump == 0. && weighted_holdout_examples_since_last_dump == 0.)
+        std::cerr << std::setw(col_since_last) << std::left << " unknown";
+      else
+        std::cerr << std::setw(col_since_last) << std::setprecision(prec_since_last) << std::fixed << std::right
+                  << (holdout_sum_loss_since_last_dump/weighted_holdout_examples_since_last_dump);
 
-	holding_out = true;
-      }
+      weighted_holdout_examples_since_last_dump = 0;
+      holdout_sum_loss_since_last_dump = 0.0;
+
+      holding_out = true;
+    }
     else
-      {
-	std::cerr << std::setw(col_avg_loss) << std::setprecision(prec_avg_loss) << std::right << std::fixed
-		  << (sum_loss / weighted_examples)
-		  << " "
-	          << std::setw(col_since_last) << std::setprecision(prec_avg_loss) << std::right << std::fixed
-		  << (sum_loss_since_last_dump / (weighted_examples - old_weighted_examples));
-      }
+    {
+      std::cerr << std::setw(col_avg_loss) << std::setprecision(prec_avg_loss) << std::right << std::fixed
+                << (sum_loss / weighted_examples)
+                << " "
+                << std::setw(col_since_last) << std::setprecision(prec_avg_loss) << std::right << std::fixed
+                << (sum_loss_since_last_dump / (weighted_examples - old_weighted_examples));
+    }
 
     std::cerr << " "
-	      << std::setw(col_example_counter) << std::right << example_number
-	      << " "
-	      << std::setw(col_example_weight) << std::setprecision(prec_example_weight) << std::right << weighted_examples
-	      << " "
+              << std::setw(col_example_counter) << std::right << example_number
+              << " "
+              << std::setw(col_example_weight) << std::setprecision(prec_example_weight) << std::right << weighted_examples
+              << " "
               << std::setw(col_current_label) << std::right << label
               << " "
-	      << std::setw(col_current_predict) << std::right << prediction
-	      << " "
-	      << std::setw(col_current_features) << std::right << num_features;
+              << std::setw(col_current_predict) << std::right << prediction
+              << " "
+              << std::setw(col_current_features) << std::right << num_features;
 
     if (holding_out)
-	std::cerr << " h";
+      std::cerr << " h";
 
     std::cerr << std::endl;
     std::cerr.flush();
@@ -469,7 +471,7 @@ struct vw {
   vector<string> dictionary_path;  // where to look for dictionaries
   vector<feature_dict*> namespace_dictionaries[256]; // each namespace has a list of dictionaries attached to it
   vector<dictionary_info> loaded_dictionaries; // which dictionaries have we loaded from a file to memory?
-  
+
   bool multilabel_prediction;
   bool audit;//should I print lots of debugging information?
   bool quiet;//Should I suppress progress-printing of updates?
@@ -498,7 +500,9 @@ struct vw {
   std::string inv_hash_regressor_name;
   std::string span_server;
 
-  size_t length () { return ((size_t)1) << num_bits; };
+  size_t length () {
+    return ((size_t)1) << num_bits;
+  };
 
   v_array<LEARNER::base_learner* (*)(vw&)> reduction_stack;
 
@@ -551,7 +555,7 @@ void compile_gram(vector<string> grams, uint32_t* dest, char* descriptor, bool q
 void compile_limits(vector<string> limits, uint32_t* dest, bool quiet);
 int print_tag(std::stringstream& ss, v_array<char> tag);
 void add_options(vw& all, po::options_description& opts);
-inline po::options_description_easy_init new_options(vw& all, std::string name = "\0") 
+inline po::options_description_easy_init new_options(vw& all, std::string name = "\0")
 {
   all.new_opts = new po::options_description(name);
   return all.new_opts->add_options();
@@ -564,7 +568,7 @@ template <class T> bool missing_option(vw& all, const char* name, const char* de
   return no_new_options(all);
 }
 template <class T, bool keep> bool missing_option(vw& all, const char* name,
-						  const char* description)
+    const char* description)
 {
   if (missing_option<T>(all, name, description))
     return true;

--- a/vowpalwabbit/hash.cc
+++ b/vowpalwabbit/hash.cc
@@ -28,14 +28,14 @@
 
 namespace MURMUR_HASH_3 {
 
-	//-----------------------------------------------------------------------------
-	// Block read - if your platform needs to do endian-swapping or can only
-	// handle aligned reads, do the conversion here
+//-----------------------------------------------------------------------------
+// Block read - if your platform needs to do endian-swapping or can only
+// handle aligned reads, do the conversion here
 
-	static inline uint32_t getblock(const uint32_t * p, int i)
-	{
-		return p[i];
-	}
+static inline uint32_t getblock(const uint32_t * p, int i)
+{
+  return p[i];
+}
 
 }
 
@@ -43,43 +43,49 @@ namespace MURMUR_HASH_3 {
 
 uint32_t uniform_hash(const void * key, size_t len, uint32_t seed)
 {
-	const uint8_t * data = (const uint8_t*)key;
-	const int nblocks = (int)len / 4;
+  const uint8_t * data = (const uint8_t*)key;
+  const int nblocks = (int)len / 4;
 
-	uint32_t h1 = seed;
+  uint32_t h1 = seed;
 
-	const uint32_t c1 = 0xcc9e2d51;
-	const uint32_t c2 = 0x1b873593;
+  const uint32_t c1 = 0xcc9e2d51;
+  const uint32_t c2 = 0x1b873593;
 
-	// --- body
-	const uint32_t * blocks = (const uint32_t *)(data + nblocks * 4);
+  // --- body
+  const uint32_t * blocks = (const uint32_t *)(data + nblocks * 4);
 
-	for (int i = -nblocks; i; i++) {
-		uint32_t k1 = MURMUR_HASH_3::getblock(blocks, i);
+  for (int i = -nblocks; i; i++) {
+    uint32_t k1 = MURMUR_HASH_3::getblock(blocks, i);
 
-		k1 *= c1;
-		k1 = ROTL32(k1, 15);
-		k1 *= c2;
+    k1 *= c1;
+    k1 = ROTL32(k1, 15);
+    k1 *= c2;
 
-		h1 ^= k1;
-		h1 = ROTL32(h1, 13);
-		h1 = h1 * 5 + 0xe6546b64;
-	}
+    h1 ^= k1;
+    h1 = ROTL32(h1, 13);
+    h1 = h1 * 5 + 0xe6546b64;
+  }
 
-	// --- tail
-	const uint8_t * tail = (const uint8_t*)(data + nblocks * 4);
+  // --- tail
+  const uint8_t * tail = (const uint8_t*)(data + nblocks * 4);
 
-	uint32_t k1 = 0;
+  uint32_t k1 = 0;
 
-	switch (len & 3) {
-	case 3: k1 ^= tail[2] << 16;
-	case 2: k1 ^= tail[1] << 8;
-	case 1: k1 ^= tail[0];
-		k1 *= c1; k1 = ROTL32(k1, 15); k1 *= c2; h1 ^= k1;
-	}
+  switch (len & 3) {
+  case 3:
+    k1 ^= tail[2] << 16;
+  case 2:
+    k1 ^= tail[1] << 8;
+  case 1:
+    k1 ^= tail[0];
+    k1 *= c1;
+    k1 = ROTL32(k1, 15);
+    k1 *= c2;
+    h1 ^= k1;
+  }
 
-	// --- finalization
-	h1 ^= len;
+  // --- finalization
+  h1 ^= len;
 
-	return MURMUR_HASH_3::fmix(h1);
+  return MURMUR_HASH_3::fmix(h1);
 }

--- a/vowpalwabbit/hash.h
+++ b/vowpalwabbit/hash.h
@@ -20,7 +20,7 @@ license as described in the file LICENSE.
 
 inline uint32_t rotl32(uint32_t x, int8_t r)
 {
-	return (x << r) | (x >> (32 - r));
+  return (x << r) | (x >> (32 - r));
 }
 
 #   define ROTL32(x,y)     rotl32(x,y)
@@ -28,22 +28,22 @@ inline uint32_t rotl32(uint32_t x, int8_t r)
 
 #endif                                      // !defined(_MSC_VER)
 
-namespace MURMUR_HASH_3 
+namespace MURMUR_HASH_3
 {
 
-	//-----------------------------------------------------------------------------
-	// Finalization mix - force all bits of a hash block to avalanche
+//-----------------------------------------------------------------------------
+// Finalization mix - force all bits of a hash block to avalanche
 
-	static inline uint32_t fmix(uint32_t h)
-	{
-		h ^= h >> 16;
-		h *= 0x85ebca6b;
-		h ^= h >> 13;
-		h *= 0xc2b2ae35;
-		h ^= h >> 16;
+static inline uint32_t fmix(uint32_t h)
+{
+  h ^= h >> 16;
+  h *= 0x85ebca6b;
+  h ^= h >> 13;
+  h *= 0xc2b2ae35;
+  h ^= h >> 16;
 
-		return h;
-	}
+  return h;
+}
 }
 
 const uint32_t hash_base = 0;

--- a/vowpalwabbit/interact.cc
+++ b/vowpalwabbit/interact.cc
@@ -24,7 +24,7 @@ float multiply(v_array<feature>& f_dest, v_array<feature>& f_src2, interact& in)
   size_t weight_mask = all->reg.weight_mask;
   size_t base_id1 = f_src1[0].weight_index & weight_mask;
   size_t base_id2 = f_src2[0].weight_index & weight_mask;
-  
+
   feature f;
   f.weight_index = f_src1[0].weight_index;
   f.x = f_src1[0].x*f_src2[0].x;
@@ -47,7 +47,7 @@ float multiply(v_array<feature>& f_dest, v_array<feature>& f_src2, interact& in)
     else if(cur_id1 < cur_id2)
       i1++;
     else
-      i2++;    
+      i2++;
   }
   return sum_sq;
 }
@@ -64,49 +64,51 @@ void predict_or_learn(interact& in, LEARNER::base_learner& base, example& ec) {
   ec.total_sum_feat_sq -= ec.sum_feat_sq[in.n2];
   ec.num_features -= f1.size();
   ec.num_features -= f2.size();
-  
+
   in.feat_store.erase();
   push_many(in.feat_store, f1.begin, f1.size());
-  
+
   ec.sum_feat_sq[in.n1] = multiply(f1, f2, in);
   ec.total_sum_feat_sq += ec.sum_feat_sq[in.n1];
   ec.num_features += f1.size();
-  
+
   /*for(size_t i = 0;i < f1.size();i++)
     cout<<f1[i].weight_index<<":"<<f1[i].x<<" ";
     cout<<endl;*/
-  
+
   // remove 2nd namespace
   int n2_i = -1;
   for (size_t i = 0; i < ec.indices.size(); i++) {
-	  if (ec.indices[i] == in.n2) {
-		  n2_i = (int)i;
-		  memmove(&ec.indices[n2_i], &ec.indices[n2_i+1], sizeof(unsigned char) * (ec.indices.size() - n2_i - 1));
-		  ec.indices.decr();
-		  break;
-	  } 
+    if (ec.indices[i] == in.n2) {
+      n2_i = (int)i;
+      memmove(&ec.indices[n2_i], &ec.indices[n2_i+1], sizeof(unsigned char) * (ec.indices.size() - n2_i - 1));
+      ec.indices.decr();
+      break;
+    }
   }
   assert(n2_i >= 0);
 
   base.predict(ec);
   if(is_learn)
     base.learn(ec);
-  
+
   // re-insert namespace into the right position
   ec.indices.incr();
   memmove(&ec.indices[n2_i + 1], &ec.indices[n2_i], sizeof(unsigned char) * (ec.indices.size() - n2_i - 1));
   ec.indices[n2_i] = in.n2;
 
   ec.atomics[in.n1].erase();
-  push_many(ec.atomics[in.n1], in.feat_store.begin, in.feat_store.size());  
+  push_many(ec.atomics[in.n1], in.feat_store.begin, in.feat_store.size());
   ec.total_sum_feat_sq = in.total_sum_feat_sq;
   ec.sum_feat_sq[in.n1] = in.n1_feat_sq;
   ec.num_features = in.num_features;
 }
 
-void finish(interact& in) {in.feat_store.delete_v();}
+void finish(interact& in) {
+  in.feat_store.delete_v();
+}
 
-LEARNER::base_learner* interact_setup(vw& all) 
+LEARNER::base_learner* interact_setup(vw& all)
 {
   if(missing_option<string, true>(all, "interact", "Put weights on feature products from namespaces <n1> and <n2>"))
     return nullptr;
@@ -115,9 +117,9 @@ LEARNER::base_learner* interact_setup(vw& all)
     cerr<<"Need two namespace arguments to interact!! EXITING\n";
     return nullptr;
   }
-  
+
   interact& data = calloc_or_die<interact>();
-  
+
   data.n1 = (unsigned char) s[0];
   data.n2 = (unsigned char) s[1];
   cout<<"Interacting namespaces "<<data.n1<<" and "<<data.n2<<endl;

--- a/vowpalwabbit/interactions.cc
+++ b/vowpalwabbit/interactions.cc
@@ -12,41 +12,41 @@ namespace INTERACTIONS
 // recursive function used internally in this module
 void expand_namespacse_with_recursion(v_string& ns, v_array<v_string>& res, v_string& val,  size_t pos)
 {
-    assert (pos <= ns.size());
+  assert (pos <= ns.size());
 
-    if (pos == ns.size())
-    {
-        // we're at the end of interaction
+  if (pos == ns.size())
+  {
+    // we're at the end of interaction
 
-        // make copy of val
-        v_string temp = v_init<unsigned char>();
-        push_many(temp, val.begin, val.size());
-        // and store it in res
-        res.push_back(temp);
-        // don't free s memory as it's data will be used later
-    } else {
+    // make copy of val
+    v_string temp = v_init<unsigned char>();
+    push_many(temp, val.begin, val.size());
+    // and store it in res
+    res.push_back(temp);
+    // don't free s memory as it's data will be used later
+  } else {
 
-        // we're at the middle of interaction
-        if (ns[pos] != ':')
-        { // not a wildcard
-            val.push_back(ns[pos]);
-            expand_namespacse_with_recursion(ns, res, val, pos + 1);
-            --val.end; // simplified val.pop() - i don't need value itself
-        }
-        else
-        {
-            for (unsigned char j = printable_start; j <= printable_end; ++j)
-            {
-                if (valid_ns(j))
-                {
-                    val.push_back(j);
-                    expand_namespacse_with_recursion(ns, res, val, pos + 1);
-                    --val.end; // simplified val.pop() - i don't need value itself
-                }
-            }
-        }
-
+    // we're at the middle of interaction
+    if (ns[pos] != ':')
+    { // not a wildcard
+      val.push_back(ns[pos]);
+      expand_namespacse_with_recursion(ns, res, val, pos + 1);
+      --val.end; // simplified val.pop() - i don't need value itself
     }
+    else
+    {
+      for (unsigned char j = printable_start; j <= printable_end; ++j)
+      {
+        if (valid_ns(j))
+        {
+          val.push_back(j);
+          expand_namespacse_with_recursion(ns, res, val, pos + 1);
+          --val.end; // simplified val.pop() - i don't need value itself
+        }
+      }
+    }
+
+  }
 }
 
 // expand namespace interactions if contain wildcards
@@ -55,26 +55,27 @@ void expand_namespacse_with_recursion(v_string& ns, v_array<v_string>& res, v_st
 
 v_array<v_string> expand_interactions(const vector<string>& vec, const size_t required_length, const string& err_msg)
 {
-    v_array<v_string> res = v_init<v_string>();
+  v_array<v_string> res = v_init<v_string>();
 
-    for (vector<string>::const_iterator i = vec.begin(); i != vec.end(); ++i)
+  for (vector<string>::const_iterator i = vec.begin(); i != vec.end(); ++i)
+  {
+    const size_t len = i->length();
+    if (required_length > 0 && len != required_length)
+      // got strict requirement of interaction length and it was failed.
     {
-        const size_t len = i->length();
-        if (required_length > 0 && len != required_length)
-	  // got strict requirement of interaction length and it was failed.
-	  { THROW(err_msg); }
-	else
-	  if (len < 2)
-	    // regardles of required_length value this check is always performed
-	    THROW("error, feature interactions must involve at least two namespaces" << err_msg);
-	      
-        v_string ns = string2v_string(*i);
-        v_string temp = v_init<unsigned char>();
-        expand_namespacse_with_recursion(ns, res, temp, 0);
-        temp.delete_v();
-        ns.delete_v();
+      THROW(err_msg);
     }
-    return res;
+    else if (len < 2)
+      // regardles of required_length value this check is always performed
+      THROW("error, feature interactions must involve at least two namespaces" << err_msg);
+
+    v_string ns = string2v_string(*i);
+    v_string temp = v_init<unsigned char>();
+    expand_namespacse_with_recursion(ns, res, temp, 0);
+    temp.delete_v();
+    ns.delete_v();
+  }
+  return res;
 }
 
 
@@ -86,18 +87,21 @@ v_array<v_string> expand_interactions(const vector<string>& vec, const size_t re
 // compares v_string
 bool is_equal_v_string(v_string& a, v_string& b)
 {
-    const size_t size = a.size();
-    if (size != b.size()) {return false;}
-    else if (size == 0) return true;
+  const size_t size = a.size();
+  if (size != b.size()) {
+    return false;
+  }
+  else if (size == 0) return true;
 
-    unsigned char* ai = a.begin;
-    unsigned char* bi = b.begin;
-    while (ai != a.end)
-        if (*ai != *bi) return false;
-        else {
-            ++ai; ++ bi;
-        }
-    return true;
+  unsigned char* ai = a.begin;
+  unsigned char* bi = b.begin;
+  while (ai != a.end)
+    if (*ai != *bi) return false;
+    else {
+      ++ai;
+      ++ bi;
+    }
+  return true;
 }
 
 
@@ -105,9 +109,9 @@ bool is_equal_v_string(v_string& a, v_string& b)
 
 struct ordered_interaction
 {
-    size_t pos;
-    unsigned char* data;
-    size_t size;
+  size_t pos;
+  unsigned char* data;
+  size_t size;
 };
 
 // returns true if iteraction contains one or more duplicated namespaces
@@ -116,23 +120,23 @@ struct ordered_interaction
 
 inline bool must_be_left_sorted(const ordered_interaction& oi)
 {
-    if (oi.size <= 1) return true; // one letter in string - no need to sort
+  if (oi.size <= 1) return true; // one letter in string - no need to sort
 
-    bool diff_ns_found = false;
-    bool pair_found = false;
+  bool diff_ns_found = false;
+  bool pair_found = false;
 
-    for (const unsigned char* i = oi.data; i != oi.data + oi.size - 1; ++i)
-        if (*i == *(i+1)) // pair found
-        {
-            if (diff_ns_found) return true; // case 'abb'
-            pair_found = true;
+  for (const unsigned char* i = oi.data; i != oi.data + oi.size - 1; ++i)
+    if (*i == *(i+1)) // pair found
+    {
+      if (diff_ns_found) return true; // case 'abb'
+      pair_found = true;
 
-        } else {
-            if (pair_found) return true; // case 'aab'
-            diff_ns_found = true;
-        }
+    } else {
+      if (pair_found) return true; // case 'aab'
+      diff_ns_found = true;
+    }
 
-    return false; // 'aaa' or 'abc'
+  return false; // 'aaa' or 'abc'
 }
 
 
@@ -140,53 +144,53 @@ inline bool must_be_left_sorted(const ordered_interaction& oi)
 // comparision function for qsort to sort namespaces in interaction
 int comp_char (const void * a, const void * b)
 {
-    return ( *(const char*)a - *(const char*)b );
+  return ( *(const char*)a - *(const char*)b );
 }
 
 // comparision function for std::sort to sort interactions by their data
 bool comp_interaction (ordered_interaction a, ordered_interaction b)
 {
-    if (a.size != b.size)
-        return a.size < b.size;
-    else
-    {
-        const int order = memcmp(a.data, b.data, a.size);
-        // a.pos < b.pos is additional level of ordering (`AB` must always be prefered to `BA` bcs autotests might be inconsistent).
-        return (order == 0)? a.pos < b.pos : order < 0;
-    }
+  if (a.size != b.size)
+    return a.size < b.size;
+  else
+  {
+    const int order = memcmp(a.data, b.data, a.size);
+    // a.pos < b.pos is additional level of ordering (`AB` must always be prefered to `BA` bcs autotests might be inconsistent).
+    return (order == 0)? a.pos < b.pos : order < 0;
+  }
 }
 
 // comparision function for std::sort to sort interactions by their position (to restore original order)
 bool comp_interaction_by_pos (ordered_interaction a, ordered_interaction b)
 {
-    return a.pos < b.pos;
+  return a.pos < b.pos;
 }
 
 // helper function for unique() fork. Just compares interactions.
 // it behave like operator == while comp_interaction() above behave like operator <
 inline bool equal_interaction (const ordered_interaction& a, const ordered_interaction& b)
 {
-    if (a.size != b.size)
-        return false;
-    else
-        return memcmp(a.data, b.data, a.size) == 0;
+  if (a.size != b.size)
+    return false;
+  else
+    return memcmp(a.data, b.data, a.size) == 0;
 }
 
 // a fork of std::unique implementation
 // made to free memory allocated by objects that overwritter by unique()
 ordered_interaction* unique_intearctions(ordered_interaction* first, ordered_interaction* last)
 {
-    if (first == last)
-        return last;
+  if (first == last)
+    return last;
 
-    ordered_interaction* result = first;
-    while (++first != last) {
-        if (!equal_interaction(*result,*first)) {
-            *(++result) = std::move(*first);
-        } else
-            free(first->data); // for this line I forked std::unique()
-    }
-    return ++result;
+  ordered_interaction* result = first;
+  while (++first != last) {
+    if (!equal_interaction(*result,*first)) {
+      *(++result) = std::move(*first);
+    } else
+      free(first->data); // for this line I forked std::unique()
+  }
+  return ++result;
 }
 
 
@@ -196,74 +200,74 @@ ordered_interaction* unique_intearctions(ordered_interaction* first, ordered_int
 
 void sort_and_filter_duplicate_interactions(v_array<v_string>& vec, bool filter_duplicates, size_t& removed_cnt, size_t& sorted_cnt)
 {
-    const size_t cnt = vec.size();
-    // 2 out parameters
-    removed_cnt = 0;
-    sorted_cnt = 0;
+  const size_t cnt = vec.size();
+  // 2 out parameters
+  removed_cnt = 0;
+  sorted_cnt = 0;
 
-    // make a copy of vec and sort namespaces of every interaction in its copy
-    v_array<ordered_interaction> vec_sorted = v_init<ordered_interaction>();
+  // make a copy of vec and sort namespaces of every interaction in its copy
+  v_array<ordered_interaction> vec_sorted = v_init<ordered_interaction>();
 
-    size_t pos = 0;
-    for (v_string *v = vec.begin; v != vec.end; ++v)
-    {
-        ordered_interaction oi;
-        size_t size = v->size();
-        // copy memory
-        oi.data = (unsigned char* )malloc(size);
-        memcpy(oi.data, v->begin, size);
+  size_t pos = 0;
+  for (v_string *v = vec.begin; v != vec.end; ++v)
+  {
+    ordered_interaction oi;
+    size_t size = v->size();
+    // copy memory
+    oi.data = (unsigned char* )malloc(size);
+    memcpy(oi.data, v->begin, size);
 
-        // sort charcters in interaction string
-        qsort(oi.data, size, sizeof(unsigned char), comp_char);
-        oi.size = size;
-        oi.pos = pos++; // save original order info
-        vec_sorted.push_back(oi);
-    }
-
-
-    if (filter_duplicates) // filter dulicated interactions
-    {
-        // sort interactions (each interaction namespaces are sorted already)
-        std::sort(vec_sorted.begin, vec_sorted.end, comp_interaction);
-        // perform unique() for them - that destroys all duplicated data.
-        ordered_interaction* new_end = unique_intearctions(vec_sorted.begin, vec_sorted.end);
-        vec_sorted.end = new_end;              // correct new ending marker
-        removed_cnt = cnt - vec_sorted.size(); // report count of removed duplicates
-        std::sort(vec_sorted.begin, vec_sorted.end, comp_interaction_by_pos); // restore original order
-    }
+    // sort charcters in interaction string
+    qsort(oi.data, size, sizeof(unsigned char), comp_char);
+    oi.size = size;
+    oi.pos = pos++; // save original order info
+    vec_sorted.push_back(oi);
+  }
 
 
-    // we have original vector and vector with duplicates removed + corresponding indexes in original vector
-    // plus second vector's data is sorted. We can reuse it if we need interaction to be left sorted.
-    // let's make a new vector from these two sources - without dulicates and with sorted data whenever it's needed.
-    v_array<v_string> res = v_init<v_string>();
-    pos = 0;
+  if (filter_duplicates) // filter dulicated interactions
+  {
+    // sort interactions (each interaction namespaces are sorted already)
+    std::sort(vec_sorted.begin, vec_sorted.end, comp_interaction);
+    // perform unique() for them - that destroys all duplicated data.
+    ordered_interaction* new_end = unique_intearctions(vec_sorted.begin, vec_sorted.end);
+    vec_sorted.end = new_end;              // correct new ending marker
+    removed_cnt = cnt - vec_sorted.size(); // report count of removed duplicates
+    std::sort(vec_sorted.begin, vec_sorted.end, comp_interaction_by_pos); // restore original order
+  }
 
-    for (ordered_interaction* oi = vec_sorted.begin; oi != vec_sorted.end; ++oi)
-    {
-        size_t copy_pos = oi->pos;
-        // if vec data has no corresponding record in vec_sorted then it's a duplicate and shall be destroyed
-        while (pos < copy_pos) vec[pos++].delete_v();
 
-        if (must_be_left_sorted(*oi)) //check if it should be sorted in result vector
-        { // if so - copy sorted data to result
-            v_string v = v_init<unsigned char>();
-            push_many(v, oi->data, oi->size);
-            res.push_back(v);
-            vec[pos].delete_v();
-            ++sorted_cnt;
-        } else // else - move unsorted data to result
-            res.push_back(vec[pos]);
-        pos++;
-        // sorted data is copied, not moved, bcs i'm lazy to write assignment operator between these two types.
-        // thus we always must free it
-        free(oi->data);
-    }
+  // we have original vector and vector with duplicates removed + corresponding indexes in original vector
+  // plus second vector's data is sorted. We can reuse it if we need interaction to be left sorted.
+  // let's make a new vector from these two sources - without dulicates and with sorted data whenever it's needed.
+  v_array<v_string> res = v_init<v_string>();
+  pos = 0;
 
-    vec_sorted.delete_v(); // sorted array destroyed. It's data partially copied to the new array, partially destroyed
-    vec.delete_v(); // original array destroyed. It's data partially moved to the new array, partially destroyed
+  for (ordered_interaction* oi = vec_sorted.begin; oi != vec_sorted.end; ++oi)
+  {
+    size_t copy_pos = oi->pos;
+    // if vec data has no corresponding record in vec_sorted then it's a duplicate and shall be destroyed
+    while (pos < copy_pos) vec[pos++].delete_v();
 
-    vec = res; // new array replaces original
+    if (must_be_left_sorted(*oi)) //check if it should be sorted in result vector
+    { // if so - copy sorted data to result
+      v_string v = v_init<unsigned char>();
+      push_many(v, oi->data, oi->size);
+      res.push_back(v);
+      vec[pos].delete_v();
+      ++sorted_cnt;
+    } else // else - move unsorted data to result
+      res.push_back(vec[pos]);
+    pos++;
+    // sorted data is copied, not moved, bcs i'm lazy to write assignment operator between these two types.
+    // thus we always must free it
+    free(oi->data);
+  }
+
+  vec_sorted.delete_v(); // sorted array destroyed. It's data partially copied to the new array, partially destroyed
+  vec.delete_v(); // original array destroyed. It's data partially moved to the new array, partially destroyed
+
+  vec = res; // new array replaces original
 }
 
 
@@ -281,21 +285,22 @@ void sort_and_filter_duplicate_interactions(v_array<v_string>& vec, bool filter_
 #ifdef DEBUG_EVAL_COUNT_OF_GEN_FT
 struct eval_gen_data
 {
-    size_t& new_features_cnt;
-    float& new_features_value;
-    eval_gen_data(size_t& features_cnt, float& features_value): new_features_cnt(features_cnt), new_features_value(features_value) {}
+  size_t& new_features_cnt;
+  float& new_features_value;
+  eval_gen_data(size_t& features_cnt, float& features_value): new_features_cnt(features_cnt), new_features_value(features_value) {}
 };
 
 void ft_cnt(eval_gen_data& dat, float fx, uint32_t )
 {
-    ++ dat.new_features_cnt;
-    dat.new_features_value += fx * fx;
+  ++ dat.new_features_cnt;
+  dat.new_features_value += fx * fx;
 }
 #endif
 
 // lookup table of factorials up tu 21!
 long long int fast_factorial[] = {1,1,2,6,24,120,720,5040,40320,362880,3628800,39916800,479001600,6227020800,87178291200,1307674368000,
-                             20922789888000,355687428096000,6402373705728000,121645100408832000,2432902008176640000};
+                                  20922789888000,355687428096000,6402373705728000,121645100408832000,2432902008176640000
+                                 };
 const size_t size_fast_factorial = sizeof(fast_factorial)/sizeof(*fast_factorial);
 
 // helper factorial function that allows to perform:
@@ -306,12 +311,12 @@ const size_t size_fast_factorial = sizeof(fast_factorial)/sizeof(*fast_factorial
 
 inline size_t factor(const size_t n, const size_t start_from = 1)
 {
-    if (n <= 0) return 1.;
-    if (start_from == 1 && n < size_fast_factorial) return fast_factorial[n];
+  if (n <= 0) return 1.;
+  if (start_from == 1 && n < size_fast_factorial) return fast_factorial[n];
 
-    size_t res = 1;
-    for (size_t i = start_from+1; i <= n; ++i) res *= i;
-    return res;
+  size_t res = 1;
+  for (size_t i = start_from+1; i <= n; ++i) res *= i;
+  return res;
 }
 
 
@@ -320,163 +325,163 @@ inline size_t factor(const size_t n, const size_t start_from = 1)
 
 void eval_count_of_generated_ft(vw& all, example& ec, size_t& new_features_cnt, float& new_features_value)
 {
-    new_features_cnt = 0;
-    new_features_value = 0.;
+  new_features_cnt = 0;
+  new_features_value = 0.;
 
-    v_array<float> results = v_init<float>();
+  v_array<float> results = v_init<float>();
 
-    if (all.permutations)
-    { // just multiply precomputed values for all namespaces
-        for (v_string* inter = all.interactions.begin; inter != all.interactions.end; ++inter)
-        {
-            size_t num_features_in_inter = 1;
-            float sum_feat_sq_in_inter = 1.;
+  if (all.permutations)
+  { // just multiply precomputed values for all namespaces
+    for (v_string* inter = all.interactions.begin; inter != all.interactions.end; ++inter)
+    {
+      size_t num_features_in_inter = 1;
+      float sum_feat_sq_in_inter = 1.;
 
-            for (unsigned char* j = inter->begin; j != inter->end; ++j)
-            {
-                const int ns = *j;
-                num_features_in_inter *= ec.atomics[ns].size();
-                sum_feat_sq_in_inter *= ec.sum_feat_sq[ns];
-                if (num_features_in_inter == 0) break;
-            }
+      for (unsigned char* j = inter->begin; j != inter->end; ++j)
+      {
+        const int ns = *j;
+        num_features_in_inter *= ec.atomics[ns].size();
+        sum_feat_sq_in_inter *= ec.sum_feat_sq[ns];
+        if (num_features_in_inter == 0) break;
+      }
 
-            if (num_features_in_inter == 0) continue;
+      if (num_features_in_inter == 0) continue;
 
-            new_features_cnt += num_features_in_inter;
-            new_features_value += sum_feat_sq_in_inter;
-        }
-
-
-    } else { // case of simple combinations
-
-        #ifdef DEBUG_EVAL_COUNT_OF_GEN_FT
-        size_t correct_features_cnt = 0;
-        float correct_features_value = 0.;
-        eval_gen_data dat(correct_features_cnt, correct_features_value);
-        generate_interactions<eval_gen_data, uint32_t, ft_cnt>(all, ec, dat);
-        #endif
-
-        for (v_string* inter = all.interactions.begin; inter != all.interactions.end; ++inter)
-        {
-            size_t num_features_in_inter = 1;
-            float sum_feat_sq_in_inter = 1.;
-
-            for (unsigned char* ns = inter->begin; ns != inter->end; ++ns)
-            {
-                if ((ns == inter->end-1) || (*ns != *(ns + 1))) // neighbour namespaces are different
-                {   // just multiply precomputed values
-                    const int nsc = *ns;
-                    num_features_in_inter *= ec.atomics[nsc].size();
-                    sum_feat_sq_in_inter *= ec.sum_feat_sq[nsc];
-                    if (num_features_in_inter == 0) break; //one of namespaces has no features - go to next interaction
-                } else { // we are at beginning of a block made of same namespace (interaction is preliminary sorted)
-
-                    // let's find out real length of this block
-                    size_t order_of_inter = 2; // alredy compared ns == ns+1
-
-                    for (unsigned char* ns_end = ns + 2; ns_end < inter->end; ++ns_end)
-                        if (*ns == *ns_end) ++order_of_inter;
-
-                    // namespace is same for whole block
-                    v_array<feature>& features = ec.atomics[(const int)*ns];
-
-                    // count number of features with value != 1.;
-                    size_t cnt_ft_value_non_1 = 0;
-
-
-                    // in this block we shall calculate number of generated features and sum of their values
-                    // keeping in mind rules applicable for simple combinations instead of permutations
-
-
-
-                    // let's calculate sum of their squared value for whole block
-
-                    // ensure results as big as order_of_inter and empty.
-                    for (size_t i = 0; i < results.size(); ++i) results[i] = 0.;
-                    while (results.size() < order_of_inter) results.push_back(0.);
-
-                    // recurrent value calculations
-                    for (feature* ft = features.begin; ft != features.end; ++ft)
-                    {
-                        const float x = ft->x*ft->x;
-
-                        if ( !PROCESS_SELF_INTERACTIONS(ft->x) )
-                        {
-                            for (size_t i = order_of_inter-1; i > 0; --i)
-                                results[i] += results[i-1]*x;
-
-                            results[0] += x;
-                        } else {
-                            results[0] += x;
-
-                            for (size_t i = 1; i < order_of_inter; ++i)
-                                results[i] += results[i-1]*x;
-
-                            ++cnt_ft_value_non_1;
-                        }
-
-                    }
-
-                    sum_feat_sq_in_inter *= results[order_of_inter-1]; // will be explained in http://bit.ly/1Hk9JX1
-
-
-                    // let's calculate  the number of a new features
-
-                    // if number of features is less than  order of interaction then go to the next interaction
-                    // as you can't make simple combination of interaction 'aaa' if a contains < 3 features.
-                    // unless one of them has value != 1. and we are counting them.
-                    const size_t ft_size = features.size();
-                    if (cnt_ft_value_non_1 == 0 && ft_size < order_of_inter)
-                    {
-                        num_features_in_inter = 0;
-                        break;
-                    }
-
-
-                    size_t n;
-                    if (cnt_ft_value_non_1 == 0) // number of generated simple combinations is C(n,k)
-                    {
-                        n = choose(ft_size, order_of_inter);
-                    } else {
-                        n = 0.;
-                        for (size_t l = 0; l <= order_of_inter; ++l)
-                        {
-                            //C(l+m-1, l) * C(n-m, k-l)
-                            size_t num = (l==0)?1:choose(l+cnt_ft_value_non_1-1, l);
-
-                            if (ft_size - cnt_ft_value_non_1 >= order_of_inter-l)
-                                num *= choose(ft_size - cnt_ft_value_non_1, order_of_inter-l);
-                            else num = 0;
-
-                            n +=  num;
-                        }
-
-                    } // details on http://bit.ly/1Hk9JX1
-
-
-                    num_features_in_inter *= n;
-
-                    ns += order_of_inter-1; //jump over whole block
-                }
-            }
-
-
-            if (num_features_in_inter == 0) continue; //signal that values should be ignored (as default value is 1)
-
-            new_features_cnt += num_features_in_inter;
-            new_features_value += sum_feat_sq_in_inter;
-        }
-
-        #ifdef DEBUG_EVAL_COUNT_OF_GEN_FT
-        if (correct_features_cnt != new_features_cnt)
-            cerr << "Incorrect new features count " << new_features_cnt << " must be " << correct_features_cnt << endl;
-        if (fabs(correct_features_value - new_features_value) > 1e-5)
-            cerr << "Incorrect new features value " << new_features_value << " must be " << correct_features_value << endl;
-        #endif
-
+      new_features_cnt += num_features_in_inter;
+      new_features_value += sum_feat_sq_in_inter;
     }
 
-    results.delete_v();
+
+  } else { // case of simple combinations
+
+#ifdef DEBUG_EVAL_COUNT_OF_GEN_FT
+    size_t correct_features_cnt = 0;
+    float correct_features_value = 0.;
+    eval_gen_data dat(correct_features_cnt, correct_features_value);
+    generate_interactions<eval_gen_data, uint32_t, ft_cnt>(all, ec, dat);
+#endif
+
+    for (v_string* inter = all.interactions.begin; inter != all.interactions.end; ++inter)
+    {
+      size_t num_features_in_inter = 1;
+      float sum_feat_sq_in_inter = 1.;
+
+      for (unsigned char* ns = inter->begin; ns != inter->end; ++ns)
+      {
+        if ((ns == inter->end-1) || (*ns != *(ns + 1))) // neighbour namespaces are different
+        { // just multiply precomputed values
+          const int nsc = *ns;
+          num_features_in_inter *= ec.atomics[nsc].size();
+          sum_feat_sq_in_inter *= ec.sum_feat_sq[nsc];
+          if (num_features_in_inter == 0) break; //one of namespaces has no features - go to next interaction
+        } else { // we are at beginning of a block made of same namespace (interaction is preliminary sorted)
+
+          // let's find out real length of this block
+          size_t order_of_inter = 2; // alredy compared ns == ns+1
+
+          for (unsigned char* ns_end = ns + 2; ns_end < inter->end; ++ns_end)
+            if (*ns == *ns_end) ++order_of_inter;
+
+          // namespace is same for whole block
+          v_array<feature>& features = ec.atomics[(const int)*ns];
+
+          // count number of features with value != 1.;
+          size_t cnt_ft_value_non_1 = 0;
+
+
+          // in this block we shall calculate number of generated features and sum of their values
+          // keeping in mind rules applicable for simple combinations instead of permutations
+
+
+
+          // let's calculate sum of their squared value for whole block
+
+          // ensure results as big as order_of_inter and empty.
+          for (size_t i = 0; i < results.size(); ++i) results[i] = 0.;
+          while (results.size() < order_of_inter) results.push_back(0.);
+
+          // recurrent value calculations
+          for (feature* ft = features.begin; ft != features.end; ++ft)
+          {
+            const float x = ft->x*ft->x;
+
+            if ( !PROCESS_SELF_INTERACTIONS(ft->x) )
+            {
+              for (size_t i = order_of_inter-1; i > 0; --i)
+                results[i] += results[i-1]*x;
+
+              results[0] += x;
+            } else {
+              results[0] += x;
+
+              for (size_t i = 1; i < order_of_inter; ++i)
+                results[i] += results[i-1]*x;
+
+              ++cnt_ft_value_non_1;
+            }
+
+          }
+
+          sum_feat_sq_in_inter *= results[order_of_inter-1]; // will be explained in http://bit.ly/1Hk9JX1
+
+
+          // let's calculate  the number of a new features
+
+          // if number of features is less than  order of interaction then go to the next interaction
+          // as you can't make simple combination of interaction 'aaa' if a contains < 3 features.
+          // unless one of them has value != 1. and we are counting them.
+          const size_t ft_size = features.size();
+          if (cnt_ft_value_non_1 == 0 && ft_size < order_of_inter)
+          {
+            num_features_in_inter = 0;
+            break;
+          }
+
+
+          size_t n;
+          if (cnt_ft_value_non_1 == 0) // number of generated simple combinations is C(n,k)
+          {
+            n = choose(ft_size, order_of_inter);
+          } else {
+            n = 0.;
+            for (size_t l = 0; l <= order_of_inter; ++l)
+            {
+              //C(l+m-1, l) * C(n-m, k-l)
+              size_t num = (l==0)?1:choose(l+cnt_ft_value_non_1-1, l);
+
+              if (ft_size - cnt_ft_value_non_1 >= order_of_inter-l)
+                num *= choose(ft_size - cnt_ft_value_non_1, order_of_inter-l);
+              else num = 0;
+
+              n +=  num;
+            }
+
+          } // details on http://bit.ly/1Hk9JX1
+
+
+          num_features_in_inter *= n;
+
+          ns += order_of_inter-1; //jump over whole block
+        }
+      }
+
+
+      if (num_features_in_inter == 0) continue; //signal that values should be ignored (as default value is 1)
+
+      new_features_cnt += num_features_in_inter;
+      new_features_value += sum_feat_sq_in_inter;
+    }
+
+#ifdef DEBUG_EVAL_COUNT_OF_GEN_FT
+    if (correct_features_cnt != new_features_cnt)
+      cerr << "Incorrect new features count " << new_features_cnt << " must be " << correct_features_cnt << endl;
+    if (fabs(correct_features_value - new_features_value) > 1e-5)
+      cerr << "Incorrect new features value " << new_features_value << " must be " << correct_features_value << endl;
+#endif
+
+  }
+
+  results.delete_v();
 }
 
 

--- a/vowpalwabbit/interactions.h
+++ b/vowpalwabbit/interactions.h
@@ -38,13 +38,13 @@ void sort_and_filter_duplicate_interactions(v_array<v_string> &vec, bool filter_
 * By default include interactions of feature with itself.
 * This approach produces slightly more interactions but it's safier
 * for some cases, as discussed in issues/698
-* Previous behaviour was: include interactions of feature with itself only if its weight != weight^2.
+* Previous behaviour was: include interactions of feature with itself only if its value != value^2.
 *
 */
 const bool feature_self_interactions = true;
 // must return logical expression
-/*old: ft_weight != 1.0 && feature_self_interactions_for_weight_other_than_1*/
-#define PROCESS_SELF_INTERACTIONS(ft_weight) feature_self_interactions
+/*old: ft_value != 1.0 && feature_self_interactions_for_value_other_than_1*/
+#define PROCESS_SELF_INTERACTIONS(ft_value) feature_self_interactions
 
 
 
@@ -54,23 +54,23 @@ const uint32_t FNV_prime = 16777619;
 
 
 
-// function estimates how many new features will be generated for example and ther sum(weight^2).
-void eval_count_of_generated_ft(vw& all, example& ec, size_t& new_features_cnt, float& new_features_weight);
+// function estimates how many new features will be generated for example and ther sum(value^2).
+void eval_count_of_generated_ft(vw& all, example& ec, size_t& new_features_cnt, float& new_features_value);
 
 
 
 // 2 template functions to pass T() proper argument (feature idx in regressor, or its coefficient)
 
 template <class R, void (*T)(R&, const float, float&)>
-inline void call_T( R& dat, weight* weight_vector, const size_t weight_mask, const float ft_weight, const uint32_t ft_idx)
+inline void call_T( R& dat, weight* weight_vector, const size_t weight_mask, const float ft_value, const uint32_t ft_idx)
 {
-    T(dat, ft_weight, weight_vector[ft_idx & weight_mask]);
+    T(dat, ft_value, weight_vector[ft_idx & weight_mask]);
 }
 
 template <class R, void (*T)(R&, float, uint32_t)>
-inline void call_T( R& dat, weight* /*weight_vector*/, const size_t /*weight_mask*/, const float ft_weight, const uint32_t ft_idx)
+inline void call_T( R& dat, weight* /*weight_vector*/, const size_t /*weight_mask*/, const float ft_value, const uint32_t ft_idx)
 {
-    T(dat, ft_weight, ft_idx);
+    T(dat, ft_value, ft_idx);
 }
 
 template <class R, void (*audit_func)(R&, const audit_data*)>
@@ -91,7 +91,7 @@ struct feature_gen_data
 {
     size_t loop_idx;          // current feature id in namespace
     uint32_t hash;            // hash of feature interactions of previous namespaces in the list
-    float x;                  // weight of feature interactions of previous namespaces in the list
+    float x;                  // value of feature interactions of previous namespaces in the list
     size_t loop_end;          // last feature id. May be less than number of features if namespace involved in interaction more than once
                               // calculated at preprocessing together with same_ns
     size_t self_interaction;  // namespace interacting with itself    
@@ -99,9 +99,11 @@ struct feature_gen_data
 //    feature_gen_data(): loop_idx(0), x(1.), loop_end(0), self_interaction(false) {}
 };
 
-// macros below may be adjusted to change the way synthetic feature weight is calculated
-// beware - its result must be non-zero
- inline float INTER_WEIGHT_OP(float weight1, float weight2) { return weight1*weight2; }
+// The inline function below may be adjusted to change the way
+// synthetic (interaction) features' values are calculated, e.g.,
+// fabs(value1-value2) or even value1>value2?1.0:-1.0
+// Beware - its result must be non-zero.
+ inline float INTERACTION_VALUE(float value1, float value2) { return value1*value2; }
 
 // uncomment line below to disable usage of inner 'for' loops for pair and triple interactions
 // end switch to usage of non-recursive feature generation algorithm for interactions of any length
@@ -167,12 +169,12 @@ inline void generate_interactions(vw& all, example& ec, R& dat, v_array<feature_
                         // next index differs for permutations and simple combinations
                         const feature_class* snd = (!same_namespace) ? features_data[snd_ns].begin :
                                                                  (PROCESS_SELF_INTERACTIONS(fst->x)) ? fst : fst+1;
-                        const float& ft_weight = fst->x;
+                        const float& ft_value = fst->x;
                         for (; snd < snd_end; ++snd)
                         {                            
                             call_audit<R, audit_func>(dat, snd);
                             //  const size_t ft_idx = ((snd->weight_index /*>> stride_shift*/) ^ halfhash) /*<< stride_shift*/;                            
-                            call_T<R, T> (dat, weight_vector, weight_mask, INTER_WEIGHT_OP(ft_weight,snd->x), (snd->weight_index^halfhash) + offset);
+                            call_T<R, T> (dat, weight_vector, weight_mask, INTERACTION_VALUE(ft_value,snd->x), (snd->weight_index^halfhash) + offset);
                             call_audit<R, audit_func>(dat, nullptr);
                         } // end for(snd)
 
@@ -214,7 +216,7 @@ inline void generate_interactions(vw& all, example& ec, R& dat, v_array<feature_
                                                                           (PROCESS_SELF_INTERACTIONS(fst->x)) ? fst : fst+1;
 
                                 const uint32_t halfhash1 = FNV_prime * fst->weight_index;
-                                const float& ft_weight = fst->x;
+                                const float& ft_value = fst->x;
 
                                 for (; snd < snd_end; ++snd)
                                 {
@@ -222,7 +224,7 @@ inline void generate_interactions(vw& all, example& ec, R& dat, v_array<feature_
                                     call_audit<R, audit_func>(dat, snd);
 
                                     const uint32_t halfhash2 = FNV_prime * (halfhash1 ^ snd->weight_index);
-                                    const float ft_weight1 = INTER_WEIGHT_OP(ft_weight, snd->x);
+                                    const float ft_value1 = INTERACTION_VALUE(ft_value, snd->x);
 
                                     // next index differs for permutations and simple combinations
                                     const feature_class* thr = (!same_namespace2) ? features_data[thr_ns].begin :
@@ -232,7 +234,7 @@ inline void generate_interactions(vw& all, example& ec, R& dat, v_array<feature_
                                     {
                                         call_audit<R, audit_func>(dat, thr);
 //                                        const size_t ft_idx = ((thr->weight_index /*>> stride_shift*/)^ halfhash2) /*<< stride_shift*/;
-                                        call_T<R, T> (dat, weight_vector, weight_mask, INTER_WEIGHT_OP(ft_weight1,thr->x), (thr->weight_index^halfhash2) + offset);
+                                        call_T<R, T> (dat, weight_vector, weight_mask, INTERACTION_VALUE(ft_value1,thr->x), (thr->weight_index^halfhash2) + offset);
                                         call_audit<R, audit_func>(dat, nullptr);
                                     } // end for (thr)
                                    call_audit<R, audit_func>(dat, nullptr);
@@ -352,7 +354,7 @@ inline void generate_interactions(vw& all, example& ec, R& dat, v_array<feature_
                         if (next_data->self_interaction)
                         {
                             // if next namespace is same, we should start with loop_idx + 1 to avoid feature interaction with itself
-                            // unless feature has weight w and w != w*w. E.g. w != 0 and w != 1. Features with w == 0 are already
+                            // unless feature has value x and x != x*x. E.g. x != 0 and x != 1. Features with x == 0 are already
                             // filtered out in parce_args.cc::maybeFeature().
 
                             next_data->loop_idx = (PROCESS_SELF_INTERACTIONS(cur_feature->x)) ? cur_data->loop_idx : cur_data->loop_idx + 1;
@@ -372,7 +374,7 @@ inline void generate_interactions(vw& all, example& ec, R& dat, v_array<feature_
                         {
                             // feature2 xor (16777619*feature1)                            
                             next_data->hash = FNV_prime * (cur_data->hash ^ cur_feature->weight_index);
-                            next_data->x = INTER_WEIGHT_OP(cur_feature->x, cur_data->x);
+                            next_data->x = INTERACTION_VALUE(cur_feature->x, cur_data->x);
                         }
 
                         ++cur_data;
@@ -387,7 +389,7 @@ inline void generate_interactions(vw& all, example& ec, R& dat, v_array<feature_
                         for (feature_class* f = start; f != end; ++f)
                         {
                             call_audit<R, audit_func>(dat, f);
-                            call_T<R, T> (dat, weight_vector, weight_mask, INTER_WEIGHT_OP(fgd2->x, f->x), (fgd2->hash^f->weight_index) + offset );
+                            call_T<R, T> (dat, weight_vector, weight_mask, INTERACTION_VALUE(fgd2->x, f->x), (fgd2->hash^f->weight_index) + offset );
                             call_audit<R, audit_func>(dat, nullptr);
                         }
 

--- a/vowpalwabbit/interactions.h
+++ b/vowpalwabbit/interactions.h
@@ -64,19 +64,19 @@ void eval_count_of_generated_ft(vw& all, example& ec, size_t& new_features_cnt, 
 template <class R, void (*T)(R&, const float, float&)>
 inline void call_T( R& dat, weight* weight_vector, const size_t weight_mask, const float ft_value, const uint32_t ft_idx)
 {
-    T(dat, ft_value, weight_vector[ft_idx & weight_mask]);
+  T(dat, ft_value, weight_vector[ft_idx & weight_mask]);
 }
 
 template <class R, void (*T)(R&, float, uint32_t)>
 inline void call_T( R& dat, weight* /*weight_vector*/, const size_t /*weight_mask*/, const float ft_value, const uint32_t ft_idx)
 {
-    T(dat, ft_value, ft_idx);
+  T(dat, ft_value, ft_idx);
 }
 
 template <class R, void (*audit_func)(R&, const audit_data*)>
 inline void call_audit(R& dat, const audit_data* f)
 {
-    audit_func(dat, f);
+  audit_func(dat, f);
 }
 
 // should be optimized away for any audit_func with feature argument
@@ -89,13 +89,13 @@ inline void call_audit(R&, const feature*) {}
 template <class feature_class>
 struct feature_gen_data
 {
-    size_t loop_idx;          // current feature id in namespace
-    uint32_t hash;            // hash of feature interactions of previous namespaces in the list
-    float x;                  // value of feature interactions of previous namespaces in the list
-    size_t loop_end;          // last feature id. May be less than number of features if namespace involved in interaction more than once
-                              // calculated at preprocessing together with same_ns
-    size_t self_interaction;  // namespace interacting with itself    
-    v_array<feature_class>* ft_arr;
+  size_t loop_idx;          // current feature id in namespace
+  uint32_t hash;            // hash of feature interactions of previous namespaces in the list
+  float x;                  // value of feature interactions of previous namespaces in the list
+  size_t loop_end;          // last feature id. May be less than number of features if namespace involved in interaction more than once
+  // calculated at preprocessing together with same_ns
+  size_t self_interaction;  // namespace interacting with itself
+  v_array<feature_class>* ft_arr;
 //    feature_gen_data(): loop_idx(0), x(1.), loop_end(0), self_interaction(false) {}
 };
 
@@ -103,7 +103,9 @@ struct feature_gen_data
 // synthetic (interaction) features' values are calculated, e.g.,
 // fabs(value1-value2) or even value1>value2?1.0:-1.0
 // Beware - its result must be non-zero.
- inline float INTERACTION_VALUE(float value1, float value2) { return value1*value2; }
+inline float INTERACTION_VALUE(float value1, float value2) {
+  return value1*value2;
+}
 
 // uncomment line below to disable usage of inner 'for' loops for pair and triple interactions
 // end switch to usage of non-recursive feature generation algorithm for interactions of any length
@@ -117,304 +119,303 @@ struct feature_gen_data
 template <class R, class S, void (*T)(R&, float, S), class feature_class = feature,  void (*audit_func)(R&, const feature_class*) /*= nullptr*/> // nullptr func can't be used as template param in old compilers
 inline void generate_interactions(vw& all, example& ec, R& dat, v_array<feature_class>* features_data /*= NULL*/) // default value removed to eliminate ambiguity in old complers
 {
-    if (features_data == NULL) features_data = (v_array<feature_class>*)ec.atomics;
-    assert(((void*)features_data == (void*)ec.atomics) || ((void*)features_data == (void*)ec.audit_features));
+  if (features_data == NULL) features_data = (v_array<feature_class>*)ec.atomics;
+  assert(((void*)features_data == (void*)ec.atomics) || ((void*)features_data == (void*)ec.audit_features));
 
-    // often used values
-    const uint32_t offset = ec.ft_offset;
+  // often used values
+  const uint32_t offset = ec.ft_offset;
 //    const uint32_t stride_shift = all.reg.stride_shift; // it seems we don't need stride shift in FTRL-like hash
-    weight* weight_vector = all.reg.weight_vector;
-    const size_t  weight_mask   = all.reg.weight_mask;
+  weight* weight_vector = all.reg.weight_vector;
+  const size_t  weight_mask   = all.reg.weight_mask;
 
-    // statedata for generic non-recursive iteration
-    v_array<feature_gen_data<feature_class> > state_data = v_init<feature_gen_data<feature_class> >();
+  // statedata for generic non-recursive iteration
+  v_array<feature_gen_data<feature_class> > state_data = v_init<feature_gen_data<feature_class> >();
 
-    feature_gen_data<feature_class> empty_ns_data;  // micro-optimization. don't want to call its constructor each time in loop.
-    empty_ns_data.loop_idx = 0;
-    empty_ns_data.x = 1.;
-    empty_ns_data.loop_end = 0;
-    empty_ns_data.self_interaction = false;
+  feature_gen_data<feature_class> empty_ns_data;  // micro-optimization. don't want to call its constructor each time in loop.
+  empty_ns_data.loop_idx = 0;
+  empty_ns_data.x = 1.;
+  empty_ns_data.loop_end = 0;
+  empty_ns_data.self_interaction = false;
 
-    // loop throw the set of possible interactions
-    for (v_string* it = all.interactions.begin; it != all.interactions.end; ++it)
-    {
-        v_string& ns = (*it);         // current list of namespaces to interact.
+  // loop throw the set of possible interactions
+  for (v_string* it = all.interactions.begin; it != all.interactions.end; ++it)
+  {
+    v_string& ns = (*it);         // current list of namespaces to interact.
 
 #ifndef GEN_INTER_LOOP
 
-        // unless GEN_INTER_LOOP is defined we use nested 'for' loops for interactions length 2 (pairs) and 3 (triples)
-        // and generic non-recursive algorythm for all other cases.
-        // nested 'for' loops approach is faster, but can't be used for interation of any length.
+    // unless GEN_INTER_LOOP is defined we use nested 'for' loops for interactions length 2 (pairs) and 3 (triples)
+    // and generic non-recursive algorythm for all other cases.
+    // nested 'for' loops approach is faster, but can't be used for interation of any length.
 
-        const size_t len = ns.size();
+    const size_t len = ns.size();
 
-        if (len == 2) //special case of pairs
-        {
-            const size_t fst_ns = ns[0];
-            if (features_data[fst_ns].size() > 0) {
+    if (len == 2) //special case of pairs
+    {
+      const size_t fst_ns = ns[0];
+      if (features_data[fst_ns].size() > 0) {
 
-                const size_t snd_ns = ns[1];
-                if (features_data[snd_ns].size() > 0) {
+        const size_t snd_ns = ns[1];
+        if (features_data[snd_ns].size() > 0) {
 
-                    const bool same_namespace = ( !all.permutations && ( fst_ns == snd_ns ) );
+          const bool same_namespace = ( !all.permutations && ( fst_ns == snd_ns ) );
 
-                    const feature_class* fst     = features_data[fst_ns].begin;
-                    const feature_class* fst_end = features_data[fst_ns].end;
-                    const feature_class* snd_end = features_data[snd_ns].end;
+          const feature_class* fst     = features_data[fst_ns].begin;
+          const feature_class* fst_end = features_data[fst_ns].end;
+          const feature_class* snd_end = features_data[snd_ns].end;
 
-                    for (; fst != fst_end; ++fst)
-                    {
-                        const uint32_t halfhash = FNV_prime * fst->weight_index;
-                        call_audit<R ,audit_func>(dat, fst);
-                        // next index differs for permutations and simple combinations
-                        const feature_class* snd = (!same_namespace) ? features_data[snd_ns].begin :
-                                                                 (PROCESS_SELF_INTERACTIONS(fst->x)) ? fst : fst+1;
-                        const float& ft_value = fst->x;
-                        for (; snd < snd_end; ++snd)
-                        {                            
-                            call_audit<R, audit_func>(dat, snd);
-                            //  const size_t ft_idx = ((snd->weight_index /*>> stride_shift*/) ^ halfhash) /*<< stride_shift*/;                            
-                            call_T<R, T> (dat, weight_vector, weight_mask, INTERACTION_VALUE(ft_value,snd->x), (snd->weight_index^halfhash) + offset);
-                            call_audit<R, audit_func>(dat, nullptr);
-                        } // end for(snd)
-
-                        call_audit<R, audit_func>(dat, nullptr);
-                    } // end for(fst)
-
-                } // end if (data[snd] size > 0)
-            } // end if (data[fst] size > 0)
-
-        } else
-
-            if (len == 3) // special case for triples
+          for (; fst != fst_end; ++fst)
+          {
+            const uint32_t halfhash = FNV_prime * fst->weight_index;
+            call_audit<R ,audit_func>(dat, fst);
+            // next index differs for permutations and simple combinations
+            const feature_class* snd = (!same_namespace) ? features_data[snd_ns].begin :
+                                       (PROCESS_SELF_INTERACTIONS(fst->x)) ? fst : fst+1;
+            const float& ft_value = fst->x;
+            for (; snd < snd_end; ++snd)
             {
-                const size_t fst_ns = ns[0];
-                if (features_data[fst_ns].size() > 0) {
+              call_audit<R, audit_func>(dat, snd);
+              //  const size_t ft_idx = ((snd->weight_index /*>> stride_shift*/) ^ halfhash) /*<< stride_shift*/;
+              call_T<R, T> (dat, weight_vector, weight_mask, INTERACTION_VALUE(ft_value,snd->x), (snd->weight_index^halfhash) + offset);
+              call_audit<R, audit_func>(dat, nullptr);
+            } // end for(snd)
 
-                    const size_t snd_ns = ns[1];
-                    if (features_data[snd_ns].size() > 0) {
+            call_audit<R, audit_func>(dat, nullptr);
+          } // end for(fst)
 
-                        const size_t thr_ns = ns[2];
-                        if (features_data[thr_ns].size() > 0) {
+        } // end if (data[snd] size > 0)
+      } // end if (data[fst] size > 0)
+
+    } else
+
+      if (len == 3) // special case for triples
+      {
+        const size_t fst_ns = ns[0];
+        if (features_data[fst_ns].size() > 0) {
+
+          const size_t snd_ns = ns[1];
+          if (features_data[snd_ns].size() > 0) {
+
+            const size_t thr_ns = ns[2];
+            if (features_data[thr_ns].size() > 0) {
 
 
-                            // don't compare 1 and 3 as interaction is sorted
-                            const bool same_namespace1 = ( !all.permutations && ( fst_ns == snd_ns ) );
-                            const bool same_namespace2 = ( !all.permutations && ( snd_ns == thr_ns ) );
+              // don't compare 1 and 3 as interaction is sorted
+              const bool same_namespace1 = ( !all.permutations && ( fst_ns == snd_ns ) );
+              const bool same_namespace2 = ( !all.permutations && ( snd_ns == thr_ns ) );
 
-                            const feature_class* fst = features_data[fst_ns].begin;
-                            const feature_class* fst_end = features_data[fst_ns].end;
-                            const feature_class* snd_end = (same_namespace1) ? fst_end : features_data[snd_ns].end;
-                            const feature_class* thr_end = (same_namespace2) ? snd_end : features_data[thr_ns].end;
+              const feature_class* fst = features_data[fst_ns].begin;
+              const feature_class* fst_end = features_data[fst_ns].end;
+              const feature_class* snd_end = (same_namespace1) ? fst_end : features_data[snd_ns].end;
+              const feature_class* thr_end = (same_namespace2) ? snd_end : features_data[thr_ns].end;
 
-                            for (; fst < fst_end; ++fst)
-                            {
-                                call_audit<R, audit_func>(dat, fst);
+              for (; fst < fst_end; ++fst)
+              {
+                call_audit<R, audit_func>(dat, fst);
 
-                                // next index differs for permutations and simple combinations
-                                const feature_class* snd = (!same_namespace1) ? features_data[snd_ns].begin :
-                                                                          (PROCESS_SELF_INTERACTIONS(fst->x)) ? fst : fst+1;
+                // next index differs for permutations and simple combinations
+                const feature_class* snd = (!same_namespace1) ? features_data[snd_ns].begin :
+                                           (PROCESS_SELF_INTERACTIONS(fst->x)) ? fst : fst+1;
 
-                                const uint32_t halfhash1 = FNV_prime * fst->weight_index;
-                                const float& ft_value = fst->x;
+                const uint32_t halfhash1 = FNV_prime * fst->weight_index;
+                const float& ft_value = fst->x;
 
-                                for (; snd < snd_end; ++snd)
-                                {
-                                    //f3 x k*(f2 x k*f1)
-                                    call_audit<R, audit_func>(dat, snd);
+                for (; snd < snd_end; ++snd)
+                {
+                  //f3 x k*(f2 x k*f1)
+                  call_audit<R, audit_func>(dat, snd);
 
-                                    const uint32_t halfhash2 = FNV_prime * (halfhash1 ^ snd->weight_index);
-                                    const float ft_value1 = INTERACTION_VALUE(ft_value, snd->x);
+                  const uint32_t halfhash2 = FNV_prime * (halfhash1 ^ snd->weight_index);
+                  const float ft_value1 = INTERACTION_VALUE(ft_value, snd->x);
 
-                                    // next index differs for permutations and simple combinations
-                                    const feature_class* thr = (!same_namespace2) ? features_data[thr_ns].begin :
-                                                                              (PROCESS_SELF_INTERACTIONS(snd->x)) ? snd : snd+1;
+                  // next index differs for permutations and simple combinations
+                  const feature_class* thr = (!same_namespace2) ? features_data[thr_ns].begin :
+                                             (PROCESS_SELF_INTERACTIONS(snd->x)) ? snd : snd+1;
 
-                                    for (; thr < thr_end; ++thr)
-                                    {
-                                        call_audit<R, audit_func>(dat, thr);
+                  for (; thr < thr_end; ++thr)
+                  {
+                    call_audit<R, audit_func>(dat, thr);
 //                                        const size_t ft_idx = ((thr->weight_index /*>> stride_shift*/)^ halfhash2) /*<< stride_shift*/;
-                                        call_T<R, T> (dat, weight_vector, weight_mask, INTERACTION_VALUE(ft_value1,thr->x), (thr->weight_index^halfhash2) + offset);
-                                        call_audit<R, audit_func>(dat, nullptr);
-                                    } // end for (thr)
-                                   call_audit<R, audit_func>(dat, nullptr);
-                                } // end for (snd)
-                                call_audit<R, audit_func>(dat, nullptr);
-                            } // end for (fst)
+                    call_T<R, T> (dat, weight_vector, weight_mask, INTERACTION_VALUE(ft_value1,thr->x), (thr->weight_index^halfhash2) + offset);
+                    call_audit<R, audit_func>(dat, nullptr);
+                  } // end for (thr)
+                  call_audit<R, audit_func>(dat, nullptr);
+                } // end for (snd)
+                call_audit<R, audit_func>(dat, nullptr);
+              } // end for (fst)
 
-                        } // end if (data[thr] size > 0)
-                    } // end if (data[snd] size > 0)
-                } // end if (data[fst] size > 0)
+            } // end if (data[thr] size > 0)
+          } // end if (data[snd] size > 0)
+        } // end if (data[fst] size > 0)
 
-            } else // generic case: quatriples, etc.
+      } else // generic case: quatriples, etc.
 
 #endif
+      {
+
+        bool must_skip_interaction = false;
+
+        // preparing state data
+        feature_gen_data<feature_class>* fgd = state_data.begin;
+        feature_gen_data<feature_class>* fgd2; // for further use
+        for (unsigned char* n = ns.begin; n != ns.end; ++n)
+        {
+          v_array<feature_class>* ft = &features_data[(int32_t)*n];
+          const size_t ft_cnt = ft->size();
+
+          if (ft_cnt == 0)
+          {
+            must_skip_interaction = true;
+            break;
+          }
+
+          if (fgd == state_data.end)
+          {
+            state_data.push_back(empty_ns_data);
+            fgd = state_data.end-1; // reassign as memory could be realloced
+          }
+
+          fgd->loop_end = ft_cnt-1; // saving number of features for each namespace
+          fgd->ft_arr = ft;
+          ++fgd;
+        }
+
+        // if any of interacting namespace has 0 features - whole interaction is skipped
+        if (must_skip_interaction) continue; //no_data_to_interact
+
+
+
+        if (!all.permutations) // adjust state_data for simple combinations
+        {
+          // if permutations mode is disabeled then namespaces in ns are already sorted and thus grouped
+          // (in fact, currently they are sorted even for enabled permutations mode)
+          // let's go throw the list and calculate number of features to skip in namespaces which
+          // repeated more than once to generate only simple combinations of features
+
+          size_t margin = 0;  // number of features to ignore if namesapce has been seen before
+
+          // iterate list backward as margin grows in this order
+
+          for (fgd = state_data.end-1; fgd > state_data.begin; --fgd)
+          {
+            fgd2 = fgd-1;
+            fgd->self_interaction = (fgd->ft_arr == fgd2->ft_arr); //state_data.begin.self_interaction is always false
+            if (fgd->self_interaction)
             {
+              size_t& loop_end = fgd2->loop_end;
 
-                bool must_skip_interaction = false;
+              if (!PROCESS_SELF_INTERACTIONS((*fgd2->ft_arr)[loop_end-margin].x))
+              {
+                ++margin; // otherwise margin can 't be increased
+                if ( (must_skip_interaction = (loop_end < margin)) ) break;
+              }
 
-                // preparing state data
-                feature_gen_data<feature_class>* fgd = state_data.begin;
-                feature_gen_data<feature_class>* fgd2; // for further use
-                for (unsigned char* n = ns.begin; n != ns.end; ++n)
-                {                    
-                    v_array<feature_class>* ft = &features_data[(int32_t)*n];
-                    const size_t ft_cnt = ft->size();
+              if (margin != 0)
+                loop_end -= margin;               // skip some features and increase margin
+            } else if (margin != 0) margin = 0;
 
-                    if (ft_cnt == 0)
-                    {
-                        must_skip_interaction = true;
-                        break;
-                    }
+          }
 
-                    if (fgd == state_data.end)
-                    {
-                        state_data.push_back(empty_ns_data);
-                        fgd = state_data.end-1; // reassign as memory could be realloced
-                    }
-
-                    fgd->loop_end = ft_cnt-1; // saving number of features for each namespace
-                    fgd->ft_arr = ft;
-                    ++fgd;
-                }
-
-                // if any of interacting namespace has 0 features - whole interaction is skipped
-                if (must_skip_interaction) continue; //no_data_to_interact
+          // if impossible_without_permutations == true then we faced with case like interaction 'aaaa'
+          // where namespace 'a' contains less than 4 unique features. It's impossible to make simple
+          // combination of length 4 without repetitions from 3 or less elements.
+          if (must_skip_interaction) continue; // impossible_without_permutations
+        } // end of state_data adjustment
 
 
+        fgd = state_data.begin;  // always equal to first ns
+        fgd2 = state_data.end-1; // always equal to last ns
+        fgd->loop_idx = 0; // loop_idx contains current feature id for curently processed namespace.
 
-                if (!all.permutations) // adjust state_data for simple combinations
-                {
-                    // if permutations mode is disabeled then namespaces in ns are already sorted and thus grouped
-                    // (in fact, currently they are sorted even for enabled permutations mode)
-                    // let's go throw the list and calculate number of features to skip in namespaces which
-                    // repeated more than once to generate only simple combinations of features
+        // beware: micro-optimization.
 
-                    size_t margin = 0;  // number of features to ignore if namesapce has been seen before                    
+        feature_class* features_begin = fgd2->ft_arr->begin; // in fact, constant in all cases. Left non constant to avoid type conversion
+        /* start & end are always point to features in last namespace of interaction.
+            for 'all.permutations == true' they are constant.*/
+        feature_class* start = features_begin;
+        feature_class* end = features_begin + fgd2->loop_end + 1; // end is constant as data->loop_end is never changed in the loop
 
-                    // iterate list backward as margin grows in this order                    
-
-                    for (fgd = state_data.end-1; fgd > state_data.begin; --fgd)
-                    {
-                        fgd2 = fgd-1;
-                        fgd->self_interaction = (fgd->ft_arr == fgd2->ft_arr); //state_data.begin.self_interaction is always false
-                        if (fgd->self_interaction)
-                        {                            
-                            size_t& loop_end = fgd2->loop_end;
-
-                            if (!PROCESS_SELF_INTERACTIONS((*fgd2->ft_arr)[loop_end-margin].x))
-                            {
-                                ++margin; // otherwise margin can 't be increased
-                                if ( (must_skip_interaction = (loop_end < margin)) ) break;
-                            }
-
-                            if (margin != 0)
-                                loop_end -= margin;               // skip some features and increase margin
-                        } else
-                            if (margin != 0) margin = 0;
-
-                    }
-
-                    // if impossible_without_permutations == true then we faced with case like interaction 'aaaa'
-                    // where namespace 'a' contains less than 4 unique features. It's impossible to make simple
-                    // combination of length 4 without repetitions from 3 or less elements.
-                    if (must_skip_interaction) continue; // impossible_without_permutations
-                } // end of state_data adjustment
+        feature_gen_data<feature_class>* cur_data = fgd;
+        feature_gen_data<feature_class>* next_data;
+        feature_class* cur_feature;
+        // end of micro-optimization block
 
 
-                fgd = state_data.begin;  // always equal to first ns
-                fgd2 = state_data.end-1; // always equal to last ns
-                fgd->loop_idx = 0; // loop_idx contains current feature id for curently processed namespace.
+        // generic feature generation cycle for interactions of any length
+        bool do_it = true;
 
-                // beware: micro-optimization.
+        while (do_it)
+        {
 
-                feature_class* features_begin = fgd2->ft_arr->begin; // in fact, constant in all cases. Left non constant to avoid type conversion
-                /* start & end are always point to features in last namespace of interaction.
-                    for 'all.permutations == true' they are constant.*/
-                feature_class* start = features_begin;
-                feature_class* end = features_begin + fgd2->loop_end + 1; // end is constant as data->loop_end is never changed in the loop
+          if (cur_data < fgd2) // can go further throw the list of namespaces in interaction
+          {
+            next_data = cur_data+1;
+            cur_feature = cur_data->ft_arr->begin + cur_data->loop_idx;
 
-                feature_gen_data<feature_class>* cur_data = fgd;
-                feature_gen_data<feature_class>* next_data;
-                feature_class* cur_feature;
-                // end of micro-optimization block
+            if (next_data->self_interaction)
+            {
+              // if next namespace is same, we should start with loop_idx + 1 to avoid feature interaction with itself
+              // unless feature has value x and x != x*x. E.g. x != 0 and x != 1. Features with x == 0 are already
+              // filtered out in parce_args.cc::maybeFeature().
 
-
-                // generic feature generation cycle for interactions of any length
-                bool do_it = true;
-
-                while (do_it)
-                {                    
-
-                    if (cur_data < fgd2) // can go further throw the list of namespaces in interaction
-                    {
-                        next_data = cur_data+1;
-                        cur_feature = cur_data->ft_arr->begin + cur_data->loop_idx;
-
-                        if (next_data->self_interaction)
-                        {
-                            // if next namespace is same, we should start with loop_idx + 1 to avoid feature interaction with itself
-                            // unless feature has value x and x != x*x. E.g. x != 0 and x != 1. Features with x == 0 are already
-                            // filtered out in parce_args.cc::maybeFeature().
-
-                            next_data->loop_idx = (PROCESS_SELF_INTERACTIONS(cur_feature->x)) ? cur_data->loop_idx : cur_data->loop_idx + 1;
-                        }
-                        else
-                            next_data->loop_idx = 0;
+              next_data->loop_idx = (PROCESS_SELF_INTERACTIONS(cur_feature->x)) ? cur_data->loop_idx : cur_data->loop_idx + 1;
+            }
+            else
+              next_data->loop_idx = 0;
 
 
-                        call_audit<R, audit_func>(dat, cur_feature);
+            call_audit<R, audit_func>(dat, cur_feature);
 
-                        if (cur_data == fgd) // first namespace
-                        {
-                            next_data->hash = FNV_prime * cur_feature->weight_index;
-                            next_data->x = cur_feature->x; // data->x == 1.                            
-                        }
-                        else
-                        {
-                            // feature2 xor (16777619*feature1)                            
-                            next_data->hash = FNV_prime * (cur_data->hash ^ cur_feature->weight_index);
-                            next_data->x = INTERACTION_VALUE(cur_feature->x, cur_data->x);
-                        }
-
-                        ++cur_data;
-
-                    } else {
-
-                        // last namespace - iterate its features and go back
-
-                        if (!all.permutations) // start value is not a constant in this case
-                            start = features_begin + fgd2->loop_idx;
-
-                        for (feature_class* f = start; f != end; ++f)
-                        {
-                            call_audit<R, audit_func>(dat, f);
-                            call_T<R, T> (dat, weight_vector, weight_mask, INTERACTION_VALUE(fgd2->x, f->x), (fgd2->hash^f->weight_index) + offset );
-                            call_audit<R, audit_func>(dat, nullptr);
-                        }
-
-                        // trying to go back increasing loop_idx of each namespace by the way
-
-                        bool go_further = true;
-
-                        do {
-                            --cur_data;
-                            go_further = (++cur_data->loop_idx > cur_data->loop_end); //increment loop_idx
-                            call_audit<R, audit_func>(dat, nullptr);
-                        } while (go_further && cur_data != fgd);
-
-                        do_it = !(cur_data == fgd && go_further);
-                        //if do_it==false - we've reached 0 namespace but its 'cur_data.loop_idx > cur_data.loop_end' -> exit the while loop
-
-                    } // if last namespace
-
-                } // while do_it
-
+            if (cur_data == fgd) // first namespace
+            {
+              next_data->hash = FNV_prime * cur_feature->weight_index;
+              next_data->x = cur_feature->x; // data->x == 1.
+            }
+            else
+            {
+              // feature2 xor (16777619*feature1)
+              next_data->hash = FNV_prime * (cur_data->hash ^ cur_feature->weight_index);
+              next_data->x = INTERACTION_VALUE(cur_feature->x, cur_data->x);
             }
 
-    } // foreach interaction in all.interactions
+            ++cur_data;
 
-    state_data.delete_v();
+          } else {
+
+            // last namespace - iterate its features and go back
+
+            if (!all.permutations) // start value is not a constant in this case
+              start = features_begin + fgd2->loop_idx;
+
+            for (feature_class* f = start; f != end; ++f)
+            {
+              call_audit<R, audit_func>(dat, f);
+              call_T<R, T> (dat, weight_vector, weight_mask, INTERACTION_VALUE(fgd2->x, f->x), (fgd2->hash^f->weight_index) + offset );
+              call_audit<R, audit_func>(dat, nullptr);
+            }
+
+            // trying to go back increasing loop_idx of each namespace by the way
+
+            bool go_further = true;
+
+            do {
+              --cur_data;
+              go_further = (++cur_data->loop_idx > cur_data->loop_end); //increment loop_idx
+              call_audit<R, audit_func>(dat, nullptr);
+            } while (go_further && cur_data != fgd);
+
+            do_it = !(cur_data == fgd && go_further);
+            //if do_it==false - we've reached 0 namespace but its 'cur_data.loop_idx > cur_data.loop_end' -> exit the while loop
+
+          } // if last namespace
+
+        } // while do_it
+
+      }
+
+  } // foreach interaction in all.interactions
+
+  state_data.delete_v();
 }
 
 template <class R>
@@ -424,22 +425,22 @@ inline void dummy_func(R&, const feature*) {} // should never be called due to c
 template <class R, class S, void (*T)(R&, float, S)>
 inline void generate_interactions(vw& all, example& ec, R& dat)
 {
-    generate_interactions<R, S, T, feature, dummy_func<R> > (all, ec, dat, ec.atomics);
+  generate_interactions<R, S, T, feature, dummy_func<R> > (all, ec, dat, ec.atomics);
 }
 
 // C(n,k) = n!/(k!(n-k)!)
 
 inline long long choose(long long n, long long k) {
-    if (k > n) return 0;
-    if (k<0) return 0;
-    if (k==n) return 1;
-    if (k==0 && n!=0) return 1;
-    long long r = 1;
-    for (long long d = 1; d <= k; ++d) {
-      r *= n--;
-      r /= d;
-    }
-    return r;
+  if (k > n) return 0;
+  if (k<0) return 0;
+  if (k==n) return 1;
+  if (k==0 && n!=0) return 1;
+  long long r = 1;
+  for (long long d = 1; d <= k; ++d) {
+    r *= n--;
+    r /= d;
+  }
+  return r;
 }
 
 } // end of namespace

--- a/vowpalwabbit/io_buf.cc
+++ b/vowpalwabbit/io_buf.cc
@@ -9,33 +9,33 @@ license as described in the file LICENSE.
 #endif
 
 size_t buf_read(io_buf &i, char* &pointer, size_t n)
-{//return a pointer to the next n bytes.  n must be smaller than the maximum size.
+{ //return a pointer to the next n bytes.  n must be smaller than the maximum size.
   if (i.space.end + n <= i.endloaded)
-    {
-      pointer = i.space.end;
-      i.space.end += n;
-      return n;
-    }
+  {
+    pointer = i.space.end;
+    i.space.end += n;
+    return n;
+  }
   else // out of bytes, so refill.
-    {
-      if (i.space.end != i.space.begin) //There exists room to shift.
-	{ // Out of buffer so swap to beginning.
-	  size_t left = i.endloaded - i.space.end;
-	  memmove(i.space.begin, i.space.end, left);
-	  i.space.end = i.space.begin;
-	  i.endloaded = i.space.begin+left;
-	}
-      if (i.fill(i.files[i.current]) > 0)
-	return buf_read(i,pointer,n);// more bytes are read.
-      else if (++i.current < i.files.size()) 
-	return buf_read(i,pointer,n);// No more bytes, so go to next file and try again.
-      else
-	{//no more bytes to read, return all that we have left.
-	  pointer = i.space.end;
-	  i.space.end = i.endloaded;
-	  return i.endloaded - pointer;
-	}
+  {
+    if (i.space.end != i.space.begin) //There exists room to shift.
+    { // Out of buffer so swap to beginning.
+      size_t left = i.endloaded - i.space.end;
+      memmove(i.space.begin, i.space.end, left);
+      i.space.end = i.space.begin;
+      i.endloaded = i.space.begin+left;
     }
+    if (i.fill(i.files[i.current]) > 0)
+      return buf_read(i,pointer,n);// more bytes are read.
+    else if (++i.current < i.files.size())
+      return buf_read(i,pointer,n);// No more bytes, so go to next file and try again.
+    else
+    { //no more bytes to read, return all that we have left.
+      pointer = i.space.end;
+      i.space.end = i.endloaded;
+      return i.endloaded - pointer;
+    }
+  }
 }
 
 bool isbinary(io_buf &i) {
@@ -51,59 +51,59 @@ bool isbinary(io_buf &i) {
 }
 
 size_t readto(io_buf &i, char* &pointer, char terminal)
-{//Return a pointer to the bytes before the terminal.  Must be less than the buffer size.
+{ //Return a pointer to the bytes before the terminal.  Must be less than the buffer size.
   pointer = i.space.end;
   while (pointer < i.endloaded && *pointer != terminal)
     pointer++;
   if (pointer != i.endloaded)
+  {
+    size_t n = pointer - i.space.end;
+    i.space.end = pointer+1;
+    pointer -= n;
+    return n+1;
+  }
+  else
+  {
+    if (i.endloaded == i.space.end_array)
+    {
+      size_t left = i.endloaded - i.space.end;
+      memmove(i.space.begin, i.space.end, left);
+      i.space.end = i.space.begin;
+      i.endloaded = i.space.begin+left;
+      pointer = i.endloaded;
+    }
+    if (i.current < i.files.size() && i.fill(i.files[i.current]) > 0)// more bytes are read.
+      return readto(i,pointer,terminal);
+    else if (++i.current < i.files.size())  //no more bytes, so go to next file.
+      return readto(i,pointer,terminal);
+    else //no more bytes to read, return everything we have.
     {
       size_t n = pointer - i.space.end;
-      i.space.end = pointer+1;
+      i.space.end = pointer;
       pointer -= n;
-      return n+1;
+      return n;
     }
-  else
-    {
-      if (i.endloaded == i.space.end_array)
-	{
-	  size_t left = i.endloaded - i.space.end;
-	  memmove(i.space.begin, i.space.end, left);
-	  i.space.end = i.space.begin;
-	  i.endloaded = i.space.begin+left;
-	  pointer = i.endloaded;
-	}
-      if (i.current < i.files.size() && i.fill(i.files[i.current]) > 0)// more bytes are read.
-	return readto(i,pointer,terminal);
-      else if (++i.current < i.files.size())  //no more bytes, so go to next file.
-	return readto(i,pointer,terminal);
-      else //no more bytes to read, return everything we have.
-	{
-	  size_t n = pointer - i.space.end;
-	  i.space.end = pointer;
-	  pointer -= n;
-	  return n;
-	}
-    }
+  }
 }
 
 void buf_write(io_buf &o, char* &pointer, size_t n)
-{//return a pointer to the next n bytes to write into.
+{ //return a pointer to the next n bytes to write into.
   if (o.space.end + n <= o.space.end_array)
-    {
-      pointer = o.space.end;
-      o.space.end += n;
-    }
+  {
+    pointer = o.space.end;
+    o.space.end += n;
+  }
   else // Time to dump the file
+  {
+    if (o.space.end != o.space.begin)
+      o.flush();
+    else // Array is short, so increase size.
     {
-      if (o.space.end != o.space.begin)
-	o.flush();
-      else // Array is short, so increase size.
-	{
-	  o.space.resize(2*(o.space.end_array - o.space.begin));
-	  o.endloaded = o.space.begin;
-	}
-      buf_write (o, pointer,n);
+      o.space.resize(2*(o.space.end_array - o.space.begin));
+      o.endloaded = o.space.begin;
     }
+    buf_write (o, pointer,n);
+  }
 }
 
 bool io_buf::is_socket(int f)
@@ -114,21 +114,21 @@ bool io_buf::is_socket(int f)
 
 ssize_t io_buf::read_file_or_socket(int f, void* buf, size_t nbytes) {
 #ifdef _WIN32
-  if (is_socket(f)) 
+  if (is_socket(f))
     return recv(f, reinterpret_cast<char*>(buf), static_cast<int>(nbytes), 0);
-  else 
-    return _read(f, buf, (unsigned int)nbytes); 
+  else
+    return _read(f, buf, (unsigned int)nbytes);
 #else
-  return read(f, buf, (unsigned int)nbytes); 
+  return read(f, buf, (unsigned int)nbytes);
 #endif
 }
 
 ssize_t io_buf::write_file_or_socket(int f, const void* buf, size_t nbytes)
 {
 #ifdef _WIN32
-  if (is_socket(f)) 
+  if (is_socket(f))
     return send(f, reinterpret_cast<const char*>(buf), static_cast<int>(nbytes), 0);
-  else 
+  else
     return _write(f, buf, (unsigned int)nbytes);
 #else
   return write(f, buf, (unsigned int)nbytes);
@@ -138,9 +138,9 @@ ssize_t io_buf::write_file_or_socket(int f, const void* buf, size_t nbytes)
 void io_buf::close_file_or_socket(int f)
 {
 #ifdef _WIN32
-  if (io_buf::is_socket(f)) 
+  if (io_buf::is_socket(f))
     closesocket(f);
-  else 
+  else
     _close(f);
 #else
   close(f);

--- a/vowpalwabbit/io_buf.h
+++ b/vowpalwabbit/io_buf.h
@@ -31,7 +31,7 @@ using namespace std;
 #endif
 
 class io_buf {
- public:
+public:
   v_array<char> space; //space.begin = beginning of loaded values.  space.end = end of read or written values.
   v_array<int> files;
   size_t count; // maximum number of file descriptors.
@@ -39,11 +39,11 @@ class io_buf {
   char* endloaded; //end of loaded values
   v_array<char> currentname;
   v_array<char> finalname;
-  
+
   static const int READ = 1;
   static const int WRITE = 2;
 
-  void init(){
+  void init() {
     space = v_init<char>();
     files = v_init<int>();
     currentname = v_init<char>();
@@ -55,34 +55,34 @@ class io_buf {
     endloaded = space.begin;
   }
 
-  virtual int open_file(const char* name, bool stdin_off, int flag=READ){
+  virtual int open_file(const char* name, bool stdin_off, int flag=READ) {
     int ret = -1;
-    switch(flag){
+    switch(flag) {
     case READ:
       if (*name != '\0')
-	{
+      {
 #ifdef _WIN32
-	  // _O_SEQUENTIAL hints to OS that we'll be reading sequentially, so cache aggressively.
-	  _sopen_s(&ret, name, _O_RDONLY|_O_BINARY|_O_SEQUENTIAL, _SH_DENYWR, 0);
+        // _O_SEQUENTIAL hints to OS that we'll be reading sequentially, so cache aggressively.
+        _sopen_s(&ret, name, _O_RDONLY|_O_BINARY|_O_SEQUENTIAL, _SH_DENYWR, 0);
 #else
-	  ret = open(name, O_RDONLY|O_LARGEFILE);
+        ret = open(name, O_RDONLY|O_LARGEFILE);
 #endif
-	}
+      }
       else if (!stdin_off)
 #ifdef _WIN32
-	ret = _fileno(stdin);
+        ret = _fileno(stdin);
 #else
-      ret = fileno(stdin);
+        ret = fileno(stdin);
 #endif
       if(ret!=-1)
-	files.push_back(ret);
+        files.push_back(ret);
       break;
 
     case WRITE:
 #ifdef _WIN32
-		_sopen_s(&ret, name, _O_CREAT|_O_WRONLY|_O_BINARY|_O_TRUNC, _SH_DENYWR, _S_IREAD|_S_IWRITE);
+      _sopen_s(&ret, name, _O_CREAT|_O_WRONLY|_O_BINARY|_O_TRUNC, _SH_DENYWR, _S_IREAD|_S_IWRITE);
 #else
-		ret = open(name, O_CREAT|O_WRONLY|O_LARGEFILE|O_TRUNC,0666);
+      ret = open(name, O_CREAT|O_WRONLY|O_LARGEFILE|O_TRUNC,0666);
 #endif
       if(ret!=-1)
         files.push_back(ret);
@@ -94,13 +94,13 @@ class io_buf {
     }
     if (ret == -1 && *name != '\0')
       THROWERRNO("can't open: " << name);
-    
+
     return ret;
   }
 
-  virtual void reset_file(int f){
+  virtual void reset_file(int f) {
 #ifdef _WIN32
-	_lseek(f, 0, SEEK_SET);
+    _lseek(f, 0, SEEK_SET);
 #else
     lseek(f, 0, SEEK_SET);
 #endif
@@ -112,16 +112,20 @@ class io_buf {
     init();
   }
 
-  virtual ~io_buf(){
+  virtual ~io_buf() {
     files.delete_v();
     space.delete_v();
   }
 
-  void set(char *p){space.end = p;}
+  void set(char *p) {
+    space.end = p;
+  }
 
-  virtual size_t num_files(){ return files.size();}
+  virtual size_t num_files() {
+    return files.size();
+  }
 
-  virtual ssize_t read_file(int f, void* buf, size_t nbytes){
+  virtual ssize_t read_file(int f, void* buf, size_t nbytes) {
     return read_file_or_socket(f, buf, nbytes);
   }
 
@@ -129,17 +133,17 @@ class io_buf {
 
   size_t fill(int f) {
     if (space.end_array - endloaded == 0)
-      {
-	size_t offset = endloaded - space.begin;
-	space.resize(2 * (space.end_array - space.begin));
-	endloaded = space.begin+offset;
-      }
+    {
+      size_t offset = endloaded - space.begin;
+      space.resize(2 * (space.end_array - space.begin));
+      endloaded = space.begin+offset;
+    }
     ssize_t num_read = read_file(f, endloaded, space.end_array - endloaded);
     if (num_read >= 0)
-      {
-	endloaded = endloaded+num_read;
-	return num_read;
-      }
+    {
+      endloaded = endloaded+num_read;
+      return num_read;
+    }
     else
       return 0;
   }
@@ -151,26 +155,28 @@ class io_buf {
   static ssize_t write_file_or_socket(int f, const void* buf, size_t nbytes);
 
   virtual void flush() {
-	if (files.size() > 0) {
-		if (write_file(files[0], space.begin, space.size()) != (int)space.size())
-			std::cerr << "error, failed to write example\n";
-		space.end = space.begin;
-	}
+    if (files.size() > 0) {
+      if (write_file(files[0], space.begin, space.size()) != (int)space.size())
+        std::cerr << "error, failed to write example\n";
+      space.end = space.begin;
+    }
   }
 
-  virtual bool close_file(){
-    if(files.size()>0){
+  virtual bool close_file() {
+    if(files.size()>0) {
       close_file_or_socket(files.pop());
       return true;
     }
     return false;
   }
 
-  virtual bool compressed() { return false; }
+  virtual bool compressed() {
+    return false;
+  }
 
   static void close_file_or_socket(int f);
 
-  void close_files(){
+  void close_files() {
     while(close_file());
   }
 
@@ -186,16 +192,15 @@ size_t readto(io_buf &i, char* &pointer, char terminal);
 inline size_t bin_read_fixed(io_buf& i, char* data, size_t len, const char* read_message)
 {
   if (len > 0)
-    {
-      char* p;
-      size_t ret = buf_read(i,p,len);
-      if (*read_message == '\0')
-	memcpy(data,p,len);
-      else
-	if (memcmp(data,p,len) != 0)
-	  THROW(read_message);
-      return ret;
-    }
+  {
+    char* p;
+    size_t ret = buf_read(i,p,len);
+    if (*read_message == '\0')
+      memcpy(data,p,len);
+    else if (memcmp(data,p,len) != 0)
+      THROW(read_message);
+    return ret;
+  }
   return 0;
 }
 
@@ -214,11 +219,11 @@ inline size_t bin_read(io_buf& i, char* data, size_t len, const char* read_messa
 inline size_t bin_write_fixed(io_buf& o, const char* data, uint32_t len)
 {
   if (len > 0)
-    {
-      char* p;
-      buf_write (o, p, len);
-      memcpy (p, data, len);
-    }
+  {
+    char* p;
+    buf_write (o, p, len);
+    memcpy (p, data, len);
+  }
   return len;
 }
 
@@ -229,21 +234,20 @@ inline size_t bin_write(io_buf& o, const char* data, uint32_t len)
   return (len + sizeof(len));
 }
 
-inline size_t bin_text_write(io_buf& io, char* data, uint32_t len, 
-		      const char* text_data, uint32_t text_len, bool text)
+inline size_t bin_text_write(io_buf& io, char* data, uint32_t len,
+                             const char* text_data, uint32_t text_len, bool text)
 {
   if (text)
     return bin_write_fixed (io, text_data, text_len);
-  else 
-    if (len > 0)
-      return bin_write (io, data, len);
+  else if (len > 0)
+    return bin_write (io, data, len);
   return 0;
 }
 
 //a unified function for read(in binary), write(in binary), and write(in text)
-inline size_t bin_text_read_write(io_buf& io, char* data, uint32_t len, 
-			 const char* read_message, bool read, 
-			 const char* text_data, uint32_t text_len, bool text)
+inline size_t bin_text_read_write(io_buf& io, char* data, uint32_t len,
+                                  const char* read_message, bool read,
+                                  const char* text_data, uint32_t text_len, bool text)
 {
   if (read)
     return bin_read(io, data, len, read_message);
@@ -251,20 +255,20 @@ inline size_t bin_text_read_write(io_buf& io, char* data, uint32_t len,
     return bin_text_write(io,data,len, text_data, text_len, text);
 }
 
-inline size_t bin_text_write_fixed(io_buf& io, char* data, uint32_t len, 
-		      const char* text_data, uint32_t text_len, bool text)
+inline size_t bin_text_write_fixed(io_buf& io, char* data, uint32_t len,
+                                   const char* text_data, uint32_t text_len, bool text)
 {
   if (text)
     return bin_write_fixed (io, text_data, text_len);
-  else 
+  else
     return bin_write_fixed (io, data, len);
   return 0;
 }
 
 //a unified function for read(in binary), write(in binary), and write(in text)
-inline size_t bin_text_read_write_fixed(io_buf& io, char* data, uint32_t len, 
-			       const char* read_message, bool read, 
-			       const char* text_data, uint32_t text_len, bool text)
+inline size_t bin_text_read_write_fixed(io_buf& io, char* data, uint32_t len,
+                                        const char* read_message, bool read,
+                                        const char* text_data, uint32_t text_len, bool text)
 {
   if (read)
     return bin_read_fixed(io, data, len, read_message);

--- a/vowpalwabbit/kernel_svm.cc
+++ b/vowpalwabbit/kernel_svm.cc
@@ -38,9 +38,9 @@ struct svm_params;
 struct svm_example {
   v_array<float> krow;
   flat_example ex;
-  
+
   ~svm_example();
-    void init_svm_example(flat_example *fec); 
+  void init_svm_example(flat_example *fec);
   int compute_kernels(svm_params& params);
   int clear_kernels();
 };
@@ -51,758 +51,760 @@ struct svm_model {
   v_array<float> alpha;
   v_array<float> delta;
 };
-  
+
 struct svm_params {
   size_t current_pass;
   bool active;
   bool active_pool_greedy;
   bool para_active;
   double active_c;
-  
+
   size_t pool_size;
   size_t pool_pos;
   size_t subsample; //NOTE: Eliminating subsample to only support 1/pool_size
   size_t reprocess;
-  
+
   svm_model* model;
   size_t maxcache;
   //size_t curcache;
-  
+
   svm_example** pool;
   float lambda;
-  
+
   void* kernel_params;
   size_t kernel_type;
-  
+
   size_t local_begin, local_end;
   size_t current_t;
-  
+
   float loss_sum;
-  
+
   vw* all;//flatten, parallel
 };
 
-  static size_t num_kernel_evals = 0;
-  static size_t num_cache_evals = 0;
-  
-  void svm_example::init_svm_example(flat_example *fec)
+static size_t num_kernel_evals = 0;
+static size_t num_cache_evals = 0;
+
+void svm_example::init_svm_example(flat_example *fec)
+{
+  ex = *fec;
+  free(fec);
+}
+
+svm_example::~svm_example()
+{
+  krow.delete_v();
+  // free flatten example contents
+  flat_example *fec = &calloc_or_die<flat_example>();
+  *fec = ex;
+  free_flatten_example(fec); // free contents of flat example and frees fec.
+}
+
+
+float
+kernel_function(const flat_example* fec1, const flat_example* fec2,
+                void* params, size_t kernel_type);
+
+int
+svm_example::compute_kernels(svm_params& params)
+{
+  int alloc = 0;
+  svm_model *model = params.model;
+  size_t n = model->num_support;
+
+  if (krow.size() < n)
   {
-    ex = *fec;
-    free(fec);
+    //computing new kernel values and caching them
+    //if(params->curcache + n > params->maxcache)
+    //trim_cache(params);
+    num_kernel_evals += krow.size();
+    //cerr<<"Kernels ";
+    for (size_t i=krow.size(); i<n; i++)
+    {
+      svm_example *sec = model->support_vec[i];
+      float kv = kernel_function(&ex, &(sec->ex), params.kernel_params, params.kernel_type);
+      krow.push_back(kv);
+      alloc += 1;
+      //cerr<<kv<<" ";
+    }
+    //cerr<<endl;
   }
-  
-  svm_example::~svm_example()
+  else
+    num_cache_evals += n;
+  return alloc;
+}
+
+int
+svm_example::clear_kernels()
+{
+  int rowsize = (int)krow.size();
+  krow.end = krow.begin;
+  krow.resize(0);
+  return -rowsize;
+}
+
+
+static int
+make_hot_sv(svm_params& params, size_t svi)
+{
+  svm_model *model = params.model;
+  size_t n = model->num_support;
+  if (svi >= model->num_support)
+    cerr << "Internal error at " << __FILE__ << ":" << __LINE__ << endl;
+  // rotate params fields
+  svm_example *svi_e = model->support_vec[svi];
+  int alloc = svi_e->compute_kernels(params);
+  float svi_alpha = model->alpha[svi];
+  float svi_delta = model->delta[svi];
+  for (size_t i=svi; i>0; --i)
   {
-    krow.delete_v();
-    // free flatten example contents
-    flat_example *fec = &calloc_or_die<flat_example>();
-    *fec = ex;
-    free_flatten_example(fec); // free contents of flat example and frees fec.
+    model->support_vec[i] = model->support_vec[i-1];
+    model->alpha[i] = model->alpha[i-1];
+    model->delta[i] = model->delta[i-1];
   }
-
-
-  float
-  kernel_function(const flat_example* fec1, const flat_example* fec2, 
-		  void* params, size_t kernel_type);
-
-  int
-  svm_example::compute_kernels(svm_params& params)
+  model->support_vec[0] = svi_e;
+  model->alpha[0] = svi_alpha;
+  model->delta[0] = svi_delta;
+  // rotate cache
+  for (size_t j=0; j<n; j++)
   {
-    int alloc = 0;
-    svm_model *model = params.model;
-    size_t n = model->num_support;
-   
-    if (krow.size() < n)
-      {
-	//computing new kernel values and caching them
-	//if(params->curcache + n > params->maxcache)
-	//trim_cache(params);
-	num_kernel_evals += krow.size();
-	//cerr<<"Kernels ";
-	for (size_t i=krow.size(); i<n; i++)
-	  {	    
-	    svm_example *sec = model->support_vec[i];
-	    float kv = kernel_function(&ex, &(sec->ex), params.kernel_params, params.kernel_type);
-	    krow.push_back(kv);
-	    alloc += 1;
-	    //cerr<<kv<<" ";
-	  }
-	//cerr<<endl;
-      }
+    svm_example *e = model->support_vec[j];
+    size_t rowsize = e->krow.size();
+    if (svi < rowsize)
+    {
+      float kv = e->krow[svi];
+      for (size_t i=svi; i>0; --i)
+        e->krow[i] = e->krow[i-1];
+      e->krow[0] = kv;
+    }
     else
-      num_cache_evals += n;
-    return alloc;
+    {
+      float kv = svi_e->krow[j];
+      e->krow.push_back(0);
+      alloc += 1;
+      for (size_t i=e->krow.size()-1; i>0; --i)
+        e->krow[i] = e->krow[i-1];
+      e->krow[0] = kv;
+    }
   }
+  return alloc;
+}
 
-  int 
-  svm_example::clear_kernels()
+static int
+trim_cache(svm_params& params)
+{
+  int sz = (int)params.maxcache;
+  svm_model *model = params.model;
+  size_t n = model->num_support;
+  int alloc = 0;
+  for (size_t i=0; i<n; i++)
   {
-    int rowsize = (int)krow.size();
-    krow.end = krow.begin;
-    krow.resize(0);
-    return -rowsize;
+    svm_example *e = model->support_vec[i];
+    sz -= (int)e->krow.size();
+    if (sz < 0)
+      alloc += e->clear_kernels();
   }
+  return alloc;
+}
 
-  
-  static int 
-  make_hot_sv(svm_params& params, size_t svi)
-  {
-    svm_model *model = params.model;    
-    size_t n = model->num_support;
-    if (svi >= model->num_support) 
-      cerr << "Internal error at " << __FILE__ << ":" << __LINE__ << endl;
-    // rotate params fields
-    svm_example *svi_e = model->support_vec[svi];
-    int alloc = svi_e->compute_kernels(params);
-    float svi_alpha = model->alpha[svi];
-    float svi_delta = model->delta[svi];
-    for (size_t i=svi; i>0; --i)
-      {
-	model->support_vec[i] = model->support_vec[i-1]; 
-	model->alpha[i] = model->alpha[i-1];
-	model->delta[i] = model->delta[i-1];
+
+int save_load_flat_example(io_buf& model_file, bool read, flat_example*& fec) {
+  size_t brw = 1;
+  if(read) {
+    fec = &calloc_or_die<flat_example>();
+    brw = bin_read_fixed(model_file, (char*) fec, sizeof(flat_example), "");
+
+    if(brw > 0) {
+      if(fec->tag_len > 0) {
+        fec->tag = calloc_or_die<char>(fec->tag_len);
+        brw = bin_read_fixed(model_file, (char*) fec->tag, fec->tag_len*sizeof(char), "");
+        if(!brw) return 2;
       }
-    model->support_vec[0] = svi_e;
-    model->alpha[0] = svi_alpha;
-    model->delta[0] = svi_delta;
-    // rotate cache    
-    for (size_t j=0; j<n; j++)
-      {
-	svm_example *e = model->support_vec[j];
-	size_t rowsize = e->krow.size();
-	if (svi < rowsize)
-	  {
-	    float kv = e->krow[svi];
-	    for (size_t i=svi; i>0; --i)
-	      e->krow[i] = e->krow[i-1];
-	    e->krow[0] = kv;
-	  }
-	else 
-	  {
-	    float kv = svi_e->krow[j];
-	    e->krow.push_back(0);
-	    alloc += 1;
-	    for (size_t i=e->krow.size()-1; i>0; --i)
-	      e->krow[i] = e->krow[i-1];
-	    e->krow[0] = kv;
-	  }
+      if(fec->feature_map_len > 0) {
+        fec->feature_map = calloc_or_die<feature>(fec->feature_map_len);
+        brw = bin_read_fixed(model_file, (char*) fec->feature_map, fec->feature_map_len*sizeof(feature), "");
+        if(!brw) return 3;
       }
-    return alloc;
+    }
+    else return 1;
   }
+  else {
+    brw = bin_write_fixed(model_file, (char*) fec, sizeof(flat_example));
 
-  static int 
-  trim_cache(svm_params& params)
-  {
-    int sz = (int)params.maxcache;
-    svm_model *model = params.model;
-    size_t n = model->num_support;
-    int alloc = 0;
-    for (size_t i=0; i<n; i++)
-      {
-	svm_example *e = model->support_vec[i];
-	sz -= (int)e->krow.size();
-	if (sz < 0)
-	  alloc += e->clear_kernels();
+    if(brw > 0) {
+      if(fec->tag_len > 0) {
+        brw = bin_write_fixed(model_file, (char*) fec->tag, (uint32_t)fec->tag_len*sizeof(char));
+        if(!brw) {
+          cerr<<fec->tag_len<<" "<<fec->tag<<endl;
+          return 2;
+        }
       }
-    return alloc;
+      if(fec->feature_map_len > 0) {
+        brw = bin_write_fixed(model_file, (char*) fec->feature_map, (uint32_t)fec->feature_map_len*sizeof(feature));
+        if(!brw) return 3;
+      }
+    }
+    else return 1;
   }
+  return 0;
+}
 
 
-  int save_load_flat_example(io_buf& model_file, bool read, flat_example*& fec) {
-    size_t brw = 1;
+void save_load_svm_model(svm_params& params, io_buf& model_file, bool read, bool text) {
+  svm_model* model = params.model;
+  //TODO: check about initialization
+
+  //cerr<<"Save load svm "<<read<<" "<<text<<endl;
+  if (model_file.files.size() == 0) return;
+
+  bin_text_read_write_fixed(model_file,(char*)&(model->num_support), sizeof(model->num_support),
+                            "", read, "", 0, text);
+  //cerr<<"Read num support "<<model->num_support<<endl;
+
+  flat_example* fec;
+  if(read)
+    model->support_vec.resize(model->num_support);
+
+  for(uint32_t i = 0; i < model->num_support; i++) {
     if(read) {
-      fec = &calloc_or_die<flat_example>();
-      brw = bin_read_fixed(model_file, (char*) fec, sizeof(flat_example), "");
-
-      if(brw > 0) {
-	if(fec->tag_len > 0) {
-	  fec->tag = calloc_or_die<char>(fec->tag_len);	
-	  brw = bin_read_fixed(model_file, (char*) fec->tag, fec->tag_len*sizeof(char), "");
-	  if(!brw) return 2;
-	}
-	if(fec->feature_map_len > 0) {
-	  fec->feature_map = calloc_or_die<feature>(fec->feature_map_len);
-	  brw = bin_read_fixed(model_file, (char*) fec->feature_map, fec->feature_map_len*sizeof(feature), ""); 	  if(!brw) return 3;
-	}
-      }
-      else return 1;
+      save_load_flat_example(model_file, read, fec);
+      svm_example* tmp= &calloc_or_die<svm_example>();
+      tmp->init_svm_example(fec);
+      model->support_vec.push_back(tmp);
     }
     else {
-      brw = bin_write_fixed(model_file, (char*) fec, sizeof(flat_example));
-
-      if(brw > 0) {
-	if(fec->tag_len > 0) {
-	  brw = bin_write_fixed(model_file, (char*) fec->tag, (uint32_t)fec->tag_len*sizeof(char));
-	  if(!brw) {
-	    cerr<<fec->tag_len<<" "<<fec->tag<<endl;
-	    return 2;
-	  }
-	}
-	if(fec->feature_map_len > 0) {
-	  brw = bin_write_fixed(model_file, (char*) fec->feature_map, (uint32_t)fec->feature_map_len*sizeof(feature));    	  if(!brw) return 3;
-	}
-      }
-      else return 1;
+      fec = &(model->support_vec[i]->ex);
+      save_load_flat_example(model_file, read, fec);
     }
-    return 0;
+  }
+  //cerr<<endl;
+
+  //cerr<<"Read model"<<endl;
+
+  if(read)
+    model->alpha.resize(model->num_support);
+  bin_text_read_write_fixed(model_file, (char*)model->alpha.begin, (uint32_t)model->num_support*sizeof(float),
+                            "", read, "", 0, text);
+  if(read)
+    model->delta.resize(model->num_support);
+  bin_text_read_write_fixed(model_file, (char*)model->delta.begin, (uint32_t)model->num_support*sizeof(float),
+                            "", read, "", 0, text);
+
+  // cerr<<"In save_load\n";
+  // for(int i = 0;i < model->num_support;i++)
+  //   cerr<<model->alpha[i]<<" ";
+  // cerr<<endl;
+}
+
+void save_load(svm_params& params, io_buf& model_file, bool read, bool text) {
+  if(text) {
+    cerr<<"Not supporting readable model for kernel svm currently\n";
+    return;
   }
 
+  save_load_svm_model(params, model_file, read, text);
 
-  void save_load_svm_model(svm_params& params, io_buf& model_file, bool read, bool text) {  
-    svm_model* model = params.model;
-    //TODO: check about initialization
+}
 
-    //cerr<<"Save load svm "<<read<<" "<<text<<endl;
-    if (model_file.files.size() == 0) return;
+float linear_kernel(const flat_example* fec1, const flat_example* fec2) {
 
-    bin_text_read_write_fixed(model_file,(char*)&(model->num_support), sizeof(model->num_support), 
-			      "", read, "", 0, text);
-    //cerr<<"Read num support "<<model->num_support<<endl;
-        
-    flat_example* fec;
-    if(read)
-      model->support_vec.resize(model->num_support);
+  float dotprod = 0;
 
-    for(uint32_t i = 0;i < model->num_support;i++) {
-      if(read) {
-	save_load_flat_example(model_file, read, fec);
-	svm_example* tmp= &calloc_or_die<svm_example>();
-	tmp->init_svm_example(fec);
-	model->support_vec.push_back(tmp);
-      }
-      else {
-	fec = &(model->support_vec[i]->ex);
-	save_load_flat_example(model_file, read, fec);
-      }
-    }
-    //cerr<<endl;
-    
-    //cerr<<"Read model"<<endl;
-    
-    if(read)
-      model->alpha.resize(model->num_support);
-    bin_text_read_write_fixed(model_file, (char*)model->alpha.begin, (uint32_t)model->num_support*sizeof(float),
-			      "", read, "", 0, text);
-    if(read)
-      model->delta.resize(model->num_support);
-    bin_text_read_write_fixed(model_file, (char*)model->delta.begin, (uint32_t)model->num_support*sizeof(float),
-			      "", read, "", 0, text);        
+  feature* ec2f = fec2->feature_map;
+  uint32_t ec2pos = ec2f->weight_index;
+  uint32_t idx1 = 0, idx2 = 0;
 
-    // cerr<<"In save_load\n";
-    // for(int i = 0;i < model->num_support;i++)
-    //   cerr<<model->alpha[i]<<" ";
-    // cerr<<endl;
-  }
+  //cerr<<"Intersection ";
+  int numint = 0;
+  for (feature* f = fec1->feature_map; idx1 < fec1->feature_map_len && idx2 < fec2->feature_map_len ; f++, idx1++) {
+    uint32_t ec1pos = f->weight_index;
+    //cerr<<ec1pos<<" "<<ec2pos<<" "<<idx1<<" "<<idx2<<" "<<f->x<<" "<<ec2f->x<<endl;
+    if(ec1pos < ec2pos) continue;
 
-  void save_load(svm_params& params, io_buf& model_file, bool read, bool text) {  
-    if(text) {
-      cerr<<"Not supporting readable model for kernel svm currently\n";
-      return;
+    while(ec1pos > ec2pos && idx2 < fec2->feature_map_len) {
+      ec2f++;
+      idx2++;
+      if(idx2 < fec2->feature_map_len)
+        ec2pos = ec2f->weight_index;
     }
 
-    save_load_svm_model(params, model_file, read, text);
-    
-  }
-  
-  float linear_kernel(const flat_example* fec1, const flat_example* fec2) {
-
-    float dotprod = 0;
-    
-    feature* ec2f = fec2->feature_map;
-    uint32_t ec2pos = ec2f->weight_index;          
-    uint32_t idx1 = 0, idx2 = 0;
-    
-    //cerr<<"Intersection ";
-    int numint = 0;
-    for (feature* f = fec1->feature_map; idx1 < fec1->feature_map_len && idx2 < fec2->feature_map_len ; f++, idx1++) {      
-      uint32_t ec1pos = f->weight_index;      
+    if(ec1pos == ec2pos) {
       //cerr<<ec1pos<<" "<<ec2pos<<" "<<idx1<<" "<<idx2<<" "<<f->x<<" "<<ec2f->x<<endl;
-      if(ec1pos < ec2pos) continue;
-
-      while(ec1pos > ec2pos && idx2 < fec2->feature_map_len) {
-	ec2f++;
-	idx2++;
-	if(idx2 < fec2->feature_map_len)
-	  ec2pos = ec2f->weight_index;
-      }      
-
-      if(ec1pos == ec2pos) {	
-	//cerr<<ec1pos<<" "<<ec2pos<<" "<<idx1<<" "<<idx2<<" "<<f->x<<" "<<ec2f->x<<endl;
-	numint++;
-	dotprod += f->x*ec2f->x;
-	//cerr<<f->x<<" "<<ec2f->x<<" "<<dotprod<<" ";
-	ec2f++;
-	idx2++;
-	//cerr<<idx2<<" ";
-	if(idx2 < fec2->feature_map_len)
-	  ec2pos = ec2f->weight_index;
-      }
-    }
-    //cerr<<endl;
-    //cerr<<"numint = "<<numint<<" dotprod = "<<dotprod<<endl;
-    return dotprod;
-  }
-
-  float poly_kernel(const flat_example* fec1, const flat_example* fec2, int power) {
-    float dotprod = linear_kernel(fec1, fec2);    
-    //cerr<<"Bandwidth = "<<bandwidth<<endl;
-    //cout<<pow(1 + dotprod, power)<<endl;
-    return pow(1 + dotprod, power);
-  }
-
-  float rbf_kernel(const flat_example* fec1, const flat_example* fec2, float bandwidth) {
-    float dotprod = linear_kernel(fec1, fec2);    
-    //cerr<<"Bandwidth = "<<bandwidth<<endl;
-    return expf(-(fec1->total_sum_feat_sq + fec2->total_sum_feat_sq - 2*dotprod)*bandwidth);
-  }
-
-  float kernel_function(const flat_example* fec1, const flat_example* fec2, void* params, size_t kernel_type) {
-    switch(kernel_type) {
-    case SVM_KER_RBF:
-      return rbf_kernel(fec1, fec2, *((float*)params));
-    case SVM_KER_POLY:
-      return poly_kernel(fec1, fec2, *((int*)params));
-    case SVM_KER_LIN:
-      return linear_kernel(fec1, fec2);
-    }
-    return 0;
-  }
-
-  float dense_dot(float* v1, v_array<float> v2, size_t n) {
-    float dot_prod = 0.;
-    for(size_t i = 0;i < n;i++)
-      dot_prod += v1[i]*v2[i];
-    return dot_prod;
-  }
-
-
-  void predict (svm_params& params, svm_example** ec_arr, float* scores, size_t n) { 
-    svm_model* model = params.model;
-    for(size_t i = 0;i < n; i++) {
-      ec_arr[i]->compute_kernels(params);
-      scores[i] = dense_dot(ec_arr[i]->krow.begin, model->alpha, model->num_support)/params.lambda;
+      numint++;
+      dotprod += f->x*ec2f->x;
+      //cerr<<f->x<<" "<<ec2f->x<<" "<<dotprod<<" ";
+      ec2f++;
+      idx2++;
+      //cerr<<idx2<<" ";
+      if(idx2 < fec2->feature_map_len)
+        ec2pos = ec2f->weight_index;
     }
   }
-  
-  void predict(svm_params& params, base_learner &, example& ec) {
-    flat_example* fec = flatten_sort_example(*(params.all),&ec);    
-    if(fec) {
-      svm_example* sec = &calloc_or_die<svm_example>(); 
-      sec->init_svm_example(fec);
-      float score;
-      predict(params, &sec, &score, 1);
-      ec.pred.scalar = score;
-      sec->~svm_example();
-      free(sec);
-    }
+  //cerr<<endl;
+  //cerr<<"numint = "<<numint<<" dotprod = "<<dotprod<<endl;
+  return dotprod;
+}
+
+float poly_kernel(const flat_example* fec1, const flat_example* fec2, int power) {
+  float dotprod = linear_kernel(fec1, fec2);
+  //cerr<<"Bandwidth = "<<bandwidth<<endl;
+  //cout<<pow(1 + dotprod, power)<<endl;
+  return pow(1 + dotprod, power);
+}
+
+float rbf_kernel(const flat_example* fec1, const flat_example* fec2, float bandwidth) {
+  float dotprod = linear_kernel(fec1, fec2);
+  //cerr<<"Bandwidth = "<<bandwidth<<endl;
+  return expf(-(fec1->total_sum_feat_sq + fec2->total_sum_feat_sq - 2*dotprod)*bandwidth);
+}
+
+float kernel_function(const flat_example* fec1, const flat_example* fec2, void* params, size_t kernel_type) {
+  switch(kernel_type) {
+  case SVM_KER_RBF:
+    return rbf_kernel(fec1, fec2, *((float*)params));
+  case SVM_KER_POLY:
+    return poly_kernel(fec1, fec2, *((int*)params));
+  case SVM_KER_LIN:
+    return linear_kernel(fec1, fec2);
   }
+  return 0;
+}
 
-      
-  size_t suboptimality(svm_model* model, double* subopt) {
+float dense_dot(float* v1, v_array<float> v2, size_t n) {
+  float dot_prod = 0.;
+  for(size_t i = 0; i < n; i++)
+    dot_prod += v1[i]*v2[i];
+  return dot_prod;
+}
 
-    size_t max_pos = 0;
-    //cerr<<"Subopt ";
-    double max_val = 0;
-    for(size_t i = 0;i < model->num_support;i++) {
-      label_data& ld = model->support_vec[i]->ex.l.simple;
-      double tmp = model->alpha[i]*ld.label;                  
-      
-      if((tmp < ld.weight && model->delta[i] < 0) || (tmp > 0 && model->delta[i] > 0)) 
-	subopt[i] = fabs(model->delta[i]);
-      else
-	subopt[i] = 0;
 
-	if(subopt[i] > max_val) {
-	  max_val = subopt[i];
-	  max_pos = i;
-	}
-	//cerr<<subopt[i]<<" ";
-      }    
-    //cerr<<endl;
-    return max_pos;
-  }  
-
-  int remove(svm_params& params, size_t svi) {
-    svm_model* model = params.model;
-    if (svi >= model->num_support) 
-      cerr << "Internal error at " << __FILE__ << ":" << __LINE__ << endl;
-    // shift params fields
-    svm_example* svi_e = model->support_vec[svi];
-    for (size_t i=svi; i<model->num_support-1; ++i)
-      {
-	model->support_vec[i] = model->support_vec[i+1];
-	model->alpha[i] = model->alpha[i+1];
-	model->delta[i] = model->delta[i+1];
-      }
-    svi_e->~svm_example();
-    free(svi_e);
-    model->support_vec.pop();
-    model->alpha.pop();
-    model->delta.pop();
-    model->num_support--;
-    // shift cache
-    int alloc = 0;
-    for (size_t j=0; j<model->num_support; j++)
-      {
-	svm_example *e = model->support_vec[j];
-	size_t rowsize = e->krow.size();
-	if (svi < rowsize)
-	  {
-	    for (size_t i=svi; i<rowsize-1; i++)
-	      e->krow[i] = e->krow[i+1];
-	    e->krow.pop();
-	    alloc -= 1;
-	  }
-      }
-    return alloc;
+void predict (svm_params& params, svm_example** ec_arr, float* scores, size_t n) {
+  svm_model* model = params.model;
+  for(size_t i = 0; i < n; i++) {
+    ec_arr[i]->compute_kernels(params);
+    scores[i] = dense_dot(ec_arr[i]->krow.begin, model->alpha, model->num_support)/params.lambda;
   }
+}
 
-  int add(svm_params& params, svm_example* fec) {
-    svm_model* model = params.model;
-    model->num_support++;
-    model->support_vec.push_back(fec);
-    model->alpha.push_back(0.);
-    model->delta.push_back(0.);
-    //cout<<"After adding "<<model->num_support<<endl;
-    return (int)(model->support_vec.size()-1);
+void predict(svm_params& params, base_learner &, example& ec) {
+  flat_example* fec = flatten_sort_example(*(params.all),&ec);
+  if(fec) {
+    svm_example* sec = &calloc_or_die<svm_example>();
+    sec->init_svm_example(fec);
+    float score;
+    predict(params, &sec, &score, 1);
+    ec.pred.scalar = score;
+    sec->~svm_example();
+    free(sec);
   }
-
-  bool update(svm_params& params, size_t pos) {
-
-    //cerr<<"Update\n";
-    svm_model* model = params.model;
-    bool overshoot = false;
-    //cerr<<"Updating model "<<pos<<" "<<model->num_support<<" ";
-    //cerr<<model->support_vec[pos]->example_counter<<endl;
-    svm_example* fec = model->support_vec[pos];
-    label_data& ld = fec->ex.l.simple;
-    fec->compute_kernels(params);
-    float *inprods = fec->krow.begin;
-    float alphaKi = dense_dot(inprods, model->alpha, model->num_support);
-    model->delta[pos] = alphaKi*ld.label/params.lambda - 1;
-    float alpha_old = model->alpha[pos];
-    alphaKi -= model->alpha[pos]*inprods[pos];
-    model->alpha[pos] = 0.;
-    
-    float proj = alphaKi*ld.label;
-    float ai = (params.lambda - proj)/inprods[pos];
-    //cerr<<model->num_support<<" "<<pos<<" "<<proj<<" "<<alphaKi<<" "<<alpha_old<<" "<<ld->label<<" "<<model->delta[pos]<<" ";
-
-    if(ai > ld.weight)				
-      ai = ld.weight;
-    else if(ai < 0)
-      ai = 0;
-
-    ai *= ld.label;
-    float diff = ai - alpha_old;
-
-    if(fabs(diff) > 1.0e-06) 
-      overshoot = true;
-    
-    if(fabs(diff) > 1.) {
-      //cerr<<"Here\n";
-      diff = (float) (diff > 0) - (diff < 0);
-      ai = alpha_old + diff;
-    }
-    
-    for(size_t i = 0;i < model->num_support; i++) {
-      label_data& ldi = model->support_vec[i]->ex.l.simple;
-      model->delta[i] += diff*inprods[i]*ldi.label/params.lambda;
-    }
-    
-    if(fabs(ai) <= 1.0e-10)
-      remove(params, pos);
-    else 
-      model->alpha[pos] = ai;
-
-    return overshoot;
-  }
-
-  void copy_char(char& c1, const char& c2) {
-    if (c2 != '\0')
-      c1 = c2;
-  }
-
-  void add_size_t(size_t& t1, const size_t& t2) {
-    t1 += t2;
-  }
-
-  void add_double(double& t1, const double& t2) {
-    t1 += t2;
-  }
-
-  void sync_queries(vw& all, svm_params& params, bool* train_pool) {
-    io_buf* b = new io_buf();
-    
-    char* queries;
-    flat_example* fec;
-
-    for(size_t i = 0;i < params.pool_pos;i++) {
-      if(!train_pool[i])
-	continue;
-      
-      fec = &(params.pool[i]->ex);
-      save_load_flat_example(*b, false, fec);
-      delete params.pool[i];
-      
-    }
-
-    size_t* sizes = calloc_or_die<size_t>(all.total);
-    sizes[all.node] = b->space.end - b->space.begin;
-    //cerr<<"Sizes = "<<sizes[all.node]<<" ";
-    all_reduce<size_t, add_size_t>(sizes, all.total, all.span_server, all.unique_id, all.total, all.node, all.socks);
-
-    size_t prev_sum = 0, total_sum = 0;
-    for(size_t i = 0;i < all.total;i++) {
-      if(i <= (all.node - 1))
-	prev_sum += sizes[i];
-      total_sum += sizes[i];
-    }
-    
-    //cerr<<total_sum<<" "<<prev_sum<<endl;
-    if(total_sum > 0) {
-      queries = calloc_or_die<char>(total_sum);
-      memcpy(queries + prev_sum, b->space.begin, b->space.end - b->space.begin);
-      b->space.delete_v();
-      all_reduce<char, copy_char>(queries, total_sum, all.span_server, all.unique_id, all.total, all.node, all.socks);
-
-      b->space.begin = queries;
-      b->space.end = b->space.begin;
-      b->endloaded = &queries[total_sum*sizeof(char)];
-
-      size_t num_read = 0;
-      params.pool_pos = 0;
-      
-      for(size_t i = 0;i < params.pool_size; i++) {	
-	if(!save_load_flat_example(*b, true, fec)) {
-	  params.pool[i] = &calloc_or_die<svm_example>();
-	  params.pool[i]->init_svm_example(fec);
-	  train_pool[i] = true;
-	  params.pool_pos++;
-	  // for(int j = 0;j < fec->feature_map_len;j++)
-	  //   cerr<<fec->feature_map[j].weight_index<<":"<<fec->feature_map[j].x<<" ";
-	  // cerr<<endl;
-	  // params.pool[i]->in_use = true;
-	  // params.current_t += ((label_data*) params.pool[i]->ld)->weight;
-	  // params.pool[i]->example_t = params.current_t;
-	}
-	else
-	  break;
-	
-	num_read += b->space.end - b->space.begin;
-	if(num_read == prev_sum)
-	  params.local_begin = i+1;
-	if(num_read == prev_sum + sizes[all.node])
-	  params.local_end = i;	
-      }
-    }
-    if(fec)
-      free(fec);
-    free(sizes);
-    delete b;
-
-  }
+}
 
 
-  void train(svm_params& params) {
-    
-    //cerr<<"In train "<<params.all->training<<endl;
-    
-    bool* train_pool = calloc_or_die<bool>(params.pool_size);
-    for(size_t i = 0;i < params.pool_size;i++)
-      train_pool[i] = false;
-    
-    float* scores = calloc_or_die<float>(params.pool_pos);
-    predict(params, params.pool, scores, params.pool_pos);
-    //cout<<scores[0]<<endl;
-    
-      
-    if(params.active) {           
-      if(params.active_pool_greedy) { 
-	multimap<double, size_t> scoremap;
-	for(size_t i = 0;i < params.pool_pos; i++)
-	  scoremap.insert(pair<const double, const size_t>(fabs(scores[i]),i));
+size_t suboptimality(svm_model* model, double* subopt) {
 
-	multimap<double, size_t>::iterator iter = scoremap.begin();
-	//cerr<<params.pool_size<<" "<<"Scoremap: ";
-	//for(;iter != scoremap.end();iter++)
-	//cerr<<iter->first<<" "<<iter->second<<" "<<((label_data*)params.pool[iter->second]->ld)->label<<"\t";
-	//cerr<<endl;
-	iter = scoremap.begin();
-	
-	for(size_t train_size = 1;iter != scoremap.end() && train_size <= params.subsample;train_size++) {
-	  //cerr<<train_size<<" "<<iter->second<<" "<<iter->first<<endl;
-	  train_pool[iter->second] = 1;
-	  iter++;	  
-	}
-      }
-      else {
+  size_t max_pos = 0;
+  //cerr<<"Subopt ";
+  double max_val = 0;
+  for(size_t i = 0; i < model->num_support; i++) {
+    label_data& ld = model->support_vec[i]->ex.l.simple;
+    double tmp = model->alpha[i]*ld.label;
 
-	for(size_t i = 0;i < params.pool_pos;i++) {
-	  float queryp = 2.0f/(1.0f + expf((float)(params.active_c*fabs(scores[i]))*(float)pow(params.pool[i]->ex.example_counter,0.5f)));
-	  if(rand() < queryp) {
-	    svm_example* fec = params.pool[i];
-	    fec->ex.l.simple.weight *= 1/queryp;
-	    train_pool[i] = 1;
-	  }
-	}
-      }
-      //free(scores);
-    }
-
-    
-    if(params.para_active) {
-      for(size_t i = 0;i < params.pool_pos;i++)
-	if(!train_pool[i])
-	  delete params.pool[i];
-      sync_queries(*(params.all), params, train_pool);
-    }
-
-    if(params.all->training) {
-      
-      svm_model* model = params.model;
-      
-      for(size_t i = 0;i < params.pool_pos;i++) {
-	//cerr<<"process: "<<i<<" "<<train_pool[i]<<endl;;
-	int model_pos = -1;
-	if(params.active) {
-	  if(train_pool[i]) {
-	    //cerr<<"i = "<<i<<"train_pool[i] = "<<train_pool[i]<<" "<<params.pool[i]->example_counter<<endl;
-	    model_pos = add(params, params.pool[i]);
-	  }
-	}
-	else
-	  model_pos = add(params, params.pool[i]);	
-	
-	//cerr<<"Added: "<<model_pos<<" "<<model->support_vec[model_pos]->example_counter<<endl;
-	//cout<<"After adding in train "<<model->num_support<<endl;
-	
-	if(model_pos >= 0) {
-	  bool overshoot = update(params, model_pos);
-	  //cerr<<model_pos<<":alpha = "<<model->alpha[model_pos]<<endl;
-
-	  double* subopt = calloc_or_die<double>(model->num_support);
-	  for(size_t j = 0;j < params.reprocess;j++) {
-	    if(model->num_support == 0) break;
-	    //cerr<<"reprocess: ";
-	    int randi = 1;//rand()%2;
-	    if(randi) {
-	      size_t max_pos = suboptimality(model, subopt);
-	      if(subopt[max_pos] > 0) {
-		if(!overshoot && max_pos == (size_t)model_pos && max_pos > 0 && j == 0) 
-		  cerr<<"Shouldn't reprocess right after process!!!\n";
-		//cerr<<max_pos<<" "<<subopt[max_pos]<<endl;
-		// cerr<<params.model->support_vec[0]->example_counter<<endl;
-		if(max_pos*model->num_support <= params.maxcache)
-		  make_hot_sv(params, max_pos);
-		update(params, max_pos);
-	      }
-	    }
-	    else {
-	      size_t rand_pos = rand()%model->num_support;
-	      update(params, rand_pos);
-	    }
-	  }	  
-	  //cerr<<endl;
-	  // cerr<<params.model->support_vec[0]->example_counter<<endl;
-	  free(subopt);
-	}
-      }
-
-    }
+    if((tmp < ld.weight && model->delta[i] < 0) || (tmp > 0 && model->delta[i] > 0))
+      subopt[i] = fabs(model->delta[i]);
     else
-      for(size_t i = 0;i < params.pool_pos;i++)
-	delete params.pool[i];
-	
-    // cerr<<params.model->support_vec[0]->example_counter<<endl;
-    // for(int i = 0;i < params.pool_size;i++)
-    //   cerr<<scores[i]<<" ";
-    // cerr<<endl;
-    free(scores);
-    //cerr<<params.model->support_vec[0]->example_counter<<endl;
-    free(train_pool);
-    //cerr<<params.model->support_vec[0]->example_counter<<endl;
-  }
+      subopt[i] = 0;
 
-  void learn(svm_params& params, base_learner&, example& ec) {
-    flat_example* fec = flatten_sort_example(*(params.all),&ec);
-    // for(int i = 0;i < fec->feature_map_len;i++)
-    //   cout<<i<<":"<<fec->feature_map[i].x<<" "<<fec->feature_map[i].weight_index<<" ";
-    // cout<<endl;
-    if(fec) {
-      svm_example* sec = &calloc_or_die<svm_example>();
-      sec->init_svm_example(fec);
-      float score = 0;
-      predict(params, &sec, &score, 1);
-      ec.pred.scalar = score;
-      ec.loss = max(0.f, 1.f - score*ec.l.simple.label);
-      params.loss_sum += ec.loss;
-      if(params.all->training && ec.example_counter % 100 == 0)
-	trim_cache(params);
-      if(params.all->training && ec.example_counter % 1000 == 0 && ec.example_counter >= 2) {
-	cerr<<"Number of support vectors = "<<params.model->num_support<<endl;
-	cerr<<"Number of kernel evaluations = "<<num_kernel_evals<<" "<<"Number of cache queries = "<<num_cache_evals<<" loss sum = "<<params.loss_sum<<" "<<params.model->alpha[params.model->num_support-1]<<" "<<params.model->alpha[params.model->num_support-2]<<endl;
-      }
-      params.pool[params.pool_pos] = sec;
-      params.pool_pos++;
-      
-      if(params.pool_pos == params.pool_size) {
-	train(params); 
-	params.pool_pos = 0;
-      }
+    if(subopt[i] > max_val) {
+      max_val = subopt[i];
+      max_pos = i;
     }
+    //cerr<<subopt[i]<<" ";
   }
+  //cerr<<endl;
+  return max_pos;
+}
 
-  void free_svm_model(svm_model* model)
+int remove(svm_params& params, size_t svi) {
+  svm_model* model = params.model;
+  if (svi >= model->num_support)
+    cerr << "Internal error at " << __FILE__ << ":" << __LINE__ << endl;
+  // shift params fields
+  svm_example* svi_e = model->support_vec[svi];
+  for (size_t i=svi; i<model->num_support-1; ++i)
   {
-    for(size_t i = 0;i < model->num_support; i++) {
-      model->support_vec[i]->~svm_example();
-      free(model->support_vec[i]);
-      model->support_vec[i] = 0;
+    model->support_vec[i] = model->support_vec[i+1];
+    model->alpha[i] = model->alpha[i+1];
+    model->delta[i] = model->delta[i+1];
+  }
+  svi_e->~svm_example();
+  free(svi_e);
+  model->support_vec.pop();
+  model->alpha.pop();
+  model->delta.pop();
+  model->num_support--;
+  // shift cache
+  int alloc = 0;
+  for (size_t j=0; j<model->num_support; j++)
+  {
+    svm_example *e = model->support_vec[j];
+    size_t rowsize = e->krow.size();
+    if (svi < rowsize)
+    {
+      for (size_t i=svi; i<rowsize-1; i++)
+        e->krow[i] = e->krow[i+1];
+      e->krow.pop();
+      alloc -= 1;
+    }
+  }
+  return alloc;
+}
+
+int add(svm_params& params, svm_example* fec) {
+  svm_model* model = params.model;
+  model->num_support++;
+  model->support_vec.push_back(fec);
+  model->alpha.push_back(0.);
+  model->delta.push_back(0.);
+  //cout<<"After adding "<<model->num_support<<endl;
+  return (int)(model->support_vec.size()-1);
+}
+
+bool update(svm_params& params, size_t pos) {
+
+  //cerr<<"Update\n";
+  svm_model* model = params.model;
+  bool overshoot = false;
+  //cerr<<"Updating model "<<pos<<" "<<model->num_support<<" ";
+  //cerr<<model->support_vec[pos]->example_counter<<endl;
+  svm_example* fec = model->support_vec[pos];
+  label_data& ld = fec->ex.l.simple;
+  fec->compute_kernels(params);
+  float *inprods = fec->krow.begin;
+  float alphaKi = dense_dot(inprods, model->alpha, model->num_support);
+  model->delta[pos] = alphaKi*ld.label/params.lambda - 1;
+  float alpha_old = model->alpha[pos];
+  alphaKi -= model->alpha[pos]*inprods[pos];
+  model->alpha[pos] = 0.;
+
+  float proj = alphaKi*ld.label;
+  float ai = (params.lambda - proj)/inprods[pos];
+  //cerr<<model->num_support<<" "<<pos<<" "<<proj<<" "<<alphaKi<<" "<<alpha_old<<" "<<ld->label<<" "<<model->delta[pos]<<" ";
+
+  if(ai > ld.weight)
+    ai = ld.weight;
+  else if(ai < 0)
+    ai = 0;
+
+  ai *= ld.label;
+  float diff = ai - alpha_old;
+
+  if(fabs(diff) > 1.0e-06)
+    overshoot = true;
+
+  if(fabs(diff) > 1.) {
+    //cerr<<"Here\n";
+    diff = (float) (diff > 0) - (diff < 0);
+    ai = alpha_old + diff;
+  }
+
+  for(size_t i = 0; i < model->num_support; i++) {
+    label_data& ldi = model->support_vec[i]->ex.l.simple;
+    model->delta[i] += diff*inprods[i]*ldi.label/params.lambda;
+  }
+
+  if(fabs(ai) <= 1.0e-10)
+    remove(params, pos);
+  else
+    model->alpha[pos] = ai;
+
+  return overshoot;
+}
+
+void copy_char(char& c1, const char& c2) {
+  if (c2 != '\0')
+    c1 = c2;
+}
+
+void add_size_t(size_t& t1, const size_t& t2) {
+  t1 += t2;
+}
+
+void add_double(double& t1, const double& t2) {
+  t1 += t2;
+}
+
+void sync_queries(vw& all, svm_params& params, bool* train_pool) {
+  io_buf* b = new io_buf();
+
+  char* queries;
+  flat_example* fec;
+
+  for(size_t i = 0; i < params.pool_pos; i++) {
+    if(!train_pool[i])
+      continue;
+
+    fec = &(params.pool[i]->ex);
+    save_load_flat_example(*b, false, fec);
+    delete params.pool[i];
+
+  }
+
+  size_t* sizes = calloc_or_die<size_t>(all.total);
+  sizes[all.node] = b->space.end - b->space.begin;
+  //cerr<<"Sizes = "<<sizes[all.node]<<" ";
+  all_reduce<size_t, add_size_t>(sizes, all.total, all.span_server, all.unique_id, all.total, all.node, all.socks);
+
+  size_t prev_sum = 0, total_sum = 0;
+  for(size_t i = 0; i < all.total; i++) {
+    if(i <= (all.node - 1))
+      prev_sum += sizes[i];
+    total_sum += sizes[i];
+  }
+
+  //cerr<<total_sum<<" "<<prev_sum<<endl;
+  if(total_sum > 0) {
+    queries = calloc_or_die<char>(total_sum);
+    memcpy(queries + prev_sum, b->space.begin, b->space.end - b->space.begin);
+    b->space.delete_v();
+    all_reduce<char, copy_char>(queries, total_sum, all.span_server, all.unique_id, all.total, all.node, all.socks);
+
+    b->space.begin = queries;
+    b->space.end = b->space.begin;
+    b->endloaded = &queries[total_sum*sizeof(char)];
+
+    size_t num_read = 0;
+    params.pool_pos = 0;
+
+    for(size_t i = 0; i < params.pool_size; i++) {
+      if(!save_load_flat_example(*b, true, fec)) {
+        params.pool[i] = &calloc_or_die<svm_example>();
+        params.pool[i]->init_svm_example(fec);
+        train_pool[i] = true;
+        params.pool_pos++;
+        // for(int j = 0;j < fec->feature_map_len;j++)
+        //   cerr<<fec->feature_map[j].weight_index<<":"<<fec->feature_map[j].x<<" ";
+        // cerr<<endl;
+        // params.pool[i]->in_use = true;
+        // params.current_t += ((label_data*) params.pool[i]->ld)->weight;
+        // params.pool[i]->example_t = params.current_t;
+      }
+      else
+        break;
+
+      num_read += b->space.end - b->space.begin;
+      if(num_read == prev_sum)
+        params.local_begin = i+1;
+      if(num_read == prev_sum + sizes[all.node])
+        params.local_end = i;
+    }
+  }
+  if(fec)
+    free(fec);
+  free(sizes);
+  delete b;
+
+}
+
+
+void train(svm_params& params) {
+
+  //cerr<<"In train "<<params.all->training<<endl;
+
+  bool* train_pool = calloc_or_die<bool>(params.pool_size);
+  for(size_t i = 0; i < params.pool_size; i++)
+    train_pool[i] = false;
+
+  float* scores = calloc_or_die<float>(params.pool_pos);
+  predict(params, params.pool, scores, params.pool_pos);
+  //cout<<scores[0]<<endl;
+
+
+  if(params.active) {
+    if(params.active_pool_greedy) {
+      multimap<double, size_t> scoremap;
+      for(size_t i = 0; i < params.pool_pos; i++)
+        scoremap.insert(pair<const double, const size_t>(fabs(scores[i]),i));
+
+      multimap<double, size_t>::iterator iter = scoremap.begin();
+      //cerr<<params.pool_size<<" "<<"Scoremap: ";
+      //for(;iter != scoremap.end();iter++)
+      //cerr<<iter->first<<" "<<iter->second<<" "<<((label_data*)params.pool[iter->second]->ld)->label<<"\t";
+      //cerr<<endl;
+      iter = scoremap.begin();
+
+      for(size_t train_size = 1; iter != scoremap.end() && train_size <= params.subsample; train_size++) {
+        //cerr<<train_size<<" "<<iter->second<<" "<<iter->first<<endl;
+        train_pool[iter->second] = 1;
+        iter++;
+      }
+    }
+    else {
+
+      for(size_t i = 0; i < params.pool_pos; i++) {
+        float queryp = 2.0f/(1.0f + expf((float)(params.active_c*fabs(scores[i]))*(float)pow(params.pool[i]->ex.example_counter,0.5f)));
+        if(rand() < queryp) {
+          svm_example* fec = params.pool[i];
+          fec->ex.l.simple.weight *= 1/queryp;
+          train_pool[i] = 1;
+        }
+      }
+    }
+    //free(scores);
+  }
+
+
+  if(params.para_active) {
+    for(size_t i = 0; i < params.pool_pos; i++)
+      if(!train_pool[i])
+        delete params.pool[i];
+    sync_queries(*(params.all), params, train_pool);
+  }
+
+  if(params.all->training) {
+
+    svm_model* model = params.model;
+
+    for(size_t i = 0; i < params.pool_pos; i++) {
+      //cerr<<"process: "<<i<<" "<<train_pool[i]<<endl;;
+      int model_pos = -1;
+      if(params.active) {
+        if(train_pool[i]) {
+          //cerr<<"i = "<<i<<"train_pool[i] = "<<train_pool[i]<<" "<<params.pool[i]->example_counter<<endl;
+          model_pos = add(params, params.pool[i]);
+        }
+      }
+      else
+        model_pos = add(params, params.pool[i]);
+
+      //cerr<<"Added: "<<model_pos<<" "<<model->support_vec[model_pos]->example_counter<<endl;
+      //cout<<"After adding in train "<<model->num_support<<endl;
+
+      if(model_pos >= 0) {
+        bool overshoot = update(params, model_pos);
+        //cerr<<model_pos<<":alpha = "<<model->alpha[model_pos]<<endl;
+
+        double* subopt = calloc_or_die<double>(model->num_support);
+        for(size_t j = 0; j < params.reprocess; j++) {
+          if(model->num_support == 0) break;
+          //cerr<<"reprocess: ";
+          int randi = 1;//rand()%2;
+          if(randi) {
+            size_t max_pos = suboptimality(model, subopt);
+            if(subopt[max_pos] > 0) {
+              if(!overshoot && max_pos == (size_t)model_pos && max_pos > 0 && j == 0)
+                cerr<<"Shouldn't reprocess right after process!!!\n";
+              //cerr<<max_pos<<" "<<subopt[max_pos]<<endl;
+              // cerr<<params.model->support_vec[0]->example_counter<<endl;
+              if(max_pos*model->num_support <= params.maxcache)
+                make_hot_sv(params, max_pos);
+              update(params, max_pos);
+            }
+          }
+          else {
+            size_t rand_pos = rand()%model->num_support;
+            update(params, rand_pos);
+          }
+        }
+        //cerr<<endl;
+        // cerr<<params.model->support_vec[0]->example_counter<<endl;
+        free(subopt);
+      }
     }
 
-    model->support_vec.delete_v();
-    model->alpha.delete_v();
-    model->delta.delete_v();
-    free(model);
+  }
+  else
+    for(size_t i = 0; i < params.pool_pos; i++)
+      delete params.pool[i];
+
+  // cerr<<params.model->support_vec[0]->example_counter<<endl;
+  // for(int i = 0;i < params.pool_size;i++)
+  //   cerr<<scores[i]<<" ";
+  // cerr<<endl;
+  free(scores);
+  //cerr<<params.model->support_vec[0]->example_counter<<endl;
+  free(train_pool);
+  //cerr<<params.model->support_vec[0]->example_counter<<endl;
+}
+
+void learn(svm_params& params, base_learner&, example& ec) {
+  flat_example* fec = flatten_sort_example(*(params.all),&ec);
+  // for(int i = 0;i < fec->feature_map_len;i++)
+  //   cout<<i<<":"<<fec->feature_map[i].x<<" "<<fec->feature_map[i].weight_index<<" ";
+  // cout<<endl;
+  if(fec) {
+    svm_example* sec = &calloc_or_die<svm_example>();
+    sec->init_svm_example(fec);
+    float score = 0;
+    predict(params, &sec, &score, 1);
+    ec.pred.scalar = score;
+    ec.loss = max(0.f, 1.f - score*ec.l.simple.label);
+    params.loss_sum += ec.loss;
+    if(params.all->training && ec.example_counter % 100 == 0)
+      trim_cache(params);
+    if(params.all->training && ec.example_counter % 1000 == 0 && ec.example_counter >= 2) {
+      cerr<<"Number of support vectors = "<<params.model->num_support<<endl;
+      cerr<<"Number of kernel evaluations = "<<num_kernel_evals<<" "<<"Number of cache queries = "<<num_cache_evals<<" loss sum = "<<params.loss_sum<<" "<<params.model->alpha[params.model->num_support-1]<<" "<<params.model->alpha[params.model->num_support-2]<<endl;
+    }
+    params.pool[params.pool_pos] = sec;
+    params.pool_pos++;
+
+    if(params.pool_pos == params.pool_size) {
+      train(params);
+      params.pool_pos = 0;
+    }
+  }
+}
+
+void free_svm_model(svm_model* model)
+{
+  for(size_t i = 0; i < model->num_support; i++) {
+    model->support_vec[i]->~svm_example();
+    free(model->support_vec[i]);
+    model->support_vec[i] = 0;
   }
 
-  void finish(svm_params& params) {
-    free(params.pool);
+  model->support_vec.delete_v();
+  model->alpha.delete_v();
+  model->delta.delete_v();
+  free(model);
+}
 
-    cerr<<"Num support = "<<params.model->num_support<<endl;
-    cerr<<"Number of kernel evaluations = "<<num_kernel_evals<<" "<<"Number of cache queries = "<<num_cache_evals<<endl;
-    cerr<<"Total loss = "<<params.loss_sum<<endl;
+void finish(svm_params& params) {
+  free(params.pool);
 
-    free_svm_model(params.model);
-    cerr<<"Done freeing model\n";
-    if(params.kernel_params) free(params.kernel_params);
-    cerr<<"Done freeing kernel params\n";
-    cerr<<"Done with finish \n";
-  }
+  cerr<<"Num support = "<<params.model->num_support<<endl;
+  cerr<<"Number of kernel evaluations = "<<num_kernel_evals<<" "<<"Number of cache queries = "<<num_cache_evals<<endl;
+  cerr<<"Total loss = "<<params.loss_sum<<endl;
+
+  free_svm_model(params.model);
+  cerr<<"Done freeing model\n";
+  if(params.kernel_params) free(params.kernel_params);
+  cerr<<"Done freeing kernel params\n";
+  cerr<<"Done with finish \n";
+}
 
 LEARNER::base_learner* kernel_svm_setup(vw &all) {
   if (missing_option(all, true, "ksvm", "kernel svm")) return nullptr;
   new_options(all, "KSVM options")
-    ("reprocess", po::value<size_t>(), "number of reprocess steps for LASVM")
-    //      ("active", "do active learning")
-    //("active_c", po::value<double>(), "parameter for query prob")
-    ("pool_greedy", "use greedy selection on mini pools")      
-    ("para_active", "do parallel active learning")
-    ("pool_size", po::value<size_t>(), "size of pools for active learning")
-    ("subsample", po::value<size_t>(), "number of items to subsample from the pool")
-    ("kernel", po::value<string>(), "type of kernel (rbf or linear (default))")
-    ("bandwidth", po::value<float>(), "bandwidth of rbf kernel")
-    ("degree", po::value<int>(), "degree of poly kernel")
-    ("lambda", po::value<double>(), "saving regularization for test time");
+  ("reprocess", po::value<size_t>(), "number of reprocess steps for LASVM")
+  //      ("active", "do active learning")
+  //("active_c", po::value<double>(), "parameter for query prob")
+  ("pool_greedy", "use greedy selection on mini pools")
+  ("para_active", "do parallel active learning")
+  ("pool_size", po::value<size_t>(), "size of pools for active learning")
+  ("subsample", po::value<size_t>(), "number of items to subsample from the pool")
+  ("kernel", po::value<string>(), "type of kernel (rbf or linear (default))")
+  ("bandwidth", po::value<float>(), "bandwidth of rbf kernel")
+  ("degree", po::value<int>(), "degree of poly kernel")
+  ("lambda", po::value<double>(), "saving regularization for test time");
   add_options(all);
-  
+
   po::variables_map& vm = all.vm;
   string loss_function = "hinge";
   float loss_parameter = 0.0;
   delete all.loss;
   all.loss = getLossFunction(all, loss_function, (float)loss_parameter);
-  
+
   svm_params& params = calloc_or_die<svm_params>();
   params.model = &calloc_or_die<svm_model>();
   params.model->num_support = 0;
@@ -810,12 +812,12 @@ LEARNER::base_learner* kernel_svm_setup(vw &all) {
   params.maxcache = 1024*1024*1024;
   params.loss_sum = 0.;
   params.all = &all;
-  
+
   if(vm.count("reprocess"))
     params.reprocess = vm["reprocess"].as<std::size_t>();
-  else 
+  else
     params.reprocess = 1;
-  
+
   if(vm.count("active"))
     params.active = true;
   if(params.active) {
@@ -828,44 +830,44 @@ LEARNER::base_learner* kernel_svm_setup(vw &all) {
     /*if(vm.count("para_active"))
       params.para_active = 1;*/
   }
-  
-  if(vm.count("pool_size")) 
+
+  if(vm.count("pool_size"))
     params.pool_size = vm["pool_size"].as<std::size_t>();
   else
     params.pool_size = 1;
-  
+
   params.pool = calloc_or_die<svm_example*>(params.pool_size);
   params.pool_pos = 0;
-  
+
   if(vm.count("subsample"))
     params.subsample = vm["subsample"].as<std::size_t>();
   else if(params.para_active)
     params.subsample = (size_t)ceil(params.pool_size / all.total);
   else
     params.subsample = 1;
-  
+
   params.lambda = all.l2_lambda;
-  
+
   *all.file_options <<" --lambda "<< params.lambda;
-  
+
   cerr<<"Lambda = "<<params.lambda<<endl;
-  
+
   std::string kernel_type;
-  
-  if(vm.count("kernel")) 
+
+  if(vm.count("kernel"))
     kernel_type = vm["kernel"].as<std::string>();
   else
     kernel_type = string("linear");
-  
+
   *all.file_options <<" --kernel "<< kernel_type;
-  
+
   cerr<<"Kernel = "<<kernel_type<<endl;
-  
+
   if(kernel_type.compare("rbf") == 0) {
     params.kernel_type = SVM_KER_RBF;
     float bandwidth = 1.;
     if(vm.count("bandwidth")) {
-      bandwidth = vm["bandwidth"].as<float>();	
+      bandwidth = vm["bandwidth"].as<float>();
       *all.file_options <<" --bandwidth "<<bandwidth;
     }
     cerr<<"bandwidth = "<<bandwidth<<endl;
@@ -876,20 +878,20 @@ LEARNER::base_learner* kernel_svm_setup(vw &all) {
     params.kernel_type = SVM_KER_POLY;
     int degree = 2;
     if(vm.count("degree")) {
-      degree = vm["degree"].as<int>();	
+      degree = vm["degree"].as<int>();
       *all.file_options <<" --degree "<<degree;
     }
     cerr<<"degree = "<<degree<<endl;
     params.kernel_params = &calloc_or_die<int>();
     *((int*)params.kernel_params) = degree;
-  }      
+  }
   else
-    params.kernel_type = SVM_KER_LIN;            
-  
+    params.kernel_type = SVM_KER_LIN;
+
   params.all->reg.weight_mask = (uint32_t)LONG_MAX;
   params.all->reg.stride_shift = 0;
-  
-  learner<svm_params>& l = init_learner(&params, learn, 1); 
+
+  learner<svm_params>& l = init_learner(&params, learn, 1);
   l.set_predict(predict);
   l.set_save_load(save_load);
   l.set_finish(finish);

--- a/vowpalwabbit/label_dictionary.cc
+++ b/vowpalwabbit/label_dictionary.cc
@@ -2,118 +2,122 @@
 #include "cost_sensitive.h"
 #include "label_dictionary.h"
 
-namespace LabelDict { 
-  size_t hash_lab(size_t lab) { return 328051 + 94389193 * lab; }
-  
-  void del_example_namespace(example& ec, char ns, v_array<feature>& features, bool audit) {
-    size_t numf = features.size();
-    // print_update is called after this del_example_namespace,
-    // so we need to keep the ec.num_features correct,
-    // so shared features are included in the reported number of "current features"
-    //ec.num_features -= numf;
+namespace LabelDict {
+size_t hash_lab(size_t lab) {
+  return 328051 + 94389193 * lab;
+}
 
-    assert (ec.atomics[(size_t)ns].size() >= numf);
-    if (ec.atomics[(size_t)ns].size() == numf) { // did NOT have ns
-      assert(ec.indices.size() > 0);
-      assert(ec.indices[ec.indices.size()-1] == (size_t)ns);
-      ec.indices.pop();
-      ec.total_sum_feat_sq -= ec.sum_feat_sq[(size_t)ns];
-      ec.atomics[(size_t)ns].erase();
-      ec.sum_feat_sq[(size_t)ns] = 0.;
-      if (audit)
-        ec.audit_features[(size_t)ns].erase();
-    } else { // DID have ns
-      for (feature*f=features.begin; f!=features.end; f++) {
-        ec.sum_feat_sq[(size_t)ns] -= f->x * f->x;
-        ec.atomics[(size_t)ns].pop();
-        if (audit)
-          ec.audit_features[(size_t)ns].pop();
-      }
-    }
-  }
+void del_example_namespace(example& ec, char ns, v_array<feature>& features, bool audit) {
+  size_t numf = features.size();
+  // print_update is called after this del_example_namespace,
+  // so we need to keep the ec.num_features correct,
+  // so shared features are included in the reported number of "current features"
+  //ec.num_features -= numf;
 
-  void add_example_namespace(example& ec, char ns, v_array<feature>& features, v_array<audit_data>* audit) {
-    bool has_ns = false;
-    for (size_t i=0; i<ec.indices.size(); i++) {
-      if (ec.indices[i] == (size_t)ns) {
-        has_ns = true;
-        break;
-      }
-    }
-    if (has_ns) {
-      ec.total_sum_feat_sq -= ec.sum_feat_sq[(size_t)ns];
-    } else {
-      ec.indices.push_back((size_t)ns);
-      ec.sum_feat_sq[(size_t)ns] = 0;
-    }
-
+  assert (ec.atomics[(size_t)ns].size() >= numf);
+  if (ec.atomics[(size_t)ns].size() == numf) { // did NOT have ns
+    assert(ec.indices.size() > 0);
+    assert(ec.indices[ec.indices.size()-1] == (size_t)ns);
+    ec.indices.pop();
+    ec.total_sum_feat_sq -= ec.sum_feat_sq[(size_t)ns];
+    ec.atomics[(size_t)ns].erase();
+    ec.sum_feat_sq[(size_t)ns] = 0.;
+    if (audit)
+      ec.audit_features[(size_t)ns].erase();
+  } else { // DID have ns
     for (feature*f=features.begin; f!=features.end; f++) {
-      ec.sum_feat_sq[(size_t)ns] += f->x * f->x;
-      ec.atomics[(size_t)ns].push_back(*f);
-    }
-
-    ec.num_features += features.size();
-    ec.total_sum_feat_sq += ec.sum_feat_sq[(size_t)ns];
-
-    if (audit != nullptr)
-      for (audit_data*f = audit->begin; f != audit->end; ++f) {
-        audit_data f2 = { f->space, f->feature, f->weight_index, f->x, false };
-        ec.audit_features[(size_t)ns].push_back(f2);
-      }
-  }
-
-  void add_example_namespaces_from_example(example& target, example& source, bool audit) {
-    for (unsigned char* idx=source.indices.begin; idx!=source.indices.end; idx++) {
-      if (*idx == constant_namespace) continue;
-      add_example_namespace(target, (char)*idx, source.atomics[*idx],
-                            audit ? &source.audit_features[*idx] : nullptr);
+      ec.sum_feat_sq[(size_t)ns] -= f->x * f->x;
+      ec.atomics[(size_t)ns].pop();
+      if (audit)
+        ec.audit_features[(size_t)ns].pop();
     }
   }
+}
 
-  void del_example_namespaces_from_example(example& target, example& source, bool audit) {
-    //for (size_t*idx=source.indices.begin; idx!=source.indices.end; idx++) {
-    unsigned char* idx = source.indices.end;
-    idx--;
-    for (; idx>=source.indices.begin; idx--) {
-      if (*idx == constant_namespace) continue;
-      del_example_namespace(target, (char)*idx, source.atomics[*idx], audit);
+void add_example_namespace(example& ec, char ns, v_array<feature>& features, v_array<audit_data>* audit) {
+  bool has_ns = false;
+  for (size_t i=0; i<ec.indices.size(); i++) {
+    if (ec.indices[i] == (size_t)ns) {
+      has_ns = true;
+      break;
     }
   }
-
-  void add_example_namespace_from_memory(label_feature_map& lfm, example& ec, size_t lab, bool audit) {
-    size_t lab_hash = hash_lab(lab);
-    feature_audit& res = lfm.get(lab, lab_hash);
-    if (res.features.size() == 0) return;
-    add_example_namespace(ec, 'l', res.features, audit ? &res.audit : nullptr);
+  if (has_ns) {
+    ec.total_sum_feat_sq -= ec.sum_feat_sq[(size_t)ns];
+  } else {
+    ec.indices.push_back((size_t)ns);
+    ec.sum_feat_sq[(size_t)ns] = 0;
   }
 
-  void del_example_namespace_from_memory(label_feature_map& lfm, example& ec, size_t lab, bool audit) {
-    size_t lab_hash = hash_lab(lab);
-    feature_audit& res = lfm.get(lab, lab_hash);
-    if (res.features.size() == 0) return;
-	del_example_namespace(ec, 'l', res.features, audit);
+  for (feature*f=features.begin; f!=features.end; f++) {
+    ec.sum_feat_sq[(size_t)ns] += f->x * f->x;
+    ec.atomics[(size_t)ns].push_back(*f);
   }
 
-  void set_label_features(label_feature_map& lfm, size_t lab, v_array<feature>&features, v_array<audit_data>* audit) {
-    size_t lab_hash = hash_lab(lab);
-    if (lfm.contains(lab, lab_hash)) { return; }
-    const v_array<audit_data> empty = { nullptr, nullptr, nullptr, 0 };
-    feature_audit fa = { features, audit ? (*audit) : empty };
-    lfm.put_after_get(lab, lab_hash, fa);
-  }
+  ec.num_features += features.size();
+  ec.total_sum_feat_sq += ec.sum_feat_sq[(size_t)ns];
 
-  void free_label_features(label_feature_map& lfm) {
-    void* label_iter = lfm.iterator();
-    while (label_iter != nullptr) {
-      feature_audit *res = lfm.iterator_get_value(label_iter);
-      res->features.erase();
-      res->features.delete_v();
-      res->audit.erase();
-      res->audit.delete_v();
-
-      label_iter = lfm.iterator_next(label_iter);
+  if (audit != nullptr)
+    for (audit_data*f = audit->begin; f != audit->end; ++f) {
+      audit_data f2 = { f->space, f->feature, f->weight_index, f->x, false };
+      ec.audit_features[(size_t)ns].push_back(f2);
     }
-    lfm.clear();
-    lfm.delete_v();
+}
+
+void add_example_namespaces_from_example(example& target, example& source, bool audit) {
+  for (unsigned char* idx=source.indices.begin; idx!=source.indices.end; idx++) {
+    if (*idx == constant_namespace) continue;
+    add_example_namespace(target, (char)*idx, source.atomics[*idx],
+                          audit ? &source.audit_features[*idx] : nullptr);
   }
+}
+
+void del_example_namespaces_from_example(example& target, example& source, bool audit) {
+  //for (size_t*idx=source.indices.begin; idx!=source.indices.end; idx++) {
+  unsigned char* idx = source.indices.end;
+  idx--;
+  for (; idx>=source.indices.begin; idx--) {
+    if (*idx == constant_namespace) continue;
+    del_example_namespace(target, (char)*idx, source.atomics[*idx], audit);
+  }
+}
+
+void add_example_namespace_from_memory(label_feature_map& lfm, example& ec, size_t lab, bool audit) {
+  size_t lab_hash = hash_lab(lab);
+  feature_audit& res = lfm.get(lab, lab_hash);
+  if (res.features.size() == 0) return;
+  add_example_namespace(ec, 'l', res.features, audit ? &res.audit : nullptr);
+}
+
+void del_example_namespace_from_memory(label_feature_map& lfm, example& ec, size_t lab, bool audit) {
+  size_t lab_hash = hash_lab(lab);
+  feature_audit& res = lfm.get(lab, lab_hash);
+  if (res.features.size() == 0) return;
+  del_example_namespace(ec, 'l', res.features, audit);
+}
+
+void set_label_features(label_feature_map& lfm, size_t lab, v_array<feature>&features, v_array<audit_data>* audit) {
+  size_t lab_hash = hash_lab(lab);
+  if (lfm.contains(lab, lab_hash)) {
+    return;
+  }
+  const v_array<audit_data> empty = { nullptr, nullptr, nullptr, 0 };
+  feature_audit fa = { features, audit ? (*audit) : empty };
+  lfm.put_after_get(lab, lab_hash, fa);
+}
+
+void free_label_features(label_feature_map& lfm) {
+  void* label_iter = lfm.iterator();
+  while (label_iter != nullptr) {
+    feature_audit *res = lfm.iterator_get_value(label_iter);
+    res->features.erase();
+    res->features.delete_v();
+    res->audit.erase();
+    res->audit.delete_v();
+
+    label_iter = lfm.iterator_next(label_iter);
+  }
+  lfm.clear();
+  lfm.delete_v();
+}
 }

--- a/vowpalwabbit/label_dictionary.h
+++ b/vowpalwabbit/label_dictionary.h
@@ -1,20 +1,22 @@
 namespace LabelDict {
-  struct feature_audit {
-    v_array<feature> features;
-    v_array<audit_data> audit;
-  };
-  typedef v_hashmap< size_t, feature_audit > label_feature_map;
-  inline bool size_t_eq(size_t &a, size_t &b) { return (a==b); }
+struct feature_audit {
+  v_array<feature> features;
+  v_array<audit_data> audit;
+};
+typedef v_hashmap< size_t, feature_audit > label_feature_map;
+inline bool size_t_eq(size_t &a, size_t &b) {
+  return (a==b);
+}
 
-  void add_example_namespace(example& ec, char ns, v_array<feature>& features, v_array<audit_data>* audit);
-  void del_example_namespace(example& ec, char ns, v_array<feature>& features, bool audit);
+void add_example_namespace(example& ec, char ns, v_array<feature>& features, v_array<audit_data>* audit);
+void del_example_namespace(example& ec, char ns, v_array<feature>& features, bool audit);
 
-  void set_label_features(label_feature_map& lfm, size_t lab, v_array<feature>& features, v_array<audit_data>* audit);
+void set_label_features(label_feature_map& lfm, size_t lab, v_array<feature>& features, v_array<audit_data>* audit);
 
-  void add_example_namespaces_from_example(example& target, example& source, bool audit);
-  void del_example_namespaces_from_example(example& target, example& source, bool audit);
-  void add_example_namespace_from_memory(label_feature_map& lfm, example& ec, size_t lab, bool audit);
-  void del_example_namespace_from_memory(label_feature_map& lfm, example& ec, size_t lab, bool audit);
+void add_example_namespaces_from_example(example& target, example& source, bool audit);
+void del_example_namespaces_from_example(example& target, example& source, bool audit);
+void add_example_namespace_from_memory(label_feature_map& lfm, example& ec, size_t lab, bool audit);
+void del_example_namespace_from_memory(label_feature_map& lfm, example& ec, size_t lab, bool audit);
 
-  void free_label_features(label_feature_map& lfm);
+void free_label_features(label_feature_map& lfm);
 }

--- a/vowpalwabbit/lda_core.cc
+++ b/vowpalwabbit/lda_core.cc
@@ -33,7 +33,7 @@ license as described in the file LICENSE.
 #if BOOST_VERSION >= 105600
 #include <boost/align/is_aligned.hpp>
 #endif
-  
+
 
 enum lda_math_mode { USE_SIMD, USE_PRECISE, USE_FAST_APPROX };
 
@@ -42,7 +42,9 @@ class index_feature
 public:
   uint32_t document;
   feature f;
-  bool operator<(const index_feature b) const { return f.weight_index < b.f.weight_index; }
+  bool operator<(const index_feature b) const {
+    return f.weight_index < b.f.weight_index;
+  }
 };
 
 struct lda {
@@ -73,7 +75,9 @@ struct lda {
 // if it makes it into VS 2015 change the next ifdef to check Visual Studio Release
 
   // static constexpr float underflow_threshold = 1.0e-10f;
-  inline const float  underflow_threshold() { return 1.0e-10f; }
+  inline const float  underflow_threshold() {
+    return 1.0e-10f;
+  }
 
   inline float digamma(float x);
   inline float lgamma(float x);
@@ -86,73 +90,79 @@ struct lda {
 
 namespace
 {
-  inline bool is_aligned16(void *ptr)
-  {
+inline bool is_aligned16(void *ptr)
+{
 #if BOOST_VERSION >= 105600
-    return boost::alignment::is_aligned(16, ptr);
+  return boost::alignment::is_aligned(16, ptr);
 #else
-    return ((reinterpret_cast<uintptr_t>(ptr) & 0x0f) == 0);
+  return ((reinterpret_cast<uintptr_t>(ptr) & 0x0f) == 0);
 #endif
-  }
+}
 }
 
 namespace ldamath
 {
-  inline float fastlog2(float x)
-  {
-    uint32_t mx;
-    memcpy(&mx, &x, sizeof(uint32_t));
-    mx = (mx & 0x007FFFFF) | (0x7e << 23);
+inline float fastlog2(float x)
+{
+  uint32_t mx;
+  memcpy(&mx, &x, sizeof(uint32_t));
+  mx = (mx & 0x007FFFFF) | (0x7e << 23);
 
-    float mx_f;
-    memcpy(&mx_f, &mx, sizeof(float));
+  float mx_f;
+  memcpy(&mx_f, &mx, sizeof(float));
 
-    uint32_t vx;
-    memcpy(&vx, &x, sizeof(uint32_t));
+  uint32_t vx;
+  memcpy(&vx, &x, sizeof(uint32_t));
 
-    float y = static_cast<float>(vx);
-    y *= 1.0f / (float)(1 << 23);
+  float y = static_cast<float>(vx);
+  y *= 1.0f / (float)(1 << 23);
 
-    return y - 124.22544637f - 1.498030302f * mx_f - 1.72587999f / (0.3520887068f + mx_f);
-  }
+  return y - 124.22544637f - 1.498030302f * mx_f - 1.72587999f / (0.3520887068f + mx_f);
+}
 
-  inline float fastlog(float x) { return 0.69314718f * fastlog2(x); }
+inline float fastlog(float x) {
+  return 0.69314718f * fastlog2(x);
+}
 
-  inline float fastpow2(float p)
-  {
-    float offset = (p < 0) * 1.0f;
-    float clipp = (p < -126.0) ? -126.0f : p;
-    int w = (int)clipp;
-    float z = clipp - w + offset;
-    uint32_t approx = (uint32_t) ((1 << 23) * (clipp + 121.2740838f + 27.7280233f / (4.84252568f - z) - 1.49012907f * z));
+inline float fastpow2(float p)
+{
+  float offset = (p < 0) * 1.0f;
+  float clipp = (p < -126.0) ? -126.0f : p;
+  int w = (int)clipp;
+  float z = clipp - w + offset;
+  uint32_t approx = (uint32_t) ((1 << 23) * (clipp + 121.2740838f + 27.7280233f / (4.84252568f - z) - 1.49012907f * z));
 
-    float v;
-    memcpy(&v, &approx, sizeof(uint32_t));
-    return v;
-  }
+  float v;
+  memcpy(&v, &approx, sizeof(uint32_t));
+  return v;
+}
 
-  inline float fastexp(float p) { return fastpow2(1.442695040f * p); }
+inline float fastexp(float p) {
+  return fastpow2(1.442695040f * p);
+}
 
-  inline float fastpow(float x, float p) { return fastpow2(p * fastlog2(x)); }
+inline float fastpow(float x, float p) {
+  return fastpow2(p * fastlog2(x));
+}
 
-  inline float fastlgamma(float x)
-  {
-    float logterm = fastlog(x * (1.0f + x) * (2.0f + x));
-    float xp3 = 3.0f + x;
+inline float fastlgamma(float x)
+{
+  float logterm = fastlog(x * (1.0f + x) * (2.0f + x));
+  float xp3 = 3.0f + x;
 
-    return -2.081061466f - x + 0.0833333f / xp3 - logterm + (2.5f + x) * fastlog(xp3);
-  }
+  return -2.081061466f - x + 0.0833333f / xp3 - logterm + (2.5f + x) * fastlog(xp3);
+}
 
-  inline float fastdigamma(float x)
-  {
-    float twopx = 2.0f + x;
-    float logterm = fastlog(twopx);
+inline float fastdigamma(float x)
+{
+  float twopx = 2.0f + x;
+  float logterm = fastlog(twopx);
 
-    return -(1.0f + 2.0f * x) / (x * (1.0f + x)) - (13.0f + 6.0f * x) / (12.0f * twopx * twopx) + logterm;
-  }
+  return -(1.0f + 2.0f * x) / (x * (1.0f + x)) - (13.0f + 6.0f * x) / (12.0f * twopx * twopx) + logterm;
+}
 
 #if !defined(VW_NO_INLINE_SIMD)
-  
+
 #if defined(__SSE2__) || defined(__SSE3__) || defined(__SSE4_1__)
 
 // Include headers for the various SSE versions:
@@ -168,174 +178,184 @@ namespace ldamath
 
 #define HAVE_SIMD_MATHMODE
 
-  typedef __m128 v4sf;
-  typedef __m128i v4si;
+typedef __m128 v4sf;
+typedef __m128i v4si;
 
-  inline v4sf v4si_to_v4sf(v4si x) { return _mm_cvtepi32_ps(x); }
+inline v4sf v4si_to_v4sf(v4si x) {
+  return _mm_cvtepi32_ps(x);
+}
 
-  inline v4si v4sf_to_v4si(v4sf x) { return _mm_cvttps_epi32(x); }
+inline v4si v4sf_to_v4si(v4sf x) {
+  return _mm_cvttps_epi32(x);
+}
 
-  // Extract v[idx]
-  template <const int idx> float v4sf_index(const v4sf x)
-  {
+// Extract v[idx]
+template <const int idx> float v4sf_index(const v4sf x)
+{
 #if defined(__SSE4_1__)
-    float ret;
-    uint32_t val;
+  float ret;
+  uint32_t val;
 
-    val = _mm_extract_ps(x, idx);
-    // Portably convert uint32_t bit pattern to float. Optimizers will generally
-    // make this disappear.
-    memcpy(&ret, &val, sizeof(uint32_t));
-    return ret;
+  val = _mm_extract_ps(x, idx);
+  // Portably convert uint32_t bit pattern to float. Optimizers will generally
+  // make this disappear.
+  memcpy(&ret, &val, sizeof(uint32_t));
+  return ret;
 #else
-    return _mm_cvtss_f32(_mm_shuffle_ps(x, x, _MM_SHUFFLE(idx, idx, idx, idx)));
+  return _mm_cvtss_f32(_mm_shuffle_ps(x, x, _MM_SHUFFLE(idx, idx, idx, idx)));
 #endif
+}
+
+// Specialization for the 0'th element
+template <> float v4sf_index<0>(const v4sf x) {
+  return _mm_cvtss_f32(x);
+}
+
+inline const v4sf v4sfl(const float x) {
+  return _mm_set1_ps(x);
+}
+
+inline const v4si v4sil(const uint32_t x) {
+  return _mm_set1_epi32(x);
+}
+
+inline v4sf vfastpow2(const v4sf p)
+{
+  v4sf ltzero = _mm_cmplt_ps(p, v4sfl(0.0f));
+  v4sf offset = _mm_and_ps(ltzero, v4sfl(1.0f));
+  v4sf lt126 = _mm_cmplt_ps(p, v4sfl(-126.0f));
+  v4sf clipp = _mm_andnot_ps(lt126, p) + _mm_and_ps(lt126, v4sfl(-126.0f));
+  v4si w = v4sf_to_v4si(clipp);
+  v4sf z = clipp - v4si_to_v4sf(w) + offset;
+
+  const v4sf c_121_2740838 = v4sfl(121.2740838f);
+  const v4sf c_27_7280233 = v4sfl(27.7280233f);
+  const v4sf c_4_84252568 = v4sfl(4.84252568f);
+  const v4sf c_1_49012907 = v4sfl(1.49012907f);
+
+  v4sf v = v4sfl(1 << 23) * (clipp + c_121_2740838 + c_27_7280233 / (c_4_84252568 - z) - c_1_49012907 * z);
+
+  return _mm_castsi128_ps(v4sf_to_v4si(v));
+}
+
+inline v4sf vfastexp(const v4sf p)
+{
+  const v4sf c_invlog_2 = v4sfl(1.442695040f);
+
+  return vfastpow2(c_invlog_2 * p);
+}
+
+inline v4sf vfastlog2(v4sf x)
+{
+  v4si vx_i = _mm_castps_si128(x);
+  v4sf mx_f = _mm_castsi128_ps(_mm_or_si128(_mm_and_si128(vx_i, v4sil(0x007FFFFF)), v4sil(0x3f000000)));
+  v4sf y = v4si_to_v4sf(vx_i) * v4sfl(1.1920928955078125e-7f);
+
+  const v4sf c_124_22551499 = v4sfl(124.22551499f);
+  const v4sf c_1_498030302 = v4sfl(1.498030302f);
+  const v4sf c_1_725877999 = v4sfl(1.72587999f);
+  const v4sf c_0_3520087068 = v4sfl(0.3520887068f);
+
+  return y - c_124_22551499 - c_1_498030302 * mx_f - c_1_725877999 / (c_0_3520087068 + mx_f);
+}
+
+inline v4sf vfastlog(v4sf x)
+{
+  const v4sf c_0_69314718 = v4sfl(0.69314718f);
+
+  return c_0_69314718 * vfastlog2(x);
+}
+
+inline v4sf vfastdigamma(v4sf x)
+{
+  v4sf twopx = v4sfl(2.0f) + x;
+  v4sf logterm = vfastlog(twopx);
+
+  return (v4sfl(-48.0f) + x * (v4sfl(-157.0f) + x * (v4sfl(-127.0f) - v4sfl(30.0f) * x))) /
+         (v4sfl(12.0f) * x * (v4sfl(1.0f) + x) * twopx * twopx) +
+         logterm;
+}
+
+void vexpdigammify(vw &all, float *gamma, const float underflow_threshold)
+{
+  float extra_sum = 0.0f;
+  v4sf sum = v4sfl(0.0f);
+  float *fp;
+  const float *fpend = gamma + all.lda;
+
+  // Iterate through the initial part of the array that isn't 128-bit SIMD
+  // aligned.
+  for (fp = gamma; fp < fpend && !is_aligned16(fp); ++fp) {
+    extra_sum += *fp;
+    *fp = fastdigamma(*fp);
   }
 
-  // Specialization for the 0'th element
-  template <> float v4sf_index<0>(const v4sf x) { return _mm_cvtss_f32(x); }
-
-  inline const v4sf v4sfl(const float x) { return _mm_set1_ps(x); }
-
-  inline const v4si v4sil(const uint32_t x) { return _mm_set1_epi32(x); }
-
-  inline v4sf vfastpow2(const v4sf p)
-  {
-    v4sf ltzero = _mm_cmplt_ps(p, v4sfl(0.0f));
-    v4sf offset = _mm_and_ps(ltzero, v4sfl(1.0f));
-    v4sf lt126 = _mm_cmplt_ps(p, v4sfl(-126.0f));
-    v4sf clipp = _mm_andnot_ps(lt126, p) + _mm_and_ps(lt126, v4sfl(-126.0f));
-    v4si w = v4sf_to_v4si(clipp);
-    v4sf z = clipp - v4si_to_v4sf(w) + offset;
-
-    const v4sf c_121_2740838 = v4sfl(121.2740838f);
-    const v4sf c_27_7280233 = v4sfl(27.7280233f);
-    const v4sf c_4_84252568 = v4sfl(4.84252568f);
-    const v4sf c_1_49012907 = v4sfl(1.49012907f);
-
-    v4sf v = v4sfl(1 << 23) * (clipp + c_121_2740838 + c_27_7280233 / (c_4_84252568 - z) - c_1_49012907 * z);
-
-    return _mm_castsi128_ps(v4sf_to_v4si(v));
+  // Rip through the aligned portion...
+  for (; is_aligned16(fp) && fp + 4 < fpend; fp += 4) {
+    v4sf arg = _mm_load_ps(fp);
+    sum += arg;
+    arg = vfastdigamma(arg);
+    _mm_store_ps(fp, arg);
   }
 
-  inline v4sf vfastexp(const v4sf p)
-  {
-    const v4sf c_invlog_2 = v4sfl(1.442695040f);
-
-    return vfastpow2(c_invlog_2 * p);
+  for (; fp < fpend; ++fp) {
+    extra_sum += *fp;
+    *fp = fastdigamma(*fp);
   }
-
-  inline v4sf vfastlog2(v4sf x)
-  {
-    v4si vx_i = _mm_castps_si128(x);
-    v4sf mx_f = _mm_castsi128_ps(_mm_or_si128(_mm_and_si128(vx_i, v4sil(0x007FFFFF)), v4sil(0x3f000000)));
-    v4sf y = v4si_to_v4sf(vx_i) * v4sfl(1.1920928955078125e-7f);
-
-    const v4sf c_124_22551499 = v4sfl(124.22551499f);
-    const v4sf c_1_498030302 = v4sfl(1.498030302f);
-    const v4sf c_1_725877999 = v4sfl(1.72587999f);
-    const v4sf c_0_3520087068 = v4sfl(0.3520887068f);
-
-    return y - c_124_22551499 - c_1_498030302 * mx_f - c_1_725877999 / (c_0_3520087068 + mx_f);
-  }
-
-  inline v4sf vfastlog(v4sf x)
-  {
-    const v4sf c_0_69314718 = v4sfl(0.69314718f);
-
-    return c_0_69314718 * vfastlog2(x);
-  }
-
-  inline v4sf vfastdigamma(v4sf x)
-  {
-    v4sf twopx = v4sfl(2.0f) + x;
-    v4sf logterm = vfastlog(twopx);
-
-    return (v4sfl(-48.0f) + x * (v4sfl(-157.0f) + x * (v4sfl(-127.0f) - v4sfl(30.0f) * x))) /
-               (v4sfl(12.0f) * x * (v4sfl(1.0f) + x) * twopx * twopx) +
-           logterm;
-  }
-
-  void vexpdigammify(vw &all, float *gamma, const float underflow_threshold)
-  {
-    float extra_sum = 0.0f;
-    v4sf sum = v4sfl(0.0f);
-    float *fp;
-    const float *fpend = gamma + all.lda;
-
-    // Iterate through the initial part of the array that isn't 128-bit SIMD
-    // aligned.
-    for (fp = gamma; fp < fpend && !is_aligned16(fp); ++fp) {
-      extra_sum += *fp;
-      *fp = fastdigamma(*fp);
-    }
-
-    // Rip through the aligned portion...
-    for (; is_aligned16(fp) && fp + 4 < fpend; fp += 4) {
-      v4sf arg = _mm_load_ps(fp);
-      sum += arg;
-      arg = vfastdigamma(arg);
-      _mm_store_ps(fp, arg);
-    }
-
-    for (; fp < fpend; ++fp) {
-      extra_sum += *fp;
-      *fp = fastdigamma(*fp);
-    }
 
 #if defined(__SSE3__) || defined(__SSE4_1__)
-    // Do two horizontal adds on sum, extract the total from the 0 element:
-    sum = _mm_hadd_ps(sum, sum);
-    sum = _mm_hadd_ps(sum, sum);
-    extra_sum += v4sf_index<0>(sum);
+  // Do two horizontal adds on sum, extract the total from the 0 element:
+  sum = _mm_hadd_ps(sum, sum);
+  sum = _mm_hadd_ps(sum, sum);
+  extra_sum += v4sf_index<0>(sum);
 #else
-    extra_sum += v4sf_index<0>(sum) + v4sf_index<1>(sum) + v4sf_index<2>(sum) + v4sf_index<3>(sum);
+  extra_sum += v4sf_index<0>(sum) + v4sf_index<1>(sum) + v4sf_index<2>(sum) + v4sf_index<3>(sum);
 #endif
 
-    extra_sum = fastdigamma(extra_sum);
-    sum = v4sfl(extra_sum);
+  extra_sum = fastdigamma(extra_sum);
+  sum = v4sfl(extra_sum);
 
-    for (fp = gamma; fp < fpend && !is_aligned16(fp); ++fp) {
-      *fp = fmax(underflow_threshold, fastexp(*fp - extra_sum));
-    }
-
-    for (; is_aligned16(fp) && fp + 4 < fpend; fp += 4) {
-      v4sf arg = _mm_load_ps(fp);
-      arg -= sum;
-      arg = vfastexp(arg);
-      arg = _mm_max_ps(v4sfl(underflow_threshold), arg);
-      _mm_store_ps(fp, arg);
-    }
-
-    for (; fp < fpend; ++fp) {
-      *fp = fmax(underflow_threshold, fastexp(*fp - extra_sum));
-    }
+  for (fp = gamma; fp < fpend && !is_aligned16(fp); ++fp) {
+    *fp = fmax(underflow_threshold, fastexp(*fp - extra_sum));
   }
 
-  void vexpdigammify_2(vw &all, float *gamma, const float *norm, const float underflow_threshold)
-  {
-    float *fp;
-    const float *np;
-    const float *fpend = gamma + all.lda;
-
-    for (fp = gamma, np = norm; fp < fpend && !is_aligned16(fp); ++fp, ++np) {
-      *fp = fmax(underflow_threshold, fastexp(fastdigamma(*fp) - *np));
-    }
-
-   for (; is_aligned16(fp) && fp + 4 < fpend; fp += 4, np += 4) {
-      v4sf arg = _mm_load_ps(fp);
-      arg = vfastdigamma(arg);
-      v4sf vnorm = _mm_loadu_ps(np);
-      arg -= vnorm;
-      arg = vfastexp(arg);
-      arg = _mm_max_ps(v4sfl(underflow_threshold), arg);
-      _mm_store_ps(fp, arg);
-    }
-
-    for (; fp < fpend; ++fp, ++np) {
-      *fp = fmax(underflow_threshold, fastexp(fastdigamma(*fp) - *np));
-    }
+  for (; is_aligned16(fp) && fp + 4 < fpend; fp += 4) {
+    v4sf arg = _mm_load_ps(fp);
+    arg -= sum;
+    arg = vfastexp(arg);
+    arg = _mm_max_ps(v4sfl(underflow_threshold), arg);
+    _mm_store_ps(fp, arg);
   }
+
+  for (; fp < fpend; ++fp) {
+    *fp = fmax(underflow_threshold, fastexp(*fp - extra_sum));
+  }
+}
+
+void vexpdigammify_2(vw &all, float *gamma, const float *norm, const float underflow_threshold)
+{
+  float *fp;
+  const float *np;
+  const float *fpend = gamma + all.lda;
+
+  for (fp = gamma, np = norm; fp < fpend && !is_aligned16(fp); ++fp, ++np) {
+    *fp = fmax(underflow_threshold, fastexp(fastdigamma(*fp) - *np));
+  }
+
+  for (; is_aligned16(fp) && fp + 4 < fpend; fp += 4, np += 4) {
+    v4sf arg = _mm_load_ps(fp);
+    arg = vfastdigamma(arg);
+    v4sf vnorm = _mm_loadu_ps(np);
+    arg -= vnorm;
+    arg = vfastexp(arg);
+    arg = _mm_max_ps(v4sfl(underflow_threshold), arg);
+    _mm_store_ps(fp, arg);
+  }
+
+  for (; fp < fpend; ++fp, ++np) {
+    *fp = fmax(underflow_threshold, fastexp(fastdigamma(*fp) - *np));
+  }
+}
 
 #else
 // PLACEHOLDER for future ARM NEON code
@@ -344,96 +364,120 @@ namespace ldamath
 
 #endif // !VW_NO_INLINE_SIMD
 
-  // Templates for common code shared between the three math modes (SIMD, fast approximations
-  // and accurate).
-  //
-  // The generic template takes a type and a specialization flag, mtype.
-  //
-  // mtype == USE_PRECISE: Use the accurate computation for lgamma, digamma.
-  // mtype == USE_FAST_APPROX: Use the fast approximations for lgamma, digamma.
-  // mtype == USE_SIMD: Use CPU SIMD instruction
-  //
-  // The generic template is specialized for the particular accuracy setting.
+// Templates for common code shared between the three math modes (SIMD, fast approximations
+// and accurate).
+//
+// The generic template takes a type and a specialization flag, mtype.
+//
+// mtype == USE_PRECISE: Use the accurate computation for lgamma, digamma.
+// mtype == USE_FAST_APPROX: Use the fast approximations for lgamma, digamma.
+// mtype == USE_SIMD: Use CPU SIMD instruction
+//
+// The generic template is specialized for the particular accuracy setting.
 
-  // Log gamma:
-  template <typename T, const lda_math_mode mtype> inline T lgamma(T x)
-  {
-    BOOST_STATIC_ASSERT_MSG(true, "ldamath::lgamma is not defined for this type and math mode.");
-  }
+// Log gamma:
+template <typename T, const lda_math_mode mtype> inline T lgamma(T x)
+{
+  BOOST_STATIC_ASSERT_MSG(true, "ldamath::lgamma is not defined for this type and math mode.");
+}
 
-  // Digamma:
-  template <typename T, const lda_math_mode mtype> inline T digamma(T x)
-  {
-    BOOST_STATIC_ASSERT_MSG(true, "ldamath::digamma is not defined for this type and math mode.");
-  }
+// Digamma:
+template <typename T, const lda_math_mode mtype> inline T digamma(T x)
+{
+  BOOST_STATIC_ASSERT_MSG(true, "ldamath::digamma is not defined for this type and math mode.");
+}
 
-  // Exponential
-  template <typename T, lda_math_mode mtype> inline T exponential(T x)
-  {
-    BOOST_STATIC_ASSERT_MSG(true, "ldamath::exponential is not defined for this type and math mode.");
-  }
+// Exponential
+template <typename T, lda_math_mode mtype> inline T exponential(T x)
+{
+  BOOST_STATIC_ASSERT_MSG(true, "ldamath::exponential is not defined for this type and math mode.");
+}
 
-  // Powf
-  template <typename T, lda_math_mode mtype> inline T powf(T x, T p)
-  {
-    BOOST_STATIC_ASSERT_MSG(true, "ldamath::powf is not defined for this type and math mode.");
-  }
+// Powf
+template <typename T, lda_math_mode mtype> inline T powf(T x, T p)
+{
+  BOOST_STATIC_ASSERT_MSG(true, "ldamath::powf is not defined for this type and math mode.");
+}
 
-  // High accuracy float specializations:
+// High accuracy float specializations:
 
-  template <> inline float lgamma<float, USE_PRECISE>(float x) { return boost::math::lgamma(x); }
-  template <> inline float digamma<float, USE_PRECISE>(float x) { return boost::math::digamma(x); }
-  template <> inline float exponential<float, USE_PRECISE>(float x) { return std::exp(x); }
-  template <> inline float powf<float, USE_PRECISE>(float x, float p) { return std::pow(x, p); }
+template <> inline float lgamma<float, USE_PRECISE>(float x) {
+  return boost::math::lgamma(x);
+}
+template <> inline float digamma<float, USE_PRECISE>(float x) {
+  return boost::math::digamma(x);
+}
+template <> inline float exponential<float, USE_PRECISE>(float x) {
+  return std::exp(x);
+}
+template <> inline float powf<float, USE_PRECISE>(float x, float p) {
+  return std::pow(x, p);
+}
 
-  // Fast approximation float specializations:
+// Fast approximation float specializations:
 
-  template <> inline float lgamma<float, USE_FAST_APPROX>(float x) { return fastlgamma(x); }
-  template <> inline float digamma<float, USE_FAST_APPROX>(float x) { return fastdigamma(x); }
-  template <> inline float exponential<float, USE_FAST_APPROX>(float x) { return fastexp(x); }
-  template <> inline float powf<float, USE_FAST_APPROX>(float x, float p) { return fastpow(x, p); }
+template <> inline float lgamma<float, USE_FAST_APPROX>(float x) {
+  return fastlgamma(x);
+}
+template <> inline float digamma<float, USE_FAST_APPROX>(float x) {
+  return fastdigamma(x);
+}
+template <> inline float exponential<float, USE_FAST_APPROX>(float x) {
+  return fastexp(x);
+}
+template <> inline float powf<float, USE_FAST_APPROX>(float x, float p) {
+  return fastpow(x, p);
+}
 
-  // SIMD specializations:
+// SIMD specializations:
 
-  template <> inline float lgamma<float, USE_SIMD>(float x) { return lgamma<float, USE_FAST_APPROX>(x); }
-  template <> inline float digamma<float, USE_SIMD>(float x) { return digamma<float, USE_FAST_APPROX>(x); }
-  template <> inline float exponential<float, USE_SIMD>(float x) { return exponential<float, USE_FAST_APPROX>(x); }
-  template <> inline float powf<float, USE_SIMD>(float x, float p) { return powf<float, USE_FAST_APPROX>(x, p); }
+template <> inline float lgamma<float, USE_SIMD>(float x) {
+  return lgamma<float, USE_FAST_APPROX>(x);
+}
+template <> inline float digamma<float, USE_SIMD>(float x) {
+  return digamma<float, USE_FAST_APPROX>(x);
+}
+template <> inline float exponential<float, USE_SIMD>(float x) {
+  return exponential<float, USE_FAST_APPROX>(x);
+}
+template <> inline float powf<float, USE_SIMD>(float x, float p) {
+  return powf<float, USE_FAST_APPROX>(x, p);
+}
 
-  template <typename T, const lda_math_mode mtype> inline void expdigammify(vw &all, T *gamma, T threshold, T initial)
-  {
-    T sum = digamma<T, mtype>(std::accumulate(gamma, gamma + all.lda, initial));
+template <typename T, const lda_math_mode mtype> inline void expdigammify(vw &all, T *gamma, T threshold, T initial)
+{
+  T sum = digamma<T, mtype>(std::accumulate(gamma, gamma + all.lda, initial));
 
-    std::transform(gamma, gamma + all.lda, gamma, [sum, threshold](T g) {
-      return fmax(threshold, exponential<T, mtype>(digamma<T, mtype>(g) - sum));
-    });
-  }
-  template <> inline void expdigammify<float, USE_SIMD>(vw &all, float *gamma, float threshold, float)
-  {
+  std::transform(gamma, gamma + all.lda, gamma, [sum, threshold](T g) {
+    return fmax(threshold, exponential<T, mtype>(digamma<T, mtype>(g) - sum));
+  });
+}
+template <> inline void expdigammify<float, USE_SIMD>(vw &all, float *gamma, float threshold, float)
+{
 #if defined(HAVE_SIMD_MATHMODE)
-    vexpdigammify(all, gamma, threshold);
+  vexpdigammify(all, gamma, threshold);
 #else
-    // Do something sensible if SIMD math isn't available:
-    expdigammify<float, USE_FAST_APPROX>(all, gamma, threshold, 0.0);
+  // Do something sensible if SIMD math isn't available:
+  expdigammify<float, USE_FAST_APPROX>(all, gamma, threshold, 0.0);
 #endif
-  }
+}
 
-  template <typename T, const lda_math_mode mtype>
-  inline void expdigammify_2(vw &all, T *gamma, T *norm, const T threshold)
-  {
-    std::transform(gamma, gamma + all.lda, norm, gamma, [threshold](float g, float n) {
-      return fmax(threshold, exponential<T, mtype>(digamma<T, mtype>(g) - n));
-    });
-  }
-  template <> inline void expdigammify_2<float, USE_SIMD>(vw &all, float *gamma, float *norm, const float threshold)
-  {
+template <typename T, const lda_math_mode mtype>
+inline void expdigammify_2(vw &all, T *gamma, T *norm, const T threshold)
+{
+  std::transform(gamma, gamma + all.lda, norm, gamma, [threshold](float g, float n) {
+    return fmax(threshold, exponential<T, mtype>(digamma<T, mtype>(g) - n));
+  });
+}
+template <> inline void expdigammify_2<float, USE_SIMD>(vw &all, float *gamma, float *norm, const float threshold)
+{
 #if defined(HAVE_SIMD_MATHMODE)
-    vexpdigammify_2(all, gamma, norm, threshold);
+  vexpdigammify_2(all, gamma, norm, threshold);
 #else
-    // Do something sensible if SIMD math isn't available:
-    expdigammify_2<float, USE_FAST_APPROX>(all, gamma, norm, threshold);
+  // Do something sensible if SIMD math isn't available:
+  expdigammify_2<float, USE_FAST_APPROX>(all, gamma, norm, threshold);
 #endif
-  }
+}
 } // namespace ldamath
 
 float lda::digamma(float x)
@@ -519,10 +563,10 @@ void lda::expdigammify_2(vw &all, float *gamma, float *norm)
     ldamath::expdigammify_2<float, USE_FAST_APPROX>(all, gamma, norm, underflow_threshold());
     break;
   case USE_PRECISE:
-	  ldamath::expdigammify_2<float, USE_PRECISE>(all, gamma, norm, underflow_threshold());
+    ldamath::expdigammify_2<float, USE_PRECISE>(all, gamma, norm, underflow_threshold());
     break;
   case USE_SIMD:
-	  ldamath::expdigammify_2<float, USE_SIMD>(all, gamma, norm, underflow_threshold());
+    ldamath::expdigammify_2<float, USE_SIMD>(all, gamma, norm, underflow_threshold());
     break;
   default:
     std::cerr << "lda::expdigammify_2: Trampled or invalid math mode, aborting" << std::endl;
@@ -539,8 +583,12 @@ static inline float average_diff(vw &all, float *oldgamma, float *newgamma)
   // thing as the "plain old" for loop. clang does a good job of reducing the
   // common subexpressions.
   sum = std::inner_product(oldgamma, oldgamma + all.lda, newgamma, 0.0f,
-                           [](float accum, float absdiff) { return accum + absdiff; },
-                           [](float old_g, float new_g) { return std::abs(old_g - new_g); });
+  [](float accum, float absdiff) {
+    return accum + absdiff;
+  },
+  [](float old_g, float new_g) {
+    return std::abs(old_g - new_g);
+  });
 
   normalizer = std::accumulate(newgamma, newgamma + all.lda, 0.0f);
   return sum / normalizer;
@@ -575,9 +623,9 @@ static inline float find_cw(lda &l, float *u_for_w, float *v)
 
 namespace
 {
-  // Effectively, these are static and not visible outside the compilation unit.
-  v_array<float> new_gamma = v_init<float>();
-  v_array<float> old_gamma = v_init<float>();
+// Effectively, these are static and not visible outside the compilation unit.
+v_array<float> new_gamma = v_init<float>();
+v_array<float> old_gamma = v_init<float>();
 }
 
 // Returns an estimate of the part of the variational bound that
@@ -754,7 +802,7 @@ void learn_batch(lda &l)
     last_weight_index = s->f.weight_index;
     float *weights_for_w = &(weights[s->f.weight_index & l.all->reg.weight_mask]);
     float decay_component =
-        l.decay_levels.end[-2] - l.decay_levels.end[(int)(-1 - l.example_t + weights_for_w[l.all->lda])];
+      l.decay_levels.end[-2] - l.decay_levels.end[(int)(-1 - l.example_t + weights_for_w[l.all->lda])];
     float decay = fmin(1.0f, std::exp(decay_component));
     float *u_for_w = weights_for_w + l.all->lda + 1;
 
@@ -829,7 +877,9 @@ void learn(lda &l, LEARNER::base_learner &, example &ec)
 }
 
 // placeholder
-void predict(lda &l, LEARNER::base_learner &base, example &ec) { learn(l, base, ec); }
+void predict(lda &l, LEARNER::base_learner &base, example &ec) {
+  learn(l, base, ec);
+}
 
 void end_pass(lda &l)
 {
@@ -842,7 +892,7 @@ void end_examples(lda &l)
   for (size_t i = 0; i < l.all->length(); i++) {
     weight *weights_for_w = &(l.all->reg.weight_vector[i << l.all->reg.stride_shift]);
     float decay_component =
-        l.decay_levels.last() - l.decay_levels.end[(int)(-1 - l.example_t + weights_for_w[l.all->lda])];
+      l.decay_levels.last() - l.decay_levels.end[(int)(-1 - l.example_t + weights_for_w[l.all->lda])];
     float decay = fmin(1.f, std::exp(decay_component));
     for (size_t k = 0; k < l.all->lda; k++)
       weights_for_w[k] *= decay;
@@ -887,11 +937,11 @@ LEARNER::base_learner *lda_setup(vw &all)
     return nullptr;
   new_options(all, "Lda options")("lda_alpha", po::value<float>()->default_value(0.1f),
                                   "Prior on sparsity of per-document topic weights")(
-      "lda_rho", po::value<float>()->default_value(0.1f), "Prior on sparsity of topic distributions")(
-      "lda_D", po::value<float>()->default_value(10000.),
-      "Number of documents")("lda_epsilon", po::value<float>()->default_value(0.001f), "Loop convergence threshold")(
-      "minibatch", po::value<size_t>()->default_value(1), "Minibatch size, for LDA")(
-      "math-mode", po::value<lda_math_mode>()->default_value(USE_SIMD), "Math mode: simd, accuracy, fast-approx");
+                                    "lda_rho", po::value<float>()->default_value(0.1f), "Prior on sparsity of topic distributions")(
+                                      "lda_D", po::value<float>()->default_value(10000.),
+                                      "Number of documents")("lda_epsilon", po::value<float>()->default_value(0.001f), "Loop convergence threshold")(
+                                        "minibatch", po::value<size_t>()->default_value(1), "Minibatch size, for LDA")(
+                                          "math-mode", po::value<lda_math_mode>()->default_value(USE_SIMD), "Math mode: simd, accuracy, fast-approx");
   add_options(all);
   po::variables_map &vm = all.vm;
 

--- a/vowpalwabbit/learner.cc
+++ b/vowpalwabbit/learner.cc
@@ -13,55 +13,55 @@ void dispatch_example(vw& all, example& ec)
 
 namespace LEARNER
 {
-  void generic_driver(vw& all)
+void generic_driver(vw& all)
+{
+  example* ec = nullptr;
+
+  all.l->init_driver();
+  while ( all.early_terminate == false )
   {
-    example* ec = nullptr;
-
-    all.l->init_driver();
-    while ( all.early_terminate == false )
-      {
-	if ((ec = VW::get_example(all.p)) != nullptr)//semiblocking operation.
-	  {
-	    if (ec->indices.size() > 1) // 1+ nonconstant feature. (most common case first)
-	      dispatch_example(all, *ec);
-	    else if (ec->end_pass)
-	      {
-		all.l->end_pass();
-		VW::finish_example(all, ec);
-	      }
-	    else if (ec->tag.size() >= 4 && !strncmp((const char*) ec->tag.begin, "save", 4))
-	      {// save state command
-
-		string final_regressor_name = all.final_regressor_name;
-		
-		if ((ec->tag).size() >= 6 && (ec->tag)[4] == '_')
-		  final_regressor_name = string(ec->tag.begin+5, (ec->tag).size()-5);
-		
-		if (!all.quiet)
-		  cerr << "saving regressor to " << final_regressor_name << endl;
-		save_predictor(all, final_regressor_name, 0);
-		
-		VW::finish_example(all,ec);
-	      }
-	    else // empty example
-	      dispatch_example(all, *ec);
-	  }
-	else if (parser_done(all.p))
-	  {
-	    all.l->end_examples();
-	    return;
-	  }
-      }
-    if (all.early_terminate) //drain any extra examples from parser and call end_examples
+    if ((ec = VW::get_example(all.p)) != nullptr)//semiblocking operation.
     {
-      while ((ec = VW::get_example(all.p)) != nullptr) //semiblocking operation.
-	    VW::finish_example(all, ec);
+      if (ec->indices.size() > 1) // 1+ nonconstant feature. (most common case first)
+        dispatch_example(all, *ec);
+      else if (ec->end_pass)
+      {
+        all.l->end_pass();
+        VW::finish_example(all, ec);
+      }
+      else if (ec->tag.size() >= 4 && !strncmp((const char*) ec->tag.begin, "save", 4))
+      { // save state command
 
-       if (parser_done(all.p))
-	    {
-	      all.l->end_examples();
-	      return;
-	    }
-	}
+        string final_regressor_name = all.final_regressor_name;
+
+        if ((ec->tag).size() >= 6 && (ec->tag)[4] == '_')
+          final_regressor_name = string(ec->tag.begin+5, (ec->tag).size()-5);
+
+        if (!all.quiet)
+          cerr << "saving regressor to " << final_regressor_name << endl;
+        save_predictor(all, final_regressor_name, 0);
+
+        VW::finish_example(all,ec);
+      }
+      else // empty example
+        dispatch_example(all, *ec);
+    }
+    else if (parser_done(all.p))
+    {
+      all.l->end_examples();
+      return;
+    }
   }
+  if (all.early_terminate) //drain any extra examples from parser and call end_examples
+  {
+    while ((ec = VW::get_example(all.p)) != nullptr) //semiblocking operation.
+      VW::finish_example(all, ec);
+
+    if (parser_done(all.p))
+    {
+      all.l->end_examples();
+      return;
+    }
+  }
+}
 }

--- a/vowpalwabbit/learner.h
+++ b/vowpalwabbit/learner.h
@@ -14,234 +14,264 @@ license as described in the file LICENSE.
 #include "parser.h"
 using namespace std;
 
-void return_simple_example(vw& all, void*, example& ec);  
-  
+void return_simple_example(vw& all, void*, example& ec);
+
 namespace LEARNER
 {
-  template<class T> struct learner;
-  typedef learner<char> base_learner;
-  
-  struct func_data {
-    void* data;
-    base_learner* base;
-    void (*func)(void* data);
-  };
-  
-  inline func_data tuple_dbf(void* data, base_learner* base, void (*func)(void* data))
+template<class T> struct learner;
+typedef learner<char> base_learner;
+
+struct func_data {
+  void* data;
+  base_learner* base;
+  void (*func)(void* data);
+};
+
+inline func_data tuple_dbf(void* data, base_learner* base, void (*func)(void* data))
+{
+  func_data foo;
+  foo.data = data;
+  foo.base = base;
+  foo.func = func;
+  return foo;
+}
+
+struct learn_data {
+  void* data;
+  base_learner* base;
+  void (*learn_f)(void* data, base_learner& base, example&);
+  void (*predict_f)(void* data, base_learner& base, example&);
+  void (*update_f)(void* data, base_learner& base, example&);
+  void (*multipredict_f)(void* data, base_learner& base, example&, size_t count, size_t step, polyprediction*pred, bool finalize_predictions);
+};
+
+struct save_load_data {
+  void* data;
+  base_learner* base;
+  void (*save_load_f)(void*, io_buf&, bool read, bool text);
+};
+
+struct finish_example_data {
+  void* data;
+  base_learner* base;
+  void (*finish_example_f)(vw&, void* data, example&);
+};
+
+void generic_driver(vw& all);
+
+inline void noop_sl(void*, io_buf&, bool, bool) {}
+inline void noop(void*) {}
+
+typedef void (*tlearn)(void* d, base_learner& base, example& ec);
+typedef void (*tmultipredict)(void* d, base_learner& base, example& ec, size_t, size_t, polyprediction*, bool);
+typedef void (*tsl)(void* d, io_buf& io, bool read, bool text);
+typedef void (*tfunc)(void*d);
+typedef void (*tend_example)(vw& all, void* d, example& ec);
+
+template<class T> learner<T>& init_learner(T*, void (*)(T&, base_learner&, example&), size_t);
+template<class T>
+learner<T>& init_learner(T*, base_learner*, void (*learn)(T&, base_learner&, example&),
+                         void (*predict)(T&, base_learner&, example&), size_t ws = 1);
+
+template<class T>
+struct learner {
+private:
+  func_data init_fd;
+  learn_data learn_fd;
+  finish_example_data finish_example_fd;
+  save_load_data save_load_fd;
+  func_data end_pass_fd;
+  func_data end_examples_fd;
+  func_data finisher_fd;
+
+public:
+  size_t weights; //this stores the number of "weight vectors" required by the learner.
+  size_t increment;
+
+  //called once for each example.  Must work under reduction.
+  inline void learn(example& ec, size_t i=0)
   {
-    func_data foo;
-    foo.data = data;
-    foo.base = base;
-    foo.func = func;
-    return foo;
+    ec.ft_offset += (uint32_t)(increment*i);
+    learn_fd.learn_f(learn_fd.data, *learn_fd.base, ec);
+    ec.ft_offset -= (uint32_t)(increment*i);
   }
-  
-  struct learn_data {
-    void* data;
-    base_learner* base;
-    void (*learn_f)(void* data, base_learner& base, example&);
-    void (*predict_f)(void* data, base_learner& base, example&);
-    void (*update_f)(void* data, base_learner& base, example&);
-    void (*multipredict_f)(void* data, base_learner& base, example&, size_t count, size_t step, polyprediction*pred, bool finalize_predictions);
-  };
-
-  struct save_load_data {
-    void* data;
-    base_learner* base;
-    void (*save_load_f)(void*, io_buf&, bool read, bool text);
-  };
-  
-  struct finish_example_data {
-    void* data;
-    base_learner* base;
-    void (*finish_example_f)(vw&, void* data, example&);
-  };
-  
-  void generic_driver(vw& all);
-  
-  inline void noop_sl(void*, io_buf&, bool, bool) {}
-  inline void noop(void*) {}
-
-  typedef void (*tlearn)(void* d, base_learner& base, example& ec);
-  typedef void (*tmultipredict)(void* d, base_learner& base, example& ec, size_t, size_t, polyprediction*, bool);
-  typedef void (*tsl)(void* d, io_buf& io, bool read, bool text);
-  typedef void (*tfunc)(void*d);
-  typedef void (*tend_example)(vw& all, void* d, example& ec);
-
-  template<class T> learner<T>& init_learner(T*, void (*)(T&, base_learner&, example&), size_t);
-  template<class T> 
-    learner<T>& init_learner(T*, base_learner*, void (*learn)(T&, base_learner&, example&), 
-			     void (*predict)(T&, base_learner&, example&), size_t ws = 1);
-  
-  template<class T>
-    struct learner {
-    private:
-      func_data init_fd;
-      learn_data learn_fd;
-      finish_example_data finish_example_fd;
-      save_load_data save_load_fd;
-      func_data end_pass_fd;
-      func_data end_examples_fd;
-      func_data finisher_fd;
-      
-    public:
-      size_t weights; //this stores the number of "weight vectors" required by the learner.
-      size_t increment;
-      
-      //called once for each example.  Must work under reduction.
-      inline void learn(example& ec, size_t i=0) 
-      { 
-	ec.ft_offset += (uint32_t)(increment*i);
-	learn_fd.learn_f(learn_fd.data, *learn_fd.base, ec);
-	ec.ft_offset -= (uint32_t)(increment*i);
+  inline void predict(example& ec, size_t i=0)
+  {
+    ec.ft_offset += (uint32_t)(increment*i);
+    learn_fd.predict_f(learn_fd.data, *learn_fd.base, ec);
+    ec.ft_offset -= (uint32_t)(increment*i);
+  }
+  inline void multipredict(example& ec, size_t lo, size_t count, polyprediction* pred, bool finalize_predictions) {
+    if (learn_fd.multipredict_f == NULL) {
+      ec.ft_offset += (uint32_t)(increment*lo);
+      for (size_t c=0; c<count; c++) {
+        learn_fd.predict_f(learn_fd.data, *learn_fd.base, ec);
+        if (finalize_predictions) pred[c] = ec.pred; // TODO: this breaks for complex labels because = doesn't do deep copy!
+        else                      pred[c].scalar = ec.partial_prediction;
+        //pred[c].scalar = finalize_prediction ec.partial_prediction; // TODO: this breaks for complex labels because = doesn't do deep copy! // note works if ec.partial_prediction, but only if finalize_prediction is run????
+        ec.ft_offset += (uint32_t)increment;
       }
-      inline void predict(example& ec, size_t i=0) 
-      { 
-	ec.ft_offset += (uint32_t)(increment*i);
-	learn_fd.predict_f(learn_fd.data, *learn_fd.base, ec);
-	ec.ft_offset -= (uint32_t)(increment*i);
-      }
-      inline void multipredict(example& ec, size_t lo, size_t count, polyprediction* pred, bool finalize_predictions) {
-        if (learn_fd.multipredict_f == NULL) {
-          ec.ft_offset += (uint32_t)(increment*lo);
-          for (size_t c=0; c<count; c++) {
-            learn_fd.predict_f(learn_fd.data, *learn_fd.base, ec);
-            if (finalize_predictions) pred[c] = ec.pred; // TODO: this breaks for complex labels because = doesn't do deep copy!
-            else                      pred[c].scalar = ec.partial_prediction;
-            //pred[c].scalar = finalize_prediction ec.partial_prediction; // TODO: this breaks for complex labels because = doesn't do deep copy! // note works if ec.partial_prediction, but only if finalize_prediction is run????
-            ec.ft_offset += (uint32_t)increment;
-          }
-          ec.ft_offset -= (uint32_t)(increment*(lo+count));
-        } else {
-          ec.ft_offset += (uint32_t)(increment*lo);
-          learn_fd.multipredict_f(learn_fd.data, *learn_fd.base, ec, count, increment, pred, finalize_predictions);
-          ec.ft_offset -= (uint32_t)(increment*lo);
-        }
-      }
-      inline void set_predict(void (*u)(T& data, base_learner& base, example&)) { learn_fd.predict_f = (tlearn)u; }
-      inline void set_learn(void (*u)(T&, base_learner&, example&)) { learn_fd.learn_f = (tlearn)u; }
-      inline void set_multipredict(void (*u)(T&, base_learner&, example&, size_t, size_t, polyprediction*, bool)) { learn_fd.multipredict_f = (tmultipredict)u; }
-      
-      inline void update(example& ec, size_t i=0) 
-      { 
-	ec.ft_offset += (uint32_t)(increment*i);
-	learn_fd.update_f(learn_fd.data, *learn_fd.base, ec);
-	ec.ft_offset -= (uint32_t)(increment*i);
-      }
-      inline void set_update(void (*u)(T& data, base_learner& base, example&))
-      { learn_fd.update_f = (tlearn)u; }
-      
-      //called anytime saving or loading needs to happen. Autorecursive.
-      inline void save_load(io_buf& io, bool read, bool text) 
-      { save_load_fd.save_load_f(save_load_fd.data, io, read, text); 
-	if (save_load_fd.base) save_load_fd.base->save_load(io, read, text); }
-      inline void set_save_load(void (*sl)(T&, io_buf&, bool, bool))
-      { save_load_fd.save_load_f = (tsl)sl; 
-	save_load_fd.data = learn_fd.data; 
-	save_load_fd.base = learn_fd.base;}
-      
-      //called to clean up state.  Autorecursive.
-      void set_finish(void (*f)(T&)) 
-      { finisher_fd = tuple_dbf(learn_fd.data,learn_fd.base, (tfunc)f); }
-      inline void finish() 
-      { 
-	if (finisher_fd.data) 
-	  {finisher_fd.func(finisher_fd.data); free(finisher_fd.data); } 
-	if (finisher_fd.base) { 
-	  finisher_fd.base->finish();
-	  free(finisher_fd.base);
-	}
-      }
-      
-      void end_pass(){ 
-	end_pass_fd.func(end_pass_fd.data);
-	if (end_pass_fd.base) end_pass_fd.base->end_pass(); }//autorecursive
-      void set_end_pass(void (*f)(T&)) 
-      {end_pass_fd = tuple_dbf(learn_fd.data, learn_fd.base, (tfunc)f);}
-      
-      //called after parsing of examples is complete.  Autorecursive.
-      void end_examples() 
-      { end_examples_fd.func(end_examples_fd.data); 
-	if (end_examples_fd.base) end_examples_fd.base->end_examples(); }  
-      void set_end_examples(void (*f)(T&)) 
-      {end_examples_fd = tuple_dbf(learn_fd.data,learn_fd.base, (tfunc)f);}
-      
-      //Called at the beginning by the driver.  Explicitly not recursive.
-      void init_driver() { init_fd.func(init_fd.data);}
-      void set_init_driver(void (*f)(T&)) 
-      { init_fd = tuple_dbf(learn_fd.data,learn_fd.base, (tfunc)f); }
-      
-      //called after learn example for each example.  Explicitly not recursive.
-      inline void finish_example(vw& all, example& ec) 
-      { finish_example_fd.finish_example_f(all, finish_example_fd.data, ec);}
-      void set_finish_example(void (*f)(vw& all, T&, example&))
-      {finish_example_fd.data = learn_fd.data;
-	finish_example_fd.finish_example_f = (tend_example)f;}
-      
-      friend learner<T>& init_learner<>(T*, void (*learn)(T&, base_learner&, example&), size_t);
-      friend learner<T>& init_learner<>(T*, base_learner*, void (*l)(T&, base_learner&, example&), 
-					void (*pred)(T&, base_learner&, example&), size_t);
-    };
-  
-  template<class T> 
-    learner<T>& init_learner(T* dat, void (*learn)(T&, base_learner&, example&), 
-			     size_t params_per_weight)
-    { // the constructor for all learning algorithms.
-      learner<T>& ret = calloc_or_die<learner<T> >();
-      ret.weights = 1;
-      ret.increment = params_per_weight;
-      ret.end_pass_fd.func = noop;
-      ret.end_examples_fd.func = noop;
-      ret.init_fd.func = noop;
-      ret.save_load_fd.save_load_f = noop_sl;
-      ret.finisher_fd.data = dat;
-      ret.finisher_fd.func = noop;
-      
-      ret.learn_fd.data = dat;
-      ret.learn_fd.learn_f = (tlearn)learn;
-      ret.learn_fd.update_f = (tlearn)learn;
-      ret.learn_fd.predict_f = (tlearn)learn;
-      ret.learn_fd.multipredict_f = nullptr;
-      ret.finish_example_fd.data = dat;
-      ret.finish_example_fd.finish_example_f = return_simple_example;
-
-      return ret;
+      ec.ft_offset -= (uint32_t)(increment*(lo+count));
+    } else {
+      ec.ft_offset += (uint32_t)(increment*lo);
+      learn_fd.multipredict_f(learn_fd.data, *learn_fd.base, ec, count, increment, pred, finalize_predictions);
+      ec.ft_offset -= (uint32_t)(increment*lo);
     }
-  
-  template<class T> 
-    learner<T>& init_learner(T* dat, base_learner* base, 
-			     void (*learn)(T&, base_learner&, example&), 
-			     void (*predict)(T&, base_learner&, example&), size_t ws) 
-    { //the reduction constructor, with separate learn and predict functions
-      learner<T>& ret = calloc_or_die<learner<T> >();
-      ret = *(learner<T>*)base;
-      
-      ret.learn_fd.data = dat;
-      ret.learn_fd.learn_f = (tlearn)learn;
-      ret.learn_fd.update_f = (tlearn)learn;
-      ret.learn_fd.predict_f = (tlearn)predict;
-      ret.learn_fd.multipredict_f = nullptr;
-      ret.learn_fd.base = base;
-      
-      ret.finisher_fd.data = dat;
-      ret.finisher_fd.base = base;
-      ret.finisher_fd.func = noop;
-      
-      ret.weights = ws;
-      ret.increment = base->increment * ret.weights;
-      return ret;
-    }
+  }
+  inline void set_predict(void (*u)(T& data, base_learner& base, example&)) {
+    learn_fd.predict_f = (tlearn)u;
+  }
+  inline void set_learn(void (*u)(T&, base_learner&, example&)) {
+    learn_fd.learn_f = (tlearn)u;
+  }
+  inline void set_multipredict(void (*u)(T&, base_learner&, example&, size_t, size_t, polyprediction*, bool)) {
+    learn_fd.multipredict_f = (tmultipredict)u;
+  }
 
-  template<class T> learner<T>& 
-    init_multiclass_learner(T* dat, base_learner* base, 
-			    void (*learn)(T&, base_learner&, example&), 
-			    void (*predict)(T&, base_learner&, example&), parser* p, size_t ws) 
+  inline void update(example& ec, size_t i=0)
+  {
+    ec.ft_offset += (uint32_t)(increment*i);
+    learn_fd.update_f(learn_fd.data, *learn_fd.base, ec);
+    ec.ft_offset -= (uint32_t)(increment*i);
+  }
+  inline void set_update(void (*u)(T& data, base_learner& base, example&))
+  {
+    learn_fd.update_f = (tlearn)u;
+  }
+
+  //called anytime saving or loading needs to happen. Autorecursive.
+  inline void save_load(io_buf& io, bool read, bool text)
+  { save_load_fd.save_load_f(save_load_fd.data, io, read, text);
+    if (save_load_fd.base) save_load_fd.base->save_load(io, read, text);
+  }
+  inline void set_save_load(void (*sl)(T&, io_buf&, bool, bool))
+  { save_load_fd.save_load_f = (tsl)sl;
+    save_load_fd.data = learn_fd.data;
+    save_load_fd.base = learn_fd.base;
+  }
+
+  //called to clean up state.  Autorecursive.
+  void set_finish(void (*f)(T&))
+  {
+    finisher_fd = tuple_dbf(learn_fd.data,learn_fd.base, (tfunc)f);
+  }
+  inline void finish()
+  {
+    if (finisher_fd.data)
     {
-      learner<T>& l = init_learner(dat,base,learn,predict,ws);
-      l.set_finish_example(MULTICLASS::finish_example<T>);
-      p->lp = MULTICLASS::mc_label;
-      return l;
+      finisher_fd.func(finisher_fd.data);
+      free(finisher_fd.data);
     }
-  
-  template<class T> base_learner* make_base(learner<T>& base) { return (base_learner*)&base; }
+    if (finisher_fd.base) {
+      finisher_fd.base->finish();
+      free(finisher_fd.base);
+    }
+  }
+
+  void end_pass() {
+    end_pass_fd.func(end_pass_fd.data);
+    if (end_pass_fd.base) end_pass_fd.base->end_pass();
+  }//autorecursive
+  void set_end_pass(void (*f)(T&))
+  {
+    end_pass_fd = tuple_dbf(learn_fd.data, learn_fd.base, (tfunc)f);
+  }
+
+  //called after parsing of examples is complete.  Autorecursive.
+  void end_examples()
+  { end_examples_fd.func(end_examples_fd.data);
+    if (end_examples_fd.base) end_examples_fd.base->end_examples();
+  }
+  void set_end_examples(void (*f)(T&))
+  {
+    end_examples_fd = tuple_dbf(learn_fd.data,learn_fd.base, (tfunc)f);
+  }
+
+  //Called at the beginning by the driver.  Explicitly not recursive.
+  void init_driver() {
+    init_fd.func(init_fd.data);
+  }
+  void set_init_driver(void (*f)(T&))
+  {
+    init_fd = tuple_dbf(learn_fd.data,learn_fd.base, (tfunc)f);
+  }
+
+  //called after learn example for each example.  Explicitly not recursive.
+  inline void finish_example(vw& all, example& ec)
+  {
+    finish_example_fd.finish_example_f(all, finish_example_fd.data, ec);
+  }
+  void set_finish_example(void (*f)(vw& all, T&, example&))
+  { finish_example_fd.data = learn_fd.data;
+    finish_example_fd.finish_example_f = (tend_example)f;
+  }
+
+  friend learner<T>& init_learner<>(T*, void (*learn)(T&, base_learner&, example&), size_t);
+  friend learner<T>& init_learner<>(T*, base_learner*, void (*l)(T&, base_learner&, example&),
+                                    void (*pred)(T&, base_learner&, example&), size_t);
+};
+
+template<class T>
+learner<T>& init_learner(T* dat, void (*learn)(T&, base_learner&, example&),
+                         size_t params_per_weight)
+{ // the constructor for all learning algorithms.
+  learner<T>& ret = calloc_or_die<learner<T> >();
+  ret.weights = 1;
+  ret.increment = params_per_weight;
+  ret.end_pass_fd.func = noop;
+  ret.end_examples_fd.func = noop;
+  ret.init_fd.func = noop;
+  ret.save_load_fd.save_load_f = noop_sl;
+  ret.finisher_fd.data = dat;
+  ret.finisher_fd.func = noop;
+
+  ret.learn_fd.data = dat;
+  ret.learn_fd.learn_f = (tlearn)learn;
+  ret.learn_fd.update_f = (tlearn)learn;
+  ret.learn_fd.predict_f = (tlearn)learn;
+  ret.learn_fd.multipredict_f = nullptr;
+  ret.finish_example_fd.data = dat;
+  ret.finish_example_fd.finish_example_f = return_simple_example;
+
+  return ret;
+}
+
+template<class T>
+learner<T>& init_learner(T* dat, base_learner* base,
+                         void (*learn)(T&, base_learner&, example&),
+                         void (*predict)(T&, base_learner&, example&), size_t ws)
+{ //the reduction constructor, with separate learn and predict functions
+  learner<T>& ret = calloc_or_die<learner<T> >();
+  ret = *(learner<T>*)base;
+
+  ret.learn_fd.data = dat;
+  ret.learn_fd.learn_f = (tlearn)learn;
+  ret.learn_fd.update_f = (tlearn)learn;
+  ret.learn_fd.predict_f = (tlearn)predict;
+  ret.learn_fd.multipredict_f = nullptr;
+  ret.learn_fd.base = base;
+
+  ret.finisher_fd.data = dat;
+  ret.finisher_fd.base = base;
+  ret.finisher_fd.func = noop;
+
+  ret.weights = ws;
+  ret.increment = base->increment * ret.weights;
+  return ret;
+}
+
+template<class T> learner<T>&
+init_multiclass_learner(T* dat, base_learner* base,
+                        void (*learn)(T&, base_learner&, example&),
+                        void (*predict)(T&, base_learner&, example&), parser* p, size_t ws)
+{
+  learner<T>& l = init_learner(dat,base,learn,predict,ws);
+  l.set_finish_example(MULTICLASS::finish_example<T>);
+  p->lp = MULTICLASS::mc_label;
+  return l;
+}
+
+template<class T> base_learner* make_base(learner<T>& base) {
+  return (base_learner*)&base;
+}
 }

--- a/vowpalwabbit/log_multi.cc
+++ b/vowpalwabbit/log_multi.cc
@@ -13,510 +13,510 @@ license as described in the file LICENSE.node
 using namespace std;
 using namespace LEARNER;
 
-  class node_pred	
+class node_pred
+{
+public:
+
+  double Ehk;
+  float norm_Ehk;
+  uint32_t nk;
+  uint32_t label;
+  uint32_t label_count;
+
+  bool operator==(node_pred v) {
+    return (label == v.label);
+  }
+
+  bool operator>(node_pred v) {
+    if(label > v.label) return true;
+    return false;
+  }
+
+  bool operator<(node_pred v) {
+    if(label < v.label) return true;
+    return false;
+  }
+
+  node_pred(uint32_t l)
   {
-  public:
-    
-    double Ehk;	
-    float norm_Ehk;
-    uint32_t nk;
-    uint32_t label;	
-    uint32_t label_count;
- 
-    bool operator==(node_pred v){
-      return (label == v.label);
-    }
-    
-    bool operator>(node_pred v){
-      if(label > v.label) return true;	
-      return false;
-    }
-    
-    bool operator<(node_pred v){
-      if(label < v.label) return true;	
-      return false;
-    }
-    
-    node_pred(uint32_t l)
+    label = l;
+    Ehk = 0.f;
+    norm_Ehk = 0;
+    nk = 0;
+    label_count = 0;
+  }
+};
+
+typedef struct
+{ //everyone has
+  uint32_t parent;//the parent node
+  v_array<node_pred> preds;//per-class state
+  uint32_t min_count;//the number of examples reaching this node (if it's a leaf) or the minimum reaching any grandchild.
+
+  bool internal;//internal or leaf
+
+  //internal nodes have
+  uint32_t base_predictor;//id of the base predictor
+  uint32_t left;//left child
+  uint32_t right;//right child
+  float norm_Eh;//the average margin at the node
+  double Eh;//total margin at the node
+  uint32_t n;//total events at the node
+
+  //leaf has
+  uint32_t max_count;//the number of samples of the most common label
+  uint32_t max_count_label;//the most common label
+} node;
+
+struct log_multi
+{
+  uint32_t k;
+
+  v_array<node> nodes;
+
+  size_t max_predictors;
+  size_t predictors_used;
+
+  bool progress;
+  uint32_t swap_resist;
+
+  uint32_t nbofswaps;
+};
+
+inline void init_leaf(node& n)
+{
+  n.internal = false;
+  n.preds.erase();
+  n.base_predictor = 0;
+  n.norm_Eh = 0;
+  n.Eh = 0;
+  n.n = 0;
+  n.max_count = 0;
+  n.max_count_label = 1;
+  n.left = 0;
+  n.right = 0;
+}
+
+inline node init_node()
+{
+  node node;
+
+  node.parent = 0;
+  node.min_count = 0;
+  node.preds = v_init<node_pred>();
+  init_leaf(node);
+
+  return node;
+}
+
+void init_tree(log_multi& d)
+{
+  d.nodes.push_back(init_node());
+  d.nbofswaps = 0;
+}
+
+inline uint32_t min_left_right(log_multi& b, node& n)
+{
+  return min(b.nodes[n.left].min_count, b.nodes[n.right].min_count);
+}
+
+inline uint32_t find_switch_node(log_multi& b)
+{
+  uint32_t node = 0;
+  while(b.nodes[node].internal)
+    if(b.nodes[b.nodes[node].left].min_count
+        < b.nodes[b.nodes[node].right].min_count)
+      node = b.nodes[node].left;
+    else
+      node = b.nodes[node].right;
+  return node;
+}
+
+inline void update_min_count(log_multi& b, uint32_t node)
+{ //Constant time min count update.
+  while(node != 0)
+  {
+    uint32_t prev = node;
+    node = b.nodes[node].parent;
+
+    if (b.nodes[node].min_count == b.nodes[prev].min_count)
+      break;
+    else
+      b.nodes[node].min_count = min_left_right(b,b.nodes[node]);
+  }
+}
+
+void display_tree_dfs(log_multi& b, node node, uint32_t depth)
+{
+  for (uint32_t i = 0; i < depth; i++)
+    cout << "\t";
+  cout << node.min_count << " " << node.left
+       << " " << node.right;
+  cout << " label = " << node.max_count_label << " labels = ";
+  for (size_t i = 0; i < node.preds.size(); i++)
+    cout << node.preds[i].label << ":" << node.preds[i].label_count << "\t";
+  cout << endl;
+
+  if (node.internal)
+  {
+    cout << "Left";
+    display_tree_dfs(b, b.nodes[node.left], depth+1);
+
+    cout << "Right";
+    display_tree_dfs(b, b.nodes[node.right], depth+1);
+  }
+}
+
+bool children(log_multi& b, uint32_t& current, uint32_t& class_index, uint32_t label)
+{
+  class_index = (uint32_t)b.nodes[current].preds.unique_add_sorted(node_pred(label));
+  b.nodes[current].preds[class_index].label_count++;
+
+  if(b.nodes[current].preds[class_index].label_count > b.nodes[current].max_count)
+  {
+    b.nodes[current].max_count = b.nodes[current].preds[class_index].label_count;
+    b.nodes[current].max_count_label = b.nodes[current].preds[class_index].label;
+  }
+
+  if (b.nodes[current].internal)
+    return true;
+  else if( b.nodes[current].preds.size() > 1
+           && (b.predictors_used < b.max_predictors
+               || b.nodes[current].min_count - b.nodes[current].max_count > b.swap_resist*(b.nodes[0].min_count + 1)))
+  { //need children and we can make them.
+    uint32_t left_child;
+    uint32_t right_child;
+    if (b.predictors_used < b.max_predictors)
     {
-      label = l;
-      Ehk = 0.f;
-      norm_Ehk = 0;
-      nk = 0;
-      label_count = 0;
+      left_child = (uint32_t)b.nodes.size();
+      b.nodes.push_back(init_node());
+      right_child = (uint32_t)b.nodes.size();
+      b.nodes.push_back(init_node());
+      b.nodes[current].base_predictor = (uint32_t)b.predictors_used++;
     }
-  };
-  
-  typedef struct
-  {//everyone has
-    uint32_t parent;//the parent node
-    v_array<node_pred> preds;//per-class state
-    uint32_t min_count;//the number of examples reaching this node (if it's a leaf) or the minimum reaching any grandchild.
+    else
+    {
+      uint32_t swap_child = find_switch_node(b);
+      uint32_t swap_parent = b.nodes[swap_child].parent;
+      uint32_t swap_grandparent = b.nodes[swap_parent].parent;
+      if (b.nodes[swap_child].min_count != b.nodes[0].min_count)
+        cout << "glargh " << b.nodes[swap_child].min_count << " != " << b.nodes[0].min_count << endl;
+      b.nbofswaps++;
 
-    bool internal;//internal or leaf
-
-    //internal nodes have
-    uint32_t base_predictor;//id of the base predictor
-    uint32_t left;//left child
-    uint32_t right;//right child
-    float norm_Eh;//the average margin at the node
-    double Eh;//total margin at the node
-    uint32_t n;//total events at the node
-
-    //leaf has
-    uint32_t max_count;//the number of samples of the most common label
-    uint32_t max_count_label;//the most common label
-  } node;
-  
-  struct log_multi
-  {
-    uint32_t k;	
-    
-    v_array<node> nodes;	
-    
-    size_t max_predictors;
-    size_t predictors_used;
-
-    bool progress;
-    uint32_t swap_resist;
-
-    uint32_t nbofswaps;
-  };	
-  
-  inline void init_leaf(node& n)
-  {
-    n.internal = false;
-    n.preds.erase();
-    n.base_predictor = 0;
-    n.norm_Eh = 0;
-    n.Eh = 0;
-    n.n = 0;
-    n.max_count = 0;
-    n.max_count_label = 1;
-    n.left = 0;
-    n.right = 0;
-  }
-
-  inline node init_node()	
-  {
-    node node; 
-    
-    node.parent = 0;
-    node.min_count = 0;
-    node.preds = v_init<node_pred>();
-    init_leaf(node);
-
-    return node;
-  }
-  
-  void init_tree(log_multi& d)
-  {
-    d.nodes.push_back(init_node());
-    d.nbofswaps = 0;
-  }
-
-  inline uint32_t min_left_right(log_multi& b, node& n)
-  {
-    return min(b.nodes[n.left].min_count, b.nodes[n.right].min_count);
-  }
-  
-  inline uint32_t find_switch_node(log_multi& b)	
-  {
-    uint32_t node = 0;
-    while(b.nodes[node].internal)
-      if(b.nodes[b.nodes[node].left].min_count 
-	 < b.nodes[b.nodes[node].right].min_count)
-	node = b.nodes[node].left; 
+      uint32_t nonswap_child;
+      if(swap_child == b.nodes[swap_parent].right)
+        nonswap_child = b.nodes[swap_parent].left;
       else
-	node = b.nodes[node].right;
-    return node;
-  }
-  
-  inline void update_min_count(log_multi& b, uint32_t node)	
-  {//Constant time min count update.    
-    while(node != 0)
-      {
-	uint32_t prev = node;
-	node = b.nodes[node].parent;
-	
-	if (b.nodes[node].min_count == b.nodes[prev].min_count)
-	  break;
-	else 
-	  b.nodes[node].min_count = min_left_right(b,b.nodes[node]);
-      }
-  }
+        nonswap_child = b.nodes[swap_parent].right;
 
-  void display_tree_dfs(log_multi& b, node node, uint32_t depth)
+      if(swap_parent == b.nodes[swap_grandparent].left)
+        b.nodes[swap_grandparent].left = nonswap_child;
+      else
+        b.nodes[swap_grandparent].right = nonswap_child;
+      b.nodes[nonswap_child].parent = swap_grandparent;
+      update_min_count(b, nonswap_child);
+
+      init_leaf(b.nodes[swap_child]);
+      left_child = swap_child;
+      b.nodes[current].base_predictor = b.nodes[swap_parent].base_predictor;
+      init_leaf(b.nodes[swap_parent]);
+      right_child = swap_parent;
+    }
+    b.nodes[current].left = left_child;
+    b.nodes[left_child].parent = current;
+    b.nodes[current].right = right_child;
+    b.nodes[right_child].parent = current;
+
+    b.nodes[left_child].min_count = b.nodes[current].min_count/2;
+    b.nodes[right_child].min_count = b.nodes[current].min_count - b.nodes[left_child].min_count;
+    update_min_count(b, left_child);
+
+    b.nodes[left_child].max_count_label = b.nodes[current].max_count_label;
+    b.nodes[right_child].max_count_label = b.nodes[current].max_count_label;
+
+    b.nodes[current].internal = true;
+  }
+  return b.nodes[current].internal;
+}
+
+void train_node(log_multi& b, base_learner& base, example& ec, uint32_t& current, uint32_t& class_index, uint32_t depth)
+{
+  if(b.nodes[current].norm_Eh > b.nodes[current].preds[class_index].norm_Ehk)
+    ec.l.simple.label = -1.f;
+  else
+    ec.l.simple.label = 1.f;
+
+  base.learn(ec, b.nodes[current].base_predictor);	// depth
+
+  ec.l.simple.label = FLT_MAX;
+  base.predict(ec, b.nodes[current].base_predictor); // depth
+
+  b.nodes[current].Eh += (double)ec.partial_prediction;
+  b.nodes[current].preds[class_index].Ehk += (double)ec.partial_prediction;
+  b.nodes[current].n++;
+  b.nodes[current].preds[class_index].nk++;
+
+  b.nodes[current].norm_Eh = (float)b.nodes[current].Eh / b.nodes[current].n;
+  b.nodes[current].preds[class_index].norm_Ehk = (float)b.nodes[current].preds[class_index].Ehk / b.nodes[current].preds[class_index].nk;
+}
+
+void verify_min_dfs(log_multi& b, node node)
+{
+  if (node.internal)
   {
-    for (uint32_t i = 0; i < depth; i++)
-      cout << "\t";
-    cout << node.min_count << " " << node.left
-	 << " " << node.right;
-    cout << " label = " << node.max_count_label << " labels = ";
-    for (size_t i = 0; i < node.preds.size(); i++)
-      cout << node.preds[i].label << ":" << node.preds[i].label_count << "\t";
-    cout << endl;
-    
-    if (node.internal)
-      {
-	cout << "Left";
-	display_tree_dfs(b, b.nodes[node.left], depth+1);
-	
-	cout << "Right";
-	display_tree_dfs(b, b.nodes[node.right], depth+1);
-      }	
+    if (node.min_count != min_left_right(b, node))
+    {
+      cout << "badness! " << endl;
+      display_tree_dfs(b, b.nodes[0], 0);
+    }
+    verify_min_dfs(b, b.nodes[node.left]);
+    verify_min_dfs(b, b.nodes[node.right]);
   }
+}
 
-  bool children(log_multi& b, uint32_t& current, uint32_t& class_index, uint32_t label)
+size_t sum_count_dfs(log_multi& b, node node)
+{
+  if (node.internal)
+    return sum_count_dfs(b, b.nodes[node.left]) + sum_count_dfs(b, b.nodes[node.right]);
+  else
+    return node.min_count;
+}
+
+inline uint32_t descend(node& n, float prediction)
+{
+  if (prediction < 0)
+    return n.left;
+  else
+    return n.right;
+}
+
+void predict(log_multi& b,  base_learner& base, example& ec)
+{
+  MULTICLASS::label_t mc = ec.l.multi;
+
+  ec.l.simple = {FLT_MAX, 0.f, 0.f};
+  uint32_t cn = 0;
+  uint32_t depth = 0;
+  while(b.nodes[cn].internal)
   {
-    class_index = (uint32_t)b.nodes[current].preds.unique_add_sorted(node_pred(label));
-    b.nodes[current].preds[class_index].label_count++;
-    
-    if(b.nodes[current].preds[class_index].label_count > b.nodes[current].max_count)
-      {
-	b.nodes[current].max_count = b.nodes[current].preds[class_index].label_count;
-	b.nodes[current].max_count_label = b.nodes[current].preds[class_index].label;
-      }
-
-    if (b.nodes[current].internal)
-      return true;
-    else if( b.nodes[current].preds.size() > 1 
-	     && (b.predictors_used < b.max_predictors 
-				     || b.nodes[current].min_count - b.nodes[current].max_count > b.swap_resist*(b.nodes[0].min_count + 1)))
-      { //need children and we can make them.
-	uint32_t left_child;
-	uint32_t right_child;
-	if (b.predictors_used < b.max_predictors)
-	  {
-	    left_child = (uint32_t)b.nodes.size();
-	    b.nodes.push_back(init_node());	
-	    right_child = (uint32_t)b.nodes.size();
-	    b.nodes.push_back(init_node());
-	    b.nodes[current].base_predictor = (uint32_t)b.predictors_used++;
-	  }
-	else
-	  {
-	    uint32_t swap_child = find_switch_node(b);
-	    uint32_t swap_parent = b.nodes[swap_child].parent;
-	    uint32_t swap_grandparent = b.nodes[swap_parent].parent;
-	    if (b.nodes[swap_child].min_count != b.nodes[0].min_count)
-	      cout << "glargh " << b.nodes[swap_child].min_count << " != " << b.nodes[0].min_count << endl;
-	    b.nbofswaps++;
-	    
-	    uint32_t nonswap_child;
-	    if(swap_child == b.nodes[swap_parent].right)
-	      nonswap_child = b.nodes[swap_parent].left;
-	    else
-	      nonswap_child = b.nodes[swap_parent].right;
-	    
-	    if(swap_parent == b.nodes[swap_grandparent].left)
-	      b.nodes[swap_grandparent].left = nonswap_child;
-	    else
-	      b.nodes[swap_grandparent].right = nonswap_child;
-	    b.nodes[nonswap_child].parent = swap_grandparent;
-	    update_min_count(b, nonswap_child);
-	    
-	    init_leaf(b.nodes[swap_child]);
-	    left_child = swap_child;
-	    b.nodes[current].base_predictor = b.nodes[swap_parent].base_predictor;
-	    init_leaf(b.nodes[swap_parent]);
-	    right_child = swap_parent;
-	  }
-	b.nodes[current].left = left_child;
-	b.nodes[left_child].parent = current;
-	b.nodes[current].right = right_child;
-	b.nodes[right_child].parent = current;
-	
-	b.nodes[left_child].min_count = b.nodes[current].min_count/2;
-	b.nodes[right_child].min_count = b.nodes[current].min_count - b.nodes[left_child].min_count;
-	update_min_count(b, left_child);
-
-	b.nodes[left_child].max_count_label = b.nodes[current].max_count_label;
-	b.nodes[right_child].max_count_label = b.nodes[current].max_count_label;
-
-	b.nodes[current].internal = true;
-      }
-    return b.nodes[current].internal;
+    base.predict(ec, b.nodes[cn].base_predictor); // depth
+    cn = descend(b.nodes[cn], ec.pred.scalar);
+    depth ++;
   }
-  
-  void train_node(log_multi& b, base_learner& base, example& ec, uint32_t& current, uint32_t& class_index, uint32_t depth)
-  {
-    if(b.nodes[current].norm_Eh > b.nodes[current].preds[class_index].norm_Ehk)
-      ec.l.simple.label = -1.f;
-    else
-      ec.l.simple.label = 1.f;
-    
-    base.learn(ec, b.nodes[current].base_predictor);	// depth
+  ec.pred.multiclass = b.nodes[cn].max_count_label;
+  ec.l.multi = mc;
+}
 
-    ec.l.simple.label = FLT_MAX;
-    base.predict(ec, b.nodes[current].base_predictor); // depth
-    
-    b.nodes[current].Eh += (double)ec.partial_prediction;
-    b.nodes[current].preds[class_index].Ehk += (double)ec.partial_prediction;
-    b.nodes[current].n++;
-    b.nodes[current].preds[class_index].nk++;	
-  
-    b.nodes[current].norm_Eh = (float)b.nodes[current].Eh / b.nodes[current].n;          
-    b.nodes[current].preds[class_index].norm_Ehk = (float)b.nodes[current].preds[class_index].Ehk / b.nodes[current].preds[class_index].nk;
-  }
-  
-  void verify_min_dfs(log_multi& b, node node)
-  {
-    if (node.internal)
-      {
-	if (node.min_count != min_left_right(b, node))
-	  {
-	    cout << "badness! " << endl;
-	    display_tree_dfs(b, b.nodes[0], 0);
-	  }
-	verify_min_dfs(b, b.nodes[node.left]);
-	verify_min_dfs(b, b.nodes[node.right]);
-      }
-  }
-  
-  size_t sum_count_dfs(log_multi& b, node node)
-  {
-    if (node.internal)
-      return sum_count_dfs(b, b.nodes[node.left]) + sum_count_dfs(b, b.nodes[node.right]);
-    else
-      return node.min_count;
-  }
+void learn(log_multi& b, base_learner& base, example& ec)
+{
+  //    verify_min_dfs(b, b.nodes[0]);
+  if (ec.l.multi.label == (uint32_t)-1 || b.progress)
+    predict(b,base,ec);
 
-  inline uint32_t descend(node& n, float prediction)
-  {
-    if (prediction < 0)
-      return n.left;
-    else
-      return n.right;
-  }
-
-  void predict(log_multi& b,  base_learner& base, example& ec)	
+  if(ec.l.multi.label != (uint32_t)-1)	//if training the tree
   {
     MULTICLASS::label_t mc = ec.l.multi;
+    uint32_t start_pred = ec.pred.multiclass;
 
-    ec.l.simple = {FLT_MAX, 0.f, 0.f};
+    uint32_t class_index = 0;
+    ec.l.simple = {FLT_MAX, mc.weight, 0.f};
     uint32_t cn = 0;
     uint32_t depth = 0;
-    while(b.nodes[cn].internal)
-      {
-	base.predict(ec, b.nodes[cn].base_predictor); // depth
-	cn = descend(b.nodes[cn], ec.pred.scalar);
-        depth ++;
-      }	
-    ec.pred.multiclass = b.nodes[cn].max_count_label;
+    while(children(b, cn, class_index, mc.label))
+    {
+      train_node(b, base, ec, cn, class_index, depth);
+      cn = descend(b.nodes[cn], ec.pred.scalar);
+      depth++;
+    }
+
+    b.nodes[cn].min_count++;
+    update_min_count(b, cn);
+    ec.pred.multiclass = start_pred;
     ec.l.multi = mc;
   }
+}
 
-  void learn(log_multi& b, base_learner& base, example& ec)
+void save_node_stats(log_multi& d)
+{
+  FILE *fp;
+  uint32_t i, j;
+  uint32_t total;
+  log_multi* b = &d;
+
+  fp = fopen("atxm_debug.csv", "wt");
+
+  for(i = 0; i < b->nodes.size(); i++)
   {
-    //    verify_min_dfs(b, b.nodes[0]);
-    if (ec.l.multi.label == (uint32_t)-1 || b.progress)
-      predict(b,base,ec);
-    
-    if(ec.l.multi.label != (uint32_t)-1)	//if training the tree
+    fprintf(fp, "Node: %4d, Internal: %1d, Eh: %7.4f, n: %6d, \n", (int) i, (int) b->nodes[i].internal, b->nodes[i].Eh / b->nodes[i].n, b->nodes[i].n);
+
+    fprintf(fp, "Label:, ");
+    for(j = 0; j < b->nodes[i].preds.size(); j++)
+    {
+      fprintf(fp, "%6d,", (int) b->nodes[i].preds[j].label);
+    }
+    fprintf(fp, "\n");
+
+    fprintf(fp, "Ehk:, ");
+    for(j = 0; j < b->nodes[i].preds.size(); j++)
+    {
+      fprintf(fp, "%7.4f,", b->nodes[i].preds[j].Ehk / b->nodes[i].preds[j].nk);
+    }
+    fprintf(fp, "\n");
+
+    total = 0;
+
+    fprintf(fp, "nk:, ");
+    for(j = 0; j < b->nodes[i].preds.size(); j++)
+    {
+      fprintf(fp, "%6d,", (int) b->nodes[i].preds[j].nk);
+      total += b->nodes[i].preds[j].nk;
+    }
+    fprintf(fp, "\n");
+
+    fprintf(fp, "max(lab:cnt:tot):, %3d,%6d,%7d,\n", (int) b->nodes[i].max_count_label, (int) b->nodes[i].max_count, (int) total);
+    fprintf(fp, "left: %4d, right: %4d", (int) b->nodes[i].left, (int) b->nodes[i].right);
+    fprintf(fp, "\n\n");
+  }
+
+  fclose(fp);
+}
+
+void finish(log_multi&)
+{
+  //save_node_stats(b);
+}
+
+void save_load_tree(log_multi& b, io_buf& model_file, bool read, bool text)
+{
+  if (model_file.files.size() > 0)
+  {
+    char buff[512];
+
+    uint32_t text_len = sprintf(buff, "k = %d ",b.k);
+    bin_text_read_write_fixed(model_file,(char*)&b.max_predictors, sizeof(b.k), "", read, buff, text_len, text);
+    uint32_t temp = (uint32_t)b.nodes.size();
+    text_len = sprintf(buff, "nodes = %d ",temp);
+    bin_text_read_write_fixed(model_file,(char*)&temp, sizeof(temp), "", read, buff, text_len, text);
+    if (read)
+      for (uint32_t j = 1; j < temp; j++)
+        b.nodes.push_back(init_node());
+    text_len = sprintf(buff, "max_predictors = %ld ",b.max_predictors);
+    bin_text_read_write_fixed(model_file,(char*)&b.max_predictors, sizeof(b.max_predictors), "", read, buff, text_len, text);
+
+    text_len = sprintf(buff, "predictors_used = %ld ",b.predictors_used);
+    bin_text_read_write_fixed(model_file,(char*)&b.predictors_used, sizeof(b.predictors_used), "", read, buff, text_len, text);
+
+    text_len = sprintf(buff, "progress = %d ",b.progress);
+    bin_text_read_write_fixed(model_file,(char*)&b.progress, sizeof(b.progress), "", read, buff, text_len, text);
+
+    text_len = sprintf(buff, "swap_resist = %d\n",b.swap_resist);
+    bin_text_read_write_fixed(model_file,(char*)&b.swap_resist, sizeof(b.swap_resist), "", read, buff, text_len, text);
+
+    for (size_t j = 0; j < b.nodes.size(); j++)
+    { //Need to read or write nodes.
+      node& n = b.nodes[j];
+      text_len = sprintf(buff, " parent = %d",n.parent);
+      bin_text_read_write_fixed(model_file,(char*)&n.parent, sizeof(n.parent), "", read, buff, text_len, text);
+
+      uint32_t temp = (uint32_t)n.preds.size();
+      text_len = sprintf(buff, " preds = %d",temp);
+      bin_text_read_write_fixed(model_file,(char*)&temp, sizeof(temp), "", read, buff, text_len, text);
+      if (read)
+        for (uint32_t k = 0; k < temp; k++)
+          n.preds.push_back(node_pred(1));
+
+      text_len = sprintf(buff, " min_count = %d",n.min_count);
+      bin_text_read_write_fixed(model_file,(char*)&n.min_count, sizeof(n.min_count), "", read, buff, text_len, text);
+
+      uint32_t text_len = sprintf(buff, " internal = %d",n.internal);
+      bin_text_read_write_fixed(model_file,(char*)&n.internal, sizeof(n.internal), "", read, buff, text_len, text)
+      ;
+
+      if (n.internal)
       {
-	MULTICLASS::label_t mc = ec.l.multi;
-	uint32_t start_pred = ec.pred.multiclass;
+        text_len = sprintf(buff, " base_predictor = %d",n.base_predictor);
+        bin_text_read_write_fixed(model_file,(char*)&n.base_predictor, sizeof(n.base_predictor), "", read, buff, text_len, text);
 
-	uint32_t class_index = 0;	
-	ec.l.simple = {FLT_MAX, mc.weight, 0.f};
-	uint32_t cn = 0;
-        uint32_t depth = 0;
-	while(children(b, cn, class_index, mc.label))
-	  {	    
-	    train_node(b, base, ec, cn, class_index, depth);
-	    cn = descend(b.nodes[cn], ec.pred.scalar);
-            depth++;
-	  }
-	
-	b.nodes[cn].min_count++;
-	update_min_count(b, cn);	
-	ec.pred.multiclass = start_pred;
-	ec.l.multi = mc;
+        text_len = sprintf(buff, " left = %d",n.left);
+        bin_text_read_write_fixed(model_file,(char*)&n.left, sizeof(n.left), "", read, buff, text_len, text);
+
+        text_len = sprintf(buff, " right = %d",n.right);
+        bin_text_read_write_fixed(model_file,(char*)&n.right, sizeof(n.right), "", read, buff, text_len, text);
+
+        text_len = sprintf(buff, " norm_Eh = %f",n.norm_Eh);
+        bin_text_read_write_fixed(model_file,(char*)&n.norm_Eh, sizeof(n.norm_Eh), "", read, buff, text_len, text);
+
+        text_len = sprintf(buff, " Eh = %f",n.Eh);
+        bin_text_read_write_fixed(model_file,(char*)&n.Eh, sizeof(n.Eh), "", read, buff, text_len, text);
+
+        text_len = sprintf(buff, " n = %d\n",n.n);
+        bin_text_read_write_fixed(model_file,(char*)&n.n, sizeof(n.n), "", read, buff, text_len, text);
       }
-  }
-  
-  void save_node_stats(log_multi& d)
-  {
-    FILE *fp;
-    uint32_t i, j;
-    uint32_t total;
-    log_multi* b = &d;
-    
-    fp = fopen("atxm_debug.csv", "wt");
-    
-    for(i = 0; i < b->nodes.size(); i++)
+      else
       {
-	fprintf(fp, "Node: %4d, Internal: %1d, Eh: %7.4f, n: %6d, \n", (int) i, (int) b->nodes[i].internal, b->nodes[i].Eh / b->nodes[i].n, b->nodes[i].n);
-	
-	fprintf(fp, "Label:, ");
-	for(j = 0; j < b->nodes[i].preds.size(); j++)
-	  {
-	    fprintf(fp, "%6d,", (int) b->nodes[i].preds[j].label);
-	  }	
-	fprintf(fp, "\n");
-	
-	fprintf(fp, "Ehk:, ");
-	for(j = 0; j < b->nodes[i].preds.size(); j++)
-	  {
-	    fprintf(fp, "%7.4f,", b->nodes[i].preds[j].Ehk / b->nodes[i].preds[j].nk);
-	  }	
-	fprintf(fp, "\n");
-	
-	total = 0;
-	
-	fprintf(fp, "nk:, ");
-	for(j = 0; j < b->nodes[i].preds.size(); j++)
-	  {
-	    fprintf(fp, "%6d,", (int) b->nodes[i].preds[j].nk);
-	    total += b->nodes[i].preds[j].nk;	
-	  }	
-	fprintf(fp, "\n");
-	
-	fprintf(fp, "max(lab:cnt:tot):, %3d,%6d,%7d,\n", (int) b->nodes[i].max_count_label, (int) b->nodes[i].max_count, (int) total);
-	fprintf(fp, "left: %4d, right: %4d", (int) b->nodes[i].left, (int) b->nodes[i].right);
-	fprintf(fp, "\n\n");
+        text_len = sprintf(buff, " max_count = %d",n.max_count);
+        bin_text_read_write_fixed(model_file,(char*)&n.max_count, sizeof(n.max_count), "", read, buff, text_len, text);
+        text_len = sprintf(buff, " max_count_label = %d\n",n.max_count_label);
+        bin_text_read_write_fixed(model_file,(char*)&n.max_count_label, sizeof(n.max_count_label), "", read, buff, text_len, text);
       }
-    
-    fclose(fp);
-  }	
-  
-  void finish(log_multi&)
-  {
-    //save_node_stats(b);
-  }
-  
-  void save_load_tree(log_multi& b, io_buf& model_file, bool read, bool text)
-  {
-    if (model_file.files.size() > 0)
-      {	
-	char buff[512];
-	
-	uint32_t text_len = sprintf(buff, "k = %d ",b.k);
-	bin_text_read_write_fixed(model_file,(char*)&b.max_predictors, sizeof(b.k), "", read, buff, text_len, text);
-	uint32_t temp = (uint32_t)b.nodes.size();
-	text_len = sprintf(buff, "nodes = %d ",temp);
-	bin_text_read_write_fixed(model_file,(char*)&temp, sizeof(temp), "", read, buff, text_len, text);
-	if (read)
-	  for (uint32_t j = 1; j < temp; j++)
-	    b.nodes.push_back(init_node());
-	text_len = sprintf(buff, "max_predictors = %ld ",b.max_predictors);
-	bin_text_read_write_fixed(model_file,(char*)&b.max_predictors, sizeof(b.max_predictors), "", read, buff, text_len, text);
 
-	text_len = sprintf(buff, "predictors_used = %ld ",b.predictors_used);
-	bin_text_read_write_fixed(model_file,(char*)&b.predictors_used, sizeof(b.predictors_used), "", read, buff, text_len, text);
+      for (size_t k = 0; k < n.preds.size(); k++)
+      {
+        node_pred& p = n.preds[k];
 
-	text_len = sprintf(buff, "progress = %d ",b.progress);
-	bin_text_read_write_fixed(model_file,(char*)&b.progress, sizeof(b.progress), "", read, buff, text_len, text);
-	
-	text_len = sprintf(buff, "swap_resist = %d\n",b.swap_resist);
-	bin_text_read_write_fixed(model_file,(char*)&b.swap_resist, sizeof(b.swap_resist), "", read, buff, text_len, text);
-	
-	for (size_t j = 0; j < b.nodes.size(); j++)
-	  {//Need to read or write nodes.
-	    node& n = b.nodes[j];
-	    text_len = sprintf(buff, " parent = %d",n.parent);
-	    bin_text_read_write_fixed(model_file,(char*)&n.parent, sizeof(n.parent), "", read, buff, text_len, text);
+        text_len = sprintf(buff, "  Ehk = %f",p.Ehk);
+        bin_text_read_write_fixed(model_file,(char*)&p.Ehk, sizeof(p.Ehk), "", read, buff, text_len, text);
 
-	    uint32_t temp = (uint32_t)n.preds.size();
-	    text_len = sprintf(buff, " preds = %d",temp);
-	    bin_text_read_write_fixed(model_file,(char*)&temp, sizeof(temp), "", read, buff, text_len, text);
-	    if (read)
-	      for (uint32_t k = 0; k < temp; k++)
-		n.preds.push_back(node_pred(1));
+        text_len = sprintf(buff, " norm_Ehk = %f",p.norm_Ehk);
+        bin_text_read_write_fixed(model_file,(char*)&p.norm_Ehk, sizeof(p.norm_Ehk), "", read, buff, text_len, text);
 
-	    text_len = sprintf(buff, " min_count = %d",n.min_count);
-	    bin_text_read_write_fixed(model_file,(char*)&n.min_count, sizeof(n.min_count), "", read, buff, text_len, text);
+        text_len = sprintf(buff, " nk = %d",p.nk);
+        bin_text_read_write_fixed(model_file,(char*)&p.nk, sizeof(p.nk), "", read, buff, text_len, text);
 
-	    uint32_t text_len = sprintf(buff, " internal = %d",n.internal);
-	    bin_text_read_write_fixed(model_file,(char*)&n.internal, sizeof(n.internal), "", read, buff, text_len, text)
-;
+        text_len = sprintf(buff, " label = %d",p.label);
+        bin_text_read_write_fixed(model_file,(char*)&p.label, sizeof(p.label), "", read, buff, text_len, text);
 
-	    if (n.internal)
-	      {
-		text_len = sprintf(buff, " base_predictor = %d",n.base_predictor);
-		bin_text_read_write_fixed(model_file,(char*)&n.base_predictor, sizeof(n.base_predictor), "", read, buff, text_len, text);
-
-		text_len = sprintf(buff, " left = %d",n.left);
-		bin_text_read_write_fixed(model_file,(char*)&n.left, sizeof(n.left), "", read, buff, text_len, text);
-		
-		text_len = sprintf(buff, " right = %d",n.right);
-		bin_text_read_write_fixed(model_file,(char*)&n.right, sizeof(n.right), "", read, buff, text_len, text);
-
-		text_len = sprintf(buff, " norm_Eh = %f",n.norm_Eh);
-		bin_text_read_write_fixed(model_file,(char*)&n.norm_Eh, sizeof(n.norm_Eh), "", read, buff, text_len, text);
-
-		text_len = sprintf(buff, " Eh = %f",n.Eh);
-		bin_text_read_write_fixed(model_file,(char*)&n.Eh, sizeof(n.Eh), "", read, buff, text_len, text);
-
-		text_len = sprintf(buff, " n = %d\n",n.n);
-		bin_text_read_write_fixed(model_file,(char*)&n.n, sizeof(n.n), "", read, buff, text_len, text);
-	      }
-	    else
-	      {
-		text_len = sprintf(buff, " max_count = %d",n.max_count);
-		bin_text_read_write_fixed(model_file,(char*)&n.max_count, sizeof(n.max_count), "", read, buff, text_len, text);
-		text_len = sprintf(buff, " max_count_label = %d\n",n.max_count_label);
-		bin_text_read_write_fixed(model_file,(char*)&n.max_count_label, sizeof(n.max_count_label), "", read, buff, text_len, text);		
-	      }
-
-	    for (size_t k = 0; k < n.preds.size(); k++)
-	      {
-		node_pred& p = n.preds[k];
-		
-		text_len = sprintf(buff, "  Ehk = %f",p.Ehk);
-		bin_text_read_write_fixed(model_file,(char*)&p.Ehk, sizeof(p.Ehk), "", read, buff, text_len, text);
-
-		text_len = sprintf(buff, " norm_Ehk = %f",p.norm_Ehk);
-		bin_text_read_write_fixed(model_file,(char*)&p.norm_Ehk, sizeof(p.norm_Ehk), "", read, buff, text_len, text);
-
-		text_len = sprintf(buff, " nk = %d",p.nk);
-		bin_text_read_write_fixed(model_file,(char*)&p.nk, sizeof(p.nk), "", read, buff, text_len, text);
-
-		text_len = sprintf(buff, " label = %d",p.label);
-		bin_text_read_write_fixed(model_file,(char*)&p.label, sizeof(p.label), "", read, buff, text_len, text);
-
-		text_len = sprintf(buff, " label_count = %d\n",p.label_count);
-		bin_text_read_write_fixed(model_file,(char*)&p.label_count, sizeof(p.label_count), "", read, buff, text_len, text);	
-	      }
-	  }
+        text_len = sprintf(buff, " label_count = %d\n",p.label_count);
+        bin_text_read_write_fixed(model_file,(char*)&p.label_count, sizeof(p.label_count), "", read, buff, text_len, text);
       }
+    }
   }
-  
+}
+
 base_learner* log_multi_setup(vw& all)	//learner setup
 {
   if (missing_option<size_t, true>(all, "log_multi", "Use online tree for multiclass"))
     return nullptr;
   new_options(all, "Logarithmic Time Multiclass options")
-    ("no_progress", "disable progressive validation")
-    ("swap_resistance", po::value<uint32_t>(), "higher = more resistance to swap, default=4");
+  ("no_progress", "disable progressive validation")
+  ("swap_resistance", po::value<uint32_t>(), "higher = more resistance to swap, default=4");
   add_options(all);
-  
+
   po::variables_map& vm = all.vm;
-  
+
   log_multi& data = calloc_or_die<log_multi>();
   data.k = (uint32_t)vm["log_multi"].as<size_t>();
   data.swap_resist = 4;
-  
+
   if (vm.count("swap_resistance"))
     data.swap_resist = vm["swap_resistance"].as<uint32_t>();
-  
+
   if (vm.count("no_progress"))
     data.progress = false;
   else
     data.progress = true;
-  
-  string loss_function = "quantile"; 
+
+  string loss_function = "quantile";
   float loss_parameter = 0.5;
   delete(all.loss);
   all.loss = getLossFunction(all, loss_function, loss_parameter);
-  
+
   data.max_predictors = data.k - 1;
-  init_tree(data);	
-  
+  init_tree(data);
+
   learner<log_multi>& l = init_multiclass_learner(&data, setup_base(all), learn, predict, all.p, data.max_predictors);
   l.set_save_load(save_load_tree);
   l.set_finish(finish);
-    
+
   return make_base(l);
 }

--- a/vowpalwabbit/loss_functions.h
+++ b/vowpalwabbit/loss_functions.h
@@ -13,24 +13,24 @@ struct vw;
 class loss_function {
 
 public :
-	/*
-	 * getLoss evaluates the example loss.
-	 * The function returns the loss value
-	 */
-	//virtual float getLoss(example *&ec, gd_vars &vars) = 0;
+  /*
+   * getLoss evaluates the example loss.
+   * The function returns the loss value
+   */
+  //virtual float getLoss(example *&ec, gd_vars &vars) = 0;
   virtual float getLoss(shared_data*, float prediction, float label) = 0;
 
-	/*
-	 * getUpdate evaluates the update scalar
-	 * The function return the update scalar
-	 */
-	virtual float getUpdate(float prediction, float label, float eta_t, float norm) = 0;
-	virtual float getUnsafeUpdate(float prediction, float label, float eta_t, float norm) = 0;
-	virtual float getRevertingWeight(shared_data*, float prediction, float eta_t) = 0;
-	virtual float getSquareGrad(float prediction, float label) = 0;
-	virtual float first_derivative(shared_data*, float prediction, float label) = 0;
-	virtual float second_derivative(shared_data*, float prediction, float label) = 0;
-	virtual ~loss_function() {};
+  /*
+   * getUpdate evaluates the update scalar
+   * The function return the update scalar
+   */
+  virtual float getUpdate(float prediction, float label, float eta_t, float norm) = 0;
+  virtual float getUnsafeUpdate(float prediction, float label, float eta_t, float norm) = 0;
+  virtual float getRevertingWeight(shared_data*, float prediction, float eta_t) = 0;
+  virtual float getSquareGrad(float prediction, float label) = 0;
+  virtual float first_derivative(shared_data*, float prediction, float label) = 0;
+  virtual float second_derivative(shared_data*, float prediction, float label) = 0;
+  virtual ~loss_function() {};
 };
 
 loss_function* getLossFunction(vw&, std::string funcName, float function_parameter = 0);

--- a/vowpalwabbit/lrq.cc
+++ b/vowpalwabbit/lrq.cc
@@ -19,10 +19,10 @@ struct LRQstate {
 bool valid_int (const char* s)
 {
   char* endptr;
-  
+
   int v = strtoul (s, &endptr, 0);
   (void) v;
-  
+
   return (*s != '\0' && *endptr == '\0');
 }
 
@@ -36,7 +36,7 @@ inline float
 cheesyrand (uint32_t x)
 {
   uint64_t seed = x;
-  
+
   return merand48 (seed);
 }
 
@@ -57,210 +57,210 @@ template <bool is_learn>
 void predict_or_learn(LRQstate& lrq, base_learner& base, example& ec)
 {
   vw& all = *lrq.all;
-  
+
   // Remember original features
-  
+
   memset (lrq.orig_size, 0, sizeof (lrq.orig_size));
   for (unsigned char* i = ec.indices.begin; i != ec.indices.end; ++i)
-    {
-      if (lrq.lrindices[*i])
-	lrq.orig_size[*i] = ec.atomics[*i].size ();
-    }
-  
+  {
+    if (lrq.lrindices[*i])
+      lrq.orig_size[*i] = ec.atomics[*i].size ();
+  }
+
   size_t which = ec.example_counter;
   float first_prediction = 0;
   float first_loss = 0;
   unsigned int maxiter = (is_learn && ! example_is_test (ec)) ? 2 : 1;
-  
+
   bool do_dropout = lrq.dropout && is_learn && ! example_is_test (ec);
   float scale = (! lrq.dropout || do_dropout) ? 1.f : 0.5f;
-  
+
   for (unsigned int iter = 0; iter < maxiter; ++iter, ++which)
+  {
+    // Add left LRQ features, holding right LRQ features fixed
+    //     and vice versa
+    // TODO: what happens with --lrq ab2 --lrq ac2
+    //       i.e. namespace occurs multiple times (?)
+
+    for (set<string>::iterator i = lrq.lrpairs.begin ();
+         i != lrq.lrpairs.end ();
+         ++i)
     {
-      // Add left LRQ features, holding right LRQ features fixed
-      //     and vice versa
-      // TODO: what happens with --lrq ab2 --lrq ac2
-      //       i.e. namespace occurs multiple times (?)
-      
-      for (set<string>::iterator i = lrq.lrpairs.begin ();
-           i != lrq.lrpairs.end ();
-           ++i)
+      unsigned char left = (*i)[which%2];
+      unsigned char right = (*i)[(which+1)%2];
+      unsigned int k = atoi (i->c_str () + 2);
+
+      for (unsigned int lfn = 0; lfn < lrq.orig_size[left]; ++lfn)
+      {
+        feature* lf = ec.atomics[left].begin + lfn;
+        float lfx = lf->x;
+        size_t lindex = lf->weight_index + ec.ft_offset;
+
+        for (unsigned int n = 1; n <= k; ++n)
+        {
+          if (! do_dropout || cheesyrbit (lrq.seed))
           {
-            unsigned char left = (*i)[which%2];
-            unsigned char right = (*i)[(which+1)%2];
-            unsigned int k = atoi (i->c_str () + 2);
+            uint32_t lwindex = (uint32_t)(lindex + (n << all.reg.stride_shift));
 
-            for (unsigned int lfn = 0; lfn < lrq.orig_size[left]; ++lfn)
+            float* lw = &all.reg.weight_vector[lwindex & all.reg.weight_mask];
+
+            // perturb away from saddle point at (0, 0)
+            if (is_learn && ! example_is_test (ec) && *lw == 0)
+              *lw = cheesyrand (lwindex);
+
+            for (unsigned int rfn = 0;
+                 rfn < lrq.orig_size[right];
+                 ++rfn)
+            {
+              feature* rf = ec.atomics[right].begin + rfn;
+              audit_data* ra = ec.audit_features[right].begin + rfn;
+
+              // NB: ec.ft_offset added by base learner
+              float rfx = rf->x;
+              size_t rindex = rf->weight_index;
+              uint32_t rwindex = (uint32_t)(rindex + (n << all.reg.stride_shift));
+
+              feature lrq;
+              lrq.x = scale * *lw * lfx * rfx;
+              lrq.weight_index = rwindex;
+
+              ec.atomics[right].push_back (lrq);
+
+              if (all.audit || all.hash_inv)
               {
-                feature* lf = ec.atomics[left].begin + lfn;
-                float lfx = lf->x;
-                size_t lindex = lf->weight_index + ec.ft_offset;
-    
-                for (unsigned int n = 1; n <= k; ++n)
-                  {
-                    if (! do_dropout || cheesyrbit (lrq.seed))
-                      {
-                        uint32_t lwindex = (uint32_t)(lindex + (n << all.reg.stride_shift));
+                std::stringstream new_feature_buffer;
 
-                        float* lw = &all.reg.weight_vector[lwindex & all.reg.weight_mask];
-
-                        // perturb away from saddle point at (0, 0)
-                        if (is_learn && ! example_is_test (ec) && *lw == 0)
-                          *lw = cheesyrand (lwindex);
-        
-                        for (unsigned int rfn = 0; 
-                             rfn < lrq.orig_size[right]; 
-                             ++rfn)
-                          {
-                            feature* rf = ec.atomics[right].begin + rfn;
-                            audit_data* ra = ec.audit_features[right].begin + rfn;
-
-                            // NB: ec.ft_offset added by base learner
-                            float rfx = rf->x;
-                            size_t rindex = rf->weight_index;
-                            uint32_t rwindex = (uint32_t)(rindex + (n << all.reg.stride_shift));
-        
-                            feature lrq; 
-                            lrq.x = scale * *lw * lfx * rfx;
-                            lrq.weight_index = rwindex; 
-
-                            ec.atomics[right].push_back (lrq);
-
-                            if (all.audit || all.hash_inv)
-                              {
-                                std::stringstream new_feature_buffer;
-
-                                new_feature_buffer << right << '^' 
-                                                   << ra->feature << '^'
-                                                   << n;
+                new_feature_buffer << right << '^'
+                                   << ra->feature << '^'
+                                   << n;
 
 #ifdef _WIN32
-								char* new_space = _strdup("lrq");
-								char* new_feature =	_strdup(new_feature_buffer.str().c_str());
+                char* new_space = _strdup("lrq");
+                char* new_feature =	_strdup(new_feature_buffer.str().c_str());
 #else
-								char* new_space = strdup("lrq");
-								char* new_feature = strdup(new_feature_buffer.str().c_str());
+                char* new_space = strdup("lrq");
+                char* new_feature = strdup(new_feature_buffer.str().c_str());
 #endif
 
-                                audit_data ad = { new_space, new_feature, lrq.weight_index, lrq.x, true };
-                                ec.audit_features[right].push_back (ad);
-                              }
-                          }
-                      }
-                  }
+                audit_data ad = { new_space, new_feature, lrq.weight_index, lrq.x, true };
+                ec.audit_features[right].push_back (ad);
               }
+            }
           }
-
-	if (is_learn)
-	  base.learn(ec);
-	else
-	  base.predict(ec);
-
-        // Restore example
-        if (iter == 0)
-          {
-            first_prediction = ec.pred.scalar;
-            first_loss = ec.loss;
-          }
-        else
-          {
-            ec.pred.scalar = first_prediction;
-            ec.loss = first_loss;
-          }
-
-        for (set<string>::iterator i = lrq.lrpairs.begin ();
-             i != lrq.lrpairs.end ();
-             ++i)
-          {
-            unsigned char right = (*i)[(which+1)%2];
-
-            ec.atomics[right].end = 
-              ec.atomics[right].begin + lrq.orig_size[right];
-
-            if (all.audit || all.hash_inv)
-              {
-                for (audit_data* a = ec.audit_features[right].begin + lrq.orig_size[right];
-                     a < ec.audit_features[right].end;
-                     ++a)
-                  {
-                    free (a->space);
-                    free (a->feature);
-                  }
-
-                ec.audit_features[right].end = 
-                  ec.audit_features[right].begin + lrq.orig_size[right];
-              }
-          }
-      }
-  }
-
-  base_learner* lrq_setup(vw& all)
-  {//parse and set arguments
-    if (missing_option<vector<string>>(all, "lrq", "use low rank quadratic features"))
-      return nullptr;
-    new_options(all, "Lrq options")
-      ("lrqdropout", "use dropout training for low rank quadratic features");
-    add_options(all);
-
-    if(!all.vm.count("lrq"))
-      return nullptr;
-
-    LRQstate& lrq = calloc_or_die<LRQstate>();
-    size_t maxk = 0;
-    lrq.all = &all;
-    new(&lrq.lrpairs) 
-      std::set<std::string> (all.vm["lrq"].as<vector<string> > ().begin (),
-                             all.vm["lrq"].as<vector<string> > ().end ());
-     
-    lrq.initial_seed = lrq.seed = all.random_seed | 8675309;
-    if (all.vm.count("lrqdropout")) 
-      {
-        lrq.dropout = true;
-        *all.file_options << " --lrqdropout ";
-      }
-    else
-      lrq.dropout = false;
-    
-    for (set<string>::iterator i = lrq.lrpairs.begin (); 
-         i != lrq.lrpairs.end (); 
-         ++i)
-      *all.file_options << " --lrq " << *i;
-    
-    if (! all.quiet)
-      {
-        cerr << "creating low rank quadratic features for pairs: ";
-        if (lrq.dropout)
-          cerr << "(using dropout) ";
-      }
-
-    for (set<string>::iterator i = lrq.lrpairs.begin (); 
-         i != lrq.lrpairs.end (); 
-         ++i)
-      {
-        if(!all.quiet){
-          if (( i->length() < 3 ) || ! valid_int (i->c_str () + 2)) 
-	    THROW("error, low-rank quadratic features must involve two sets and a rank.");
-
-          cerr << *i << " ";
         }
-        // TODO: colon-syntax
-        
-        unsigned int k = atoi (i->c_str () + 2);
-
-        lrq.lrindices[(int) (*i)[0]] = 1;
-        lrq.lrindices[(int) (*i)[1]] = 1;
-
-        maxk = max (maxk, k);
       }
+    }
 
-    if(!all.quiet)
-      cerr<<endl;
-        
-	all.wpp = all.wpp * (uint32_t)(1 + maxk);
-    learner<LRQstate>& l = init_learner(&lrq, setup_base(all), predict_or_learn<true>, 
-					predict_or_learn<false>, 1 + maxk);
-    l.set_end_pass(reset_seed);
+    if (is_learn)
+      base.learn(ec);
+    else
+      base.predict(ec);
 
-    // TODO: leaks memory ?
-    return make_base(l);
+    // Restore example
+    if (iter == 0)
+    {
+      first_prediction = ec.pred.scalar;
+      first_loss = ec.loss;
+    }
+    else
+    {
+      ec.pred.scalar = first_prediction;
+      ec.loss = first_loss;
+    }
+
+    for (set<string>::iterator i = lrq.lrpairs.begin ();
+         i != lrq.lrpairs.end ();
+         ++i)
+    {
+      unsigned char right = (*i)[(which+1)%2];
+
+      ec.atomics[right].end =
+        ec.atomics[right].begin + lrq.orig_size[right];
+
+      if (all.audit || all.hash_inv)
+      {
+        for (audit_data* a = ec.audit_features[right].begin + lrq.orig_size[right];
+             a < ec.audit_features[right].end;
+             ++a)
+        {
+          free (a->space);
+          free (a->feature);
+        }
+
+        ec.audit_features[right].end =
+          ec.audit_features[right].begin + lrq.orig_size[right];
+      }
+    }
   }
+}
+
+base_learner* lrq_setup(vw& all)
+{ //parse and set arguments
+  if (missing_option<vector<string>>(all, "lrq", "use low rank quadratic features"))
+    return nullptr;
+  new_options(all, "Lrq options")
+  ("lrqdropout", "use dropout training for low rank quadratic features");
+  add_options(all);
+
+  if(!all.vm.count("lrq"))
+    return nullptr;
+
+  LRQstate& lrq = calloc_or_die<LRQstate>();
+  size_t maxk = 0;
+  lrq.all = &all;
+  new(&lrq.lrpairs)
+  std::set<std::string> (all.vm["lrq"].as<vector<string> > ().begin (),
+                         all.vm["lrq"].as<vector<string> > ().end ());
+
+  lrq.initial_seed = lrq.seed = all.random_seed | 8675309;
+  if (all.vm.count("lrqdropout"))
+  {
+    lrq.dropout = true;
+    *all.file_options << " --lrqdropout ";
+  }
+  else
+    lrq.dropout = false;
+
+  for (set<string>::iterator i = lrq.lrpairs.begin ();
+       i != lrq.lrpairs.end ();
+       ++i)
+    *all.file_options << " --lrq " << *i;
+
+  if (! all.quiet)
+  {
+    cerr << "creating low rank quadratic features for pairs: ";
+    if (lrq.dropout)
+      cerr << "(using dropout) ";
+  }
+
+  for (set<string>::iterator i = lrq.lrpairs.begin ();
+       i != lrq.lrpairs.end ();
+       ++i)
+  {
+    if(!all.quiet) {
+      if (( i->length() < 3 ) || ! valid_int (i->c_str () + 2))
+        THROW("error, low-rank quadratic features must involve two sets and a rank.");
+
+      cerr << *i << " ";
+    }
+    // TODO: colon-syntax
+
+    unsigned int k = atoi (i->c_str () + 2);
+
+    lrq.lrindices[(int) (*i)[0]] = 1;
+    lrq.lrindices[(int) (*i)[1]] = 1;
+
+    maxk = max (maxk, k);
+  }
+
+  if(!all.quiet)
+    cerr<<endl;
+
+  all.wpp = all.wpp * (uint32_t)(1 + maxk);
+  learner<LRQstate>& l = init_learner(&lrq, setup_base(all), predict_or_learn<true>,
+                                      predict_or_learn<false>, 1 + maxk);
+  l.set_end_pass(reset_seed);
+
+  // TODO: leaks memory ?
+  return make_base(l);
+}

--- a/vowpalwabbit/main.cc
+++ b/vowpalwabbit/main.cc
@@ -21,73 +21,73 @@ int main(int argc, char *argv[])
 {
   try {
     vw& all = parse_args(argc, argv);
-	io_buf model;
-	parse_regressor_args(all, model);
-	parse_modules(all, model);
-	parse_sources(all, model);
+    io_buf model;
+    parse_regressor_args(all, model);
+    parse_modules(all, model);
+    parse_sources(all, model);
 
     all.vw_is_main = true;
     struct timeb t_start, t_end;
     ftime(&t_start);
-    
+
     if (!all.quiet && !all.bfgs && !all.searchstr)
-        {
-        	std::cerr << std::left
-        	          << std::setw(shared_data::col_avg_loss) << std::left << "average"
-        		  << " "
-        		  << std::setw(shared_data::col_since_last) << std::left << "since"
-        		  << " "
-			  << std::right
-        		  << std::setw(shared_data::col_example_counter) << "example"
-        		  << " "
-        		  << std::setw(shared_data::col_example_weight) << "example"
-        		  << " "
-        		  << std::setw(shared_data::col_current_label) << "current"
-        		  << " "
-        		  << std::setw(shared_data::col_current_predict) << "current"
-        		  << " "
-        		  << std::setw(shared_data::col_current_features) << "current"
-        		  << std::endl;
-        	std::cerr << std::left
-        	          << std::setw(shared_data::col_avg_loss) << std::left << "loss"
-        		  << " "
-        		  << std::setw(shared_data::col_since_last) << std::left << "last"
-        		  << " "
-			  << std::right
-        		  << std::setw(shared_data::col_example_counter) << "counter"
-        		  << " "
-        		  << std::setw(shared_data::col_example_weight) << "weight"
-        		  << " "
-        		  << std::setw(shared_data::col_current_label) << "label"
-        		  << " "
-        		  << std::setw(shared_data::col_current_predict) << "predict"
-        		  << " "
-        		  << std::setw(shared_data::col_current_features) << "features"
-        		  << std::endl;
-        }
+    {
+      std::cerr << std::left
+                << std::setw(shared_data::col_avg_loss) << std::left << "average"
+                << " "
+                << std::setw(shared_data::col_since_last) << std::left << "since"
+                << " "
+                << std::right
+                << std::setw(shared_data::col_example_counter) << "example"
+                << " "
+                << std::setw(shared_data::col_example_weight) << "example"
+                << " "
+                << std::setw(shared_data::col_current_label) << "current"
+                << " "
+                << std::setw(shared_data::col_current_predict) << "current"
+                << " "
+                << std::setw(shared_data::col_current_features) << "current"
+                << std::endl;
+      std::cerr << std::left
+                << std::setw(shared_data::col_avg_loss) << std::left << "loss"
+                << " "
+                << std::setw(shared_data::col_since_last) << std::left << "last"
+                << " "
+                << std::right
+                << std::setw(shared_data::col_example_counter) << "counter"
+                << " "
+                << std::setw(shared_data::col_example_weight) << "weight"
+                << " "
+                << std::setw(shared_data::col_current_label) << "label"
+                << " "
+                << std::setw(shared_data::col_current_predict) << "predict"
+                << " "
+                << std::setw(shared_data::col_current_features) << "features"
+                << std::endl;
+    }
 
     VW::start_parser(all);
     LEARNER::generic_driver(all);
     VW::end_parser(all);
 
     ftime(&t_end);
-    double net_time = (int) (1000.0 * (t_end.time - t_start.time) + (t_end.millitm - t_start.millitm)); 
+    double net_time = (int) (1000.0 * (t_end.time - t_start.time) + (t_end.millitm - t_start.millitm));
     if(!all.quiet && all.span_server != "")
-        cerr<<"Net time taken by process = "<<net_time/(double)(1000)<<" seconds\n";
+      cerr<<"Net time taken by process = "<<net_time/(double)(1000)<<" seconds\n";
 
     if(all.span_server != "") {
-        float loss = (float)all.sd->sum_loss;
-        all.sd->sum_loss = (double)accumulate_scalar(all, all.span_server, loss);
-        float weighted_examples = (float)all.sd->weighted_examples;
-        all.sd->weighted_examples = (double)accumulate_scalar(all, all.span_server, weighted_examples);
-        float weighted_labels = (float)all.sd->weighted_labels;
-        all.sd->weighted_labels = (double)accumulate_scalar(all, all.span_server, weighted_labels);
-        float weighted_unlabeled_examples = (float)all.sd->weighted_unlabeled_examples;
-        all.sd->weighted_unlabeled_examples = (double)accumulate_scalar(all, all.span_server, weighted_unlabeled_examples);
-        float example_number = (float)all.sd->example_number;
-        all.sd->example_number = (uint64_t)accumulate_scalar(all, all.span_server, example_number);
-        float total_features = (float)all.sd->total_features;
-        all.sd->total_features = (uint64_t)accumulate_scalar(all, all.span_server, total_features);
+      float loss = (float)all.sd->sum_loss;
+      all.sd->sum_loss = (double)accumulate_scalar(all, all.span_server, loss);
+      float weighted_examples = (float)all.sd->weighted_examples;
+      all.sd->weighted_examples = (double)accumulate_scalar(all, all.span_server, weighted_examples);
+      float weighted_labels = (float)all.sd->weighted_labels;
+      all.sd->weighted_labels = (double)accumulate_scalar(all, all.span_server, weighted_labels);
+      float weighted_unlabeled_examples = (float)all.sd->weighted_unlabeled_examples;
+      all.sd->weighted_unlabeled_examples = (double)accumulate_scalar(all, all.span_server, weighted_unlabeled_examples);
+      float example_number = (float)all.sd->example_number;
+      all.sd->example_number = (uint64_t)accumulate_scalar(all, all.span_server, example_number);
+      float total_features = (float)all.sd->total_features;
+      all.sd->total_features = (uint64_t)accumulate_scalar(all, all.span_server, total_features);
     }
 
     VW::finish(all);

--- a/vowpalwabbit/memory.h
+++ b/vowpalwabbit/memory.h
@@ -7,18 +7,22 @@ T* calloc_or_die(size_t nmemb)
 {
   if (nmemb == 0)
     return nullptr;
-  
+
   void* data = calloc(nmemb, sizeof(T));
   if (data == nullptr) {
     const char* msg = "internal error: memory allocation failed; dying!";
-	// use low-level function since we're already out of memory.
-	fputs(msg, stderr);
+    // use low-level function since we're already out of memory.
+    fputs(msg, stderr);
     THROW(msg);
   }
   return (T*)data;
 }
 
 template<class T> T& calloc_or_die()
-{ return *calloc_or_die<T>(1); }
+{
+  return *calloc_or_die<T>(1);
+}
 
-inline void free_it(void* ptr) { if (ptr != nullptr) free(ptr); }
+inline void free_it(void* ptr) {
+  if (ptr != nullptr) free(ptr);
+}

--- a/vowpalwabbit/mf.cc
+++ b/vowpalwabbit/mf.cc
@@ -68,25 +68,25 @@ void predict(mf& data, base_learner& base, example& ec) {
     if (ec.atomics[left_ns].size() > 0 && ec.atomics[right_ns].size() > 0) {
       for (size_t k = 1; k <= data.rank; k++) {
 
-	ec.indices[0] = left_ns;
+        ec.indices[0] = left_ns;
 
-	// compute l^k * x_l using base learner
-	base.predict(ec, k);
-	float x_dot_l = ec.partial_prediction;
-	if (cache_sub_predictions)
-	  data.sub_predictions[2*k-1] = x_dot_l;
+        // compute l^k * x_l using base learner
+        base.predict(ec, k);
+        float x_dot_l = ec.partial_prediction;
+        if (cache_sub_predictions)
+          data.sub_predictions[2*k-1] = x_dot_l;
 
-	// set example to right namespace only
-	ec.indices[0] = right_ns;
+        // set example to right namespace only
+        ec.indices[0] = right_ns;
 
-	// compute r^k * x_r using base learner
-	base.predict(ec, k + data.rank);
-	float x_dot_r = ec.partial_prediction;
-	if (cache_sub_predictions)
-	  data.sub_predictions[2*k] = x_dot_r;
+        // compute r^k * x_r using base learner
+        base.predict(ec, k + data.rank);
+        float x_dot_r = ec.partial_prediction;
+        if (cache_sub_predictions)
+          data.sub_predictions[2*k] = x_dot_r;
 
-	// accumulate prediction
-	prediction += (x_dot_l * x_dot_r);
+        // accumulate prediction
+        prediction += (x_dot_l * x_dot_r);
       }
     }
   }
@@ -131,20 +131,20 @@ void learn(mf& data, base_learner& base, example& ec) {
 
       for (size_t k = 1; k <= data.rank; k++) {
 
-	// multiply features in left namespace by r^k * x_r
-	for (feature* f = ec.atomics[left_ns].begin; f != ec.atomics[left_ns].end; f++)
-	  f->x *= data.sub_predictions[2*k];
+        // multiply features in left namespace by r^k * x_r
+        for (feature* f = ec.atomics[left_ns].begin; f != ec.atomics[left_ns].end; f++)
+          f->x *= data.sub_predictions[2*k];
 
-	// update l^k using base learner
-	base.update(ec, k);
+        // update l^k using base learner
+        base.update(ec, k);
 
-	// restore left namespace features (undoing multiply)
-	copy_array(ec.atomics[left_ns], data.temp_features);
+        // restore left namespace features (undoing multiply)
+        copy_array(ec.atomics[left_ns], data.temp_features);
 
-	// compute new l_k * x_l scaling factors
-	// base.predict(ec, k);
-	// data.sub_predictions[2*k-1] = ec.partial_prediction;
-	// ec.pred.scalar = ec.updated_prediction;
+        // compute new l_k * x_l scaling factors
+        // base.predict(ec, k);
+        // data.sub_predictions[2*k-1] = ec.partial_prediction;
+        // ec.pred.scalar = ec.updated_prediction;
       }
 
       // set example to right namespace only
@@ -155,16 +155,16 @@ void learn(mf& data, base_learner& base, example& ec) {
 
       for (size_t k = 1; k <= data.rank; k++) {
 
-	// multiply features in right namespace by l^k * x_l
-	for (feature* f = ec.atomics[right_ns].begin; f != ec.atomics[right_ns].end; f++)
-	  f->x *= data.sub_predictions[2*k-1];
+        // multiply features in right namespace by l^k * x_l
+        for (feature* f = ec.atomics[right_ns].begin; f != ec.atomics[right_ns].end; f++)
+          f->x *= data.sub_predictions[2*k-1];
 
-	// update r^k using base learner
-	base.update(ec, k + data.rank);
-	ec.pred.scalar = ec.updated_prediction;
+        // update r^k using base learner
+        base.update(ec, k + data.rank);
+        ec.pred.scalar = ec.updated_prediction;
 
-	// restore right namespace features
-	copy_array(ec.atomics[right_ns], data.temp_features);
+        // restore right namespace features
+        copy_array(ec.atomics[right_ns], data.temp_features);
       }
     }
   }
@@ -184,22 +184,22 @@ void finish(mf& o) {
   o.sub_predictions.delete_v();
 }
 
-  base_learner* mf_setup(vw& all) {
-    if (missing_option<size_t, true>(all, "new_mf", "rank for reduction-based matrix factorization")) 
-      return nullptr;
-    
-    mf& data = calloc_or_die<mf>();
-    data.all = &all;
-    data.rank = (uint32_t)all.vm["new_mf"].as<size_t>();
-    
-    // store global pairs in local data structure and clear global pairs
-    // for eventual calls to base learner
-    data.pairs = all.pairs;
-    all.pairs.clear();
-    
-    all.random_positive_weights = true;
-    
-    learner<mf>& l = init_learner(&data, setup_base(all), learn, predict<false>, 2*data.rank+1);
-    l.set_finish(finish);
-    return make_base(l);
-  }
+base_learner* mf_setup(vw& all) {
+  if (missing_option<size_t, true>(all, "new_mf", "rank for reduction-based matrix factorization"))
+    return nullptr;
+
+  mf& data = calloc_or_die<mf>();
+  data.all = &all;
+  data.rank = (uint32_t)all.vm["new_mf"].as<size_t>();
+
+  // store global pairs in local data structure and clear global pairs
+  // for eventual calls to base learner
+  data.pairs = all.pairs;
+  all.pairs.clear();
+
+  all.random_positive_weights = true;
+
+  learner<mf>& l = init_learner(&data, setup_base(all), learn, predict<false>, 2*data.rank+1);
+  l.set_finish(finish);
+  return make_base(l);
+}

--- a/vowpalwabbit/multiclass.cc
+++ b/vowpalwabbit/multiclass.cc
@@ -6,123 +6,124 @@
 
 namespace MULTICLASS {
 
-  char* bufread_label(label_t* ld, char* c)
-  {
-    memcpy(&ld->label, c, sizeof(ld->label));
-    c += sizeof(ld->label);
-    memcpy(&ld->weight, c, sizeof(ld->weight));
-    c += sizeof(ld->weight);
-    return c;
-  }
-  
-  size_t read_cached_label(shared_data*, void* v, io_buf& cache)
-  {
-    label_t* ld = (label_t*) v;
-    char *c;
-    size_t total = sizeof(ld->label)+sizeof(ld->weight);
-    if (buf_read(cache, c, total) < total) 
-      return 0;
-    c = bufread_label(ld,c);
-    
-    return total;
-  }
-  
-  float weight(void* v)
-  {
-    label_t* ld = (label_t*) v;
-    return (ld->weight > 0) ? ld->weight : 0.f;
-  }
-  
-  char* bufcache_label(label_t* ld, char* c)
-  {
-    memcpy(c, &ld->label, sizeof(ld->label));
-    c += sizeof(ld->label);
-    memcpy(c, &ld->weight, sizeof(ld->weight));
-    c += sizeof(ld->weight);
-    return c;
-  }
+char* bufread_label(label_t* ld, char* c)
+{
+  memcpy(&ld->label, c, sizeof(ld->label));
+  c += sizeof(ld->label);
+  memcpy(&ld->weight, c, sizeof(ld->weight));
+  c += sizeof(ld->weight);
+  return c;
+}
 
-  void cache_label(void* v, io_buf& cache)
-  {
-    char *c;
-    label_t* ld = (label_t*) v;
-    buf_write(cache, c, sizeof(ld->label)+sizeof(ld->weight));
-    c = bufcache_label(ld,c);
+size_t read_cached_label(shared_data*, void* v, io_buf& cache)
+{
+  label_t* ld = (label_t*) v;
+  char *c;
+  size_t total = sizeof(ld->label)+sizeof(ld->weight);
+  if (buf_read(cache, c, total) < total)
+    return 0;
+  c = bufread_label(ld,c);
+
+  return total;
+}
+
+float weight(void* v)
+{
+  label_t* ld = (label_t*) v;
+  return (ld->weight > 0) ? ld->weight : 0.f;
+}
+
+char* bufcache_label(label_t* ld, char* c)
+{
+  memcpy(c, &ld->label, sizeof(ld->label));
+  c += sizeof(ld->label);
+  memcpy(c, &ld->weight, sizeof(ld->weight));
+  c += sizeof(ld->weight);
+  return c;
+}
+
+void cache_label(void* v, io_buf& cache)
+{
+  char *c;
+  label_t* ld = (label_t*) v;
+  buf_write(cache, c, sizeof(ld->label)+sizeof(ld->weight));
+  c = bufcache_label(ld,c);
+}
+
+void default_label(void* v)
+{
+  label_t* ld = (label_t*) v;
+  ld->label = (uint32_t)-1;
+  ld->weight = 1.;
+}
+
+void delete_label(void*) {}
+
+void parse_label(parser*, shared_data*sd, void* v, v_array<substring>& words)
+{
+  label_t* ld = (label_t*)v;
+
+  switch(words.size()) {
+  case 0:
+    break;
+  case 1:
+    ld->label = sd->ldict ? sd->ldict->get(words[0]) : int_of_substring(words[0]);
+    ld->weight = 1.0;
+    break;
+  case 2:
+    ld->label = sd->ldict ? sd->ldict->get(words[0]) : int_of_substring(words[0]);
+    ld->weight = float_of_substring(words[1]);
+    break;
+  default:
+    cerr << "malformed example!\n";
+    cerr << "words.size() = " << words.size() << endl;
   }
+  if (ld->label == 0)
+    THROW("label 0 is not allowed for multiclass.  Valid labels are {1,k}" << (sd->ldict ? "\nthis likely happened because you specified an invalid label with named labels" : ""));
+}
 
-  void default_label(void* v)
+label_parser mc_label = {default_label, parse_label,
+                         cache_label, read_cached_label,
+                         delete_label, weight,
+                         nullptr,
+                         sizeof(label_t)
+                        };
+
+void print_update(vw& all, example &ec)
+{
+  if (all.sd->weighted_examples >= all.sd->dump_interval && !all.quiet && !all.bfgs)
   {
-    label_t* ld = (label_t*) v;
-    ld->label = (uint32_t)-1;
-    ld->weight = 1.;
-  }
-
-  void delete_label(void*) {}
-
-  void parse_label(parser*, shared_data*sd, void* v, v_array<substring>& words)
-  {
-    label_t* ld = (label_t*)v;
-
-    switch(words.size()) {
-    case 0:
-      break;
-    case 1:
-      ld->label = sd->ldict ? sd->ldict->get(words[0]) : int_of_substring(words[0]);
-      ld->weight = 1.0;
-      break;
-    case 2:
-      ld->label = sd->ldict ? sd->ldict->get(words[0]) : int_of_substring(words[0]);
-      ld->weight = float_of_substring(words[1]);
-      break;
-    default:
-      cerr << "malformed example!\n";
-      cerr << "words.size() = " << words.size() << endl;
+    if (! all.sd->ldict)
+      all.sd->print_update(all.holdout_set_off, all.current_pass, ec.l.multi.label, ec.pred.multiclass,
+                           ec.num_features, all.progress_add, all.progress_arg);
+    else {
+      substring ss_label = all.sd->ldict->get(ec.l.multi.label);
+      substring ss_pred  = all.sd->ldict->get(ec.pred.multiclass);
+      all.sd->print_update(all.holdout_set_off, all.current_pass,
+                           !ss_label.begin ? "unknown" : string(ss_label.begin, ss_label.end - ss_label.begin),
+                           !ss_pred.begin  ? "unknown" : string(ss_pred.begin, ss_pred.end - ss_pred.begin),
+                           ec.num_features, all.progress_add, all.progress_arg);
     }
-    if (ld->label == 0)
-      THROW("label 0 is not allowed for multiclass.  Valid labels are {1,k}" << (sd->ldict ? "\nthis likely happened because you specified an invalid label with named labels" : ""));
   }
+}
 
-  label_parser mc_label = {default_label, parse_label, 
-				  cache_label, read_cached_label, 
-				  delete_label, weight, 
-				  nullptr,
-				  sizeof(label_t)};
-  
-  void print_update(vw& all, example &ec)
-  {
-    if (all.sd->weighted_examples >= all.sd->dump_interval && !all.quiet && !all.bfgs)
-      {
-        if (! all.sd->ldict)
-	all.sd->print_update(all.holdout_set_off, all.current_pass, ec.l.multi.label, ec.pred.multiclass,
-			     ec.num_features, all.progress_add, all.progress_arg);
-        else {
-          substring ss_label = all.sd->ldict->get(ec.l.multi.label);
-          substring ss_pred  = all.sd->ldict->get(ec.pred.multiclass);
-          all.sd->print_update(all.holdout_set_off, all.current_pass,
-                               !ss_label.begin ? "unknown" : string(ss_label.begin, ss_label.end - ss_label.begin),
-                               !ss_pred.begin  ? "unknown" : string(ss_pred.begin, ss_pred.end - ss_pred.begin),
-                               ec.num_features, all.progress_add, all.progress_arg);
-      }
-  }
-  }
+void finish_example(vw& all, example& ec)
+{
+  float loss = 0;
+  if (ec.l.multi.label != (uint32_t)ec.pred.multiclass)
+    loss = ec.l.multi.weight;
 
-  void finish_example(vw& all, example& ec)
-  {
-    float loss = 0;
-    if (ec.l.multi.label != (uint32_t)ec.pred.multiclass)
-      loss = ec.l.multi.weight;
-    
-    all.sd->update(ec.test_only, loss, ec.l.multi.weight, ec.num_features);
-    
-    for (int* sink = all.final_prediction_sink.begin; sink != all.final_prediction_sink.end; sink++)
-      if (! all.sd->ldict)
+  all.sd->update(ec.test_only, loss, ec.l.multi.weight, ec.num_features);
+
+  for (int* sink = all.final_prediction_sink.begin; sink != all.final_prediction_sink.end; sink++)
+    if (! all.sd->ldict)
       all.print(*sink, (float)ec.pred.multiclass, 0, ec.tag);
-      else {
-        substring ss_pred = all.sd->ldict->get(ec.pred.multiclass);
-        all.print_text(*sink, string(ss_pred.begin, ss_pred.end - ss_pred.begin), ec.tag);
-      }
-    
-    MULTICLASS::print_update(all, ec);
-    VW::finish_example(all, &ec);
-  }
+    else {
+      substring ss_pred = all.sd->ldict->get(ec.pred.multiclass);
+      all.print_text(*sink, string(ss_pred.begin, ss_pred.end - ss_pred.begin), ec.tag);
+    }
+
+  MULTICLASS::print_update(all, ec);
+  VW::finish_example(all, &ec);
+}
 }

--- a/vowpalwabbit/multiclass.h
+++ b/vowpalwabbit/multiclass.h
@@ -11,17 +11,21 @@ struct vw;
 
 namespace MULTICLASS
 {
-  struct label_t {
-    uint32_t label;
-    float weight;
-  };
-  
-  extern label_parser mc_label;
-  
-  void finish_example(vw& all, example& ec);
+struct label_t {
+  uint32_t label;
+  float weight;
+};
 
-  template <class T> void finish_example(vw& all, T&, example& ec) { finish_example(all, ec); }
+extern label_parser mc_label;
 
-  inline bool label_is_test(label_t* ld)
-  { return ld->label == (uint32_t)-1; }
+void finish_example(vw& all, example& ec);
+
+template <class T> void finish_example(vw& all, T&, example& ec) {
+  finish_example(all, ec);
+}
+
+inline bool label_is_test(label_t* ld)
+{
+  return ld->label == (uint32_t)-1;
+}
 }

--- a/vowpalwabbit/multilabel.cc
+++ b/vowpalwabbit/multilabel.cc
@@ -3,210 +3,211 @@
 #include "vw.h"
 
 namespace MULTILABEL {
-  bool is_test_label(labels& ld)
+bool is_test_label(labels& ld)
+{
+  if (ld.label_v.size() == 0)
+    return true;
+  else
+    return false;
+}
+
+char* bufread_label(labels* ld, char* c, io_buf& cache)
+{
+  size_t num = *(size_t *)c;
+  ld->label_v.erase();
+  c += sizeof(size_t);
+  size_t total = sizeof(uint32_t)*num;
+  if (buf_read(cache, c, (int)total) < total)
   {
-    if (ld.label_v.size() == 0)
-      return true;
-    else 
-      return false;
-  }
-  
-  char* bufread_label(labels* ld, char* c, io_buf& cache)
-  {
-    size_t num = *(size_t *)c;
-    ld->label_v.erase();
-    c += sizeof(size_t);
-    size_t total = sizeof(uint32_t)*num;
-    if (buf_read(cache, c, (int)total) < total) 
-      {
-        cout << "error in demarshal of cost data" << endl;
-        return c;
-      }
-    for (size_t i = 0; i<num; i++)
-      {
-        uint32_t temp = *(uint32_t *)c;
-        c += sizeof(uint32_t);
-        ld->label_v.push_back(temp);
-      }
-  
+    cout << "error in demarshal of cost data" << endl;
     return c;
   }
-
-  size_t read_cached_label(shared_data*, void* v, io_buf& cache)
+  for (size_t i = 0; i<num; i++)
   {
-    labels* ld = (labels*) v;
-    ld->label_v.erase();
-    char *c;
-    size_t total = sizeof(size_t);
-    if (buf_read(cache, c, (int)total) < total) 
-      return 0;
-    c = bufread_label(ld,c, cache);
-  
-    return total;
+    uint32_t temp = *(uint32_t *)c;
+    c += sizeof(uint32_t);
+    ld->label_v.push_back(temp);
   }
 
-  float weight(void*)
-  {
-    return 1.;
-  }
+  return c;
+}
 
-  char* bufcache_label(labels* ld, char* c)
-  {
-    *(size_t *)c = ld->label_v.size();
-    c += sizeof(size_t);
-    for (unsigned int i = 0; i< ld->label_v.size(); i++)
-      {
-        *(uint32_t *)c = ld->label_v[i];
-        c += sizeof(uint32_t);
-      }
-    return c;
-  }
+size_t read_cached_label(shared_data*, void* v, io_buf& cache)
+{
+  labels* ld = (labels*) v;
+  ld->label_v.erase();
+  char *c;
+  size_t total = sizeof(size_t);
+  if (buf_read(cache, c, (int)total) < total)
+    return 0;
+  c = bufread_label(ld,c, cache);
 
-  void cache_label(void* v, io_buf& cache)
-  {
-    char *c;
-    labels* ld = (labels*) v;
-    buf_write(cache, c, sizeof(size_t)+sizeof(uint32_t)*ld->label_v.size());
-    bufcache_label(ld,c);
-  }
+  return total;
+}
 
-  void default_label(void* v)
-  {
-    labels* ld = (labels*) v;
-    ld->label_v.erase();
-  }
+float weight(void*)
+{
+  return 1.;
+}
 
-  void delete_label(void* v)
+char* bufcache_label(labels* ld, char* c)
+{
+  *(size_t *)c = ld->label_v.size();
+  c += sizeof(size_t);
+  for (unsigned int i = 0; i< ld->label_v.size(); i++)
   {
-    labels* ld = (labels*)v;
-    if (ld) ld->label_v.delete_v();
+    *(uint32_t *)c = ld->label_v[i];
+    c += sizeof(uint32_t);
   }
+  return c;
+}
 
-  void copy_label(void* dst, void* src)
+void cache_label(void* v, io_buf& cache)
+{
+  char *c;
+  labels* ld = (labels*) v;
+  buf_write(cache, c, sizeof(size_t)+sizeof(uint32_t)*ld->label_v.size());
+  bufcache_label(ld,c);
+}
+
+void default_label(void* v)
+{
+  labels* ld = (labels*) v;
+  ld->label_v.erase();
+}
+
+void delete_label(void* v)
+{
+  labels* ld = (labels*)v;
+  if (ld) ld->label_v.delete_v();
+}
+
+void copy_label(void* dst, void* src)
+{
+  if (dst && src) {
+    labels* ldD = (labels*)dst;
+    labels* ldS = (labels*)src;
+    copy_array(ldD->label_v, ldS->label_v);
+  }
+}
+
+void parse_label(parser* p, shared_data*, void* v, v_array<substring>& words)
+{
+  labels* ld = (labels*)v;
+
+  ld->label_v.erase();
+  switch(words.size())
   {
-    if (dst && src) {
-      labels* ldD = (labels*)dst;
-      labels* ldS = (labels*)src;
-      copy_array(ldD->label_v, ldS->label_v);
+  case 0:
+    break;
+  case 1:
+    tokenize(',', words[0], p->parse_name);
+
+    for (size_t i = 0; i < p->parse_name.size(); i++)
+    {
+      *(p->parse_name[i].end) = '\0';
+      uint32_t n = atoi(p->parse_name[i].begin);
+      ld->label_v.push_back(n);
     }
+    break;
+  default:
+    cerr << "example with an odd label, what is ";
+    for (size_t i = 0; i < words.size(); i++)
+      cerr << words[i].begin << " ";
+    cerr << endl;
   }
+}
 
-  void parse_label(parser* p, shared_data*, void* v, v_array<substring>& words)
+
+label_parser multilabel = {default_label, parse_label,
+                           cache_label, read_cached_label,
+                           delete_label, weight,
+                           copy_label,
+                           sizeof(labels)
+                          };
+
+void print_update(vw& all, bool is_test, example& ec)
+{
+  if (all.sd->weighted_examples >= all.sd->dump_interval && !all.quiet && !all.bfgs)
   {
-    labels* ld = (labels*)v;
+    stringstream label_string;
+    if (is_test)
+      label_string << " unknown";
+    else
+      for(size_t i = 0; i < ec.l.multilabels.label_v.size(); i++)
+        label_string << " " << ec.l.multilabels.label_v[i];
 
-    ld->label_v.erase();
-    switch(words.size())
+    stringstream pred_string;
+    for(size_t i = 0; i < ec.pred.multilabels.label_v.size(); i++)
+      pred_string << " " << ec.pred.multilabels.label_v[i];
+
+
+    all.sd->print_update(all.holdout_set_off, all.current_pass, label_string.str(), pred_string.str(),
+                         ec.num_features, all.progress_add, all.progress_arg);
+  }
+}
+
+void print_multilabel(int f, labels& mls, v_array<char>&)
+{
+  if (f >= 0)
+  {
+    std::stringstream ss;
+
+    for (size_t i = 0; i < mls.label_v.size(); i++)
+    {
+      if (i > 0)
+        ss << ',';
+      ss << mls.label_v[i];
+    }
+    ss << '\n';
+    ssize_t len = ss.str().size();
+    ssize_t t = io_buf::write_file_or_socket(f, ss.str().c_str(), (unsigned int)len);
+    if (t != len)
+      cerr << "write error: " << strerror(errno) << endl;
+  }
+}
+
+void output_example(vw& all, example& ec)
+{
+  labels& ld = ec.l.multilabels;
+
+  float loss = 0.;
+  if (!is_test_label(ld))
+  { //need to compute exact loss
+    labels preds = ec.pred.multilabels;
+    labels given = ec.l.multilabels;
+
+    uint32_t preds_index = 0;
+    uint32_t given_index = 0;
+
+    while(preds_index < preds.label_v.size() && given_index < given.label_v.size())
+    {
+      if (preds.label_v[preds_index] < given.label_v[given_index])
+        preds_index++;
+      else if (preds.label_v[preds_index] > given.label_v[given_index])
       {
-      case 0:
-	break;
-      case 1:
-	tokenize(',', words[0], p->parse_name);
-	
-	for (size_t i = 0; i < p->parse_name.size(); i++)
-	  {
-	    *(p->parse_name[i].end) = '\0';
-	    uint32_t n = atoi(p->parse_name[i].begin);
-	    ld->label_v.push_back(n);
-	  }
-	break;
-      default:
-	cerr << "example with an odd label, what is ";
-	for (size_t i = 0; i < words.size(); i++)
-	  cerr << words[i].begin << " ";
-	cerr << endl;
+        given_index++;
+        loss++;
+      }
+      else
+      {
+        preds_index++;
+        given_index++;
       }
     }
-
-
-label_parser multilabel = {default_label, parse_label, 
-			   cache_label, read_cached_label, 
-			   delete_label, weight, 
-			   copy_label,
-			   sizeof(labels)};
-
- void print_update(vw& all, bool is_test, example& ec)
-  {
-    if (all.sd->weighted_examples >= all.sd->dump_interval && !all.quiet && !all.bfgs)
-      {
-	stringstream label_string;
-        if (is_test)
-          label_string << " unknown";
-        else
-	  for(size_t i = 0; i < ec.l.multilabels.label_v.size(); i++)
-	    label_string << " " << ec.l.multilabels.label_v[i];
-
-	stringstream pred_string;
-	  for(size_t i = 0; i < ec.pred.multilabels.label_v.size(); i++)
-	    pred_string << " " << ec.pred.multilabels.label_v[i];
-	  
-	  
-	  all.sd->print_update(all.holdout_set_off, all.current_pass, label_string.str(), pred_string.str(), 
-			       ec.num_features, all.progress_add, all.progress_arg);
-      }
+    loss += given.label_v.size() - given_index;
   }
 
-  void print_multilabel(int f, labels& mls, v_array<char>&)
-  {
-    if (f >= 0)
-      {
-	std::stringstream ss;
-	
-	for (size_t i = 0; i < mls.label_v.size(); i++)
-	  {
-	    if (i > 0)
-	      ss << ',';
-	    ss << mls.label_v[i];
-	  }
-	ss << '\n';
-	ssize_t len = ss.str().size();
-	ssize_t t = io_buf::write_file_or_socket(f, ss.str().c_str(), (unsigned int)len);
-	if (t != len)
-	  cerr << "write error: " << strerror(errno) << endl;
-      }
-  }
+  all.sd->update(ec.test_only, loss, 1.f, ec.num_features);
 
-  void output_example(vw& all, example& ec)
-  {
-    labels& ld = ec.l.multilabels;
+  for (int* sink = all.final_prediction_sink.begin; sink != all.final_prediction_sink.end; sink++)
+    print_multilabel(*sink, ec.pred.multilabels, ec.tag);
 
-    float loss = 0.;
-    if (!is_test_label(ld))
-      {//need to compute exact loss
-	labels preds = ec.pred.multilabels;
-	labels given = ec.l.multilabels;
-	
-	uint32_t preds_index = 0;
-	uint32_t given_index = 0;
+  print_update(all, is_test_label(ec.l.multilabels), ec);
+}
 
-	while(preds_index < preds.label_v.size() && given_index < given.label_v.size())
-	  {
-	    if (preds.label_v[preds_index] < given.label_v[given_index])
-	      preds_index++;
-	    else if (preds.label_v[preds_index] > given.label_v[given_index])
-	      {
-		given_index++;
-		loss++;
-	      }
-	    else
-	      {
-		preds_index++;
-		given_index++;
-	      }
-	  }
-	loss += given.label_v.size() - given_index;
-      }
-
-    all.sd->update(ec.test_only, loss, 1.f, ec.num_features);
-    
-    for (int* sink = all.final_prediction_sink.begin; sink != all.final_prediction_sink.end; sink++)
-      print_multilabel(*sink, ec.pred.multilabels, ec.tag);
-
-    print_update(all, is_test_label(ec.l.multilabels), ec);
-  }
-
-  bool example_is_test(example& ec)
-  {
-    return is_test_label(ec.l.multilabels);
-  }
+bool example_is_test(example& ec)
+{
+  return is_test_label(ec.l.multilabels);
+}
 }

--- a/vowpalwabbit/multilabel.h
+++ b/vowpalwabbit/multilabel.h
@@ -10,15 +10,15 @@ struct example;
 struct vw;
 
 namespace MULTILABEL {
-  struct labels {
-    v_array<uint32_t> label_v;
-  };
-  
-  void output_example(vw& all, example& ec);
-  extern label_parser multilabel;
+struct labels {
+  v_array<uint32_t> label_v;
+};
 
-  bool example_is_test(example& ec);
+void output_example(vw& all, example& ec);
+extern label_parser multilabel;
 
-  void print_update(vw& all, bool is_test, example& ec, const v_array<example*> *ec_seq);
-  void print_multilabel(int f, labels& mls, v_array<char>& tag);
+bool example_is_test(example& ec);
+
+void print_update(vw& all, bool is_test, example& ec, const v_array<example*> *ec_seq);
+void print_multilabel(int f, labels& mls, v_array<char>& tag);
 }

--- a/vowpalwabbit/multilabel_oaa.cc
+++ b/vowpalwabbit/multilabel_oaa.cc
@@ -23,16 +23,16 @@ void predict_or_learn(multi_oaa& o, LEARNER::base_learner& base, example& ec) {
   for (uint32_t i = 0; i < o.k; i++) {
     if (is_learn) {
       ec.l.simple.label = -1.f;
-      if (multilabels.label_v.size() > multilabel_index 
-	  && multilabels.label_v[multilabel_index] == i)
-	{
-	  ec.l.simple.label = 1.f;
-	  multilabel_index++;
-	}
+      if (multilabels.label_v.size() > multilabel_index
+          && multilabels.label_v[multilabel_index] == i)
+      {
+        ec.l.simple.label = 1.f;
+        multilabel_index++;
+      }
       base.learn(ec, i);
     } else
       base.predict(ec, i);
-    if (ec.pred.scalar > 0.) 
+    if (ec.pred.scalar > 0.)
       preds.label_v.push_back(i);
   }
   if (is_learn && multilabel_index < multilabels.label_v.size())
@@ -50,14 +50,14 @@ void finish_example(vw& all, multi_oaa&, example& ec)
 
 LEARNER::base_learner* multilabel_oaa_setup(vw& all)
 {
-  if (missing_option<size_t, true>(all, "multilabel_oaa", "One-against-all multilabel with <k> labels")) 
+  if (missing_option<size_t, true>(all, "multilabel_oaa", "One-against-all multilabel with <k> labels"))
     return nullptr;
-  
+
   multi_oaa& data = calloc_or_die<multi_oaa>();
   data.k = all.vm["multilabel_oaa"].as<size_t>();
-  
+
   LEARNER::learner<multi_oaa>& l = LEARNER::init_learner(&data, setup_base(all), predict_or_learn<true>,
-						   predict_or_learn<false>, data.k);
+                                   predict_or_learn<false>, data.k);
   l.set_finish_example(finish_example);
   all.p->lp = MULTILABEL::multilabel;
   all.multilabel_prediction = true;

--- a/vowpalwabbit/network.cc
+++ b/vowpalwabbit/network.cc
@@ -39,11 +39,11 @@ int open_socket(const char* host)
   short unsigned int port = 26542;
   hostent* he;
   if (colon != nullptr)
-    {
-      port = atoi(colon+1);
-      string hostname(host,colon-host);
-      he = gethostbyname(hostname.c_str());
-    }
+  {
+    port = atoi(colon+1);
+    string hostname(host,colon-host);
+    he = gethostbyname(hostname.c_str());
+  }
   else
     he = gethostbyname(host);
 
@@ -65,11 +65,11 @@ int open_socket(const char* host)
   char id = '\0';
   if (
 #ifdef _WIN32
-      _write(sd, &id, sizeof(id)) < (int)sizeof(id)
+    _write(sd, &id, sizeof(id)) < (int)sizeof(id)
 #else
-      write(sd, &id, sizeof(id)) < (int)sizeof(id)
+    write(sd, &id, sizeof(id)) < (int)sizeof(id)
 #endif
-      )
+  )
     cerr << "write failed!" << endl;
   return sd;
 }

--- a/vowpalwabbit/nn.cc
+++ b/vowpalwabbit/nn.cc
@@ -37,434 +37,437 @@ struct nn {
 
   float* hidden_units;
   bool* dropped_out;
-  
+
   polyprediction* hidden_units_pred;
   polyprediction* hiddenbias_pred;
-  
+
   vw* all;//many things
 };
 
 #define cast_uint32_t static_cast<uint32_t>
 
-  static inline float
-  fastpow2 (float p)
-  {
-    float offset = (p < 0) ? 1.0f : 0.0f;
-    float clipp = (p < -126) ? -126.0f : p;
-    int w = (int)clipp;
-    float z = clipp - w + offset;
-    union { uint32_t i; float f; } v = { cast_uint32_t ( (1 << 23) * (clipp + 121.2740575f + 27.7280233f / (4.84252568f - z) - 1.49012907f * z) ) };
+static inline float
+fastpow2 (float p)
+{
+  float offset = (p < 0) ? 1.0f : 0.0f;
+  float clipp = (p < -126) ? -126.0f : p;
+  int w = (int)clipp;
+  float z = clipp - w + offset;
+  union {
+    uint32_t i;
+    float f;
+  } v = { cast_uint32_t ( (1 << 23) * (clipp + 121.2740575f + 27.7280233f / (4.84252568f - z) - 1.49012907f * z) ) };
 
-    return v.f;
+  return v.f;
+}
+
+static inline float
+fastexp (float p)
+{
+  return fastpow2 (1.442695040f * p);
+}
+
+static inline float
+fasttanh (float p)
+{
+  return -1.0f + 2.0f / (1.0f + fastexp (-2.0f * p));
+}
+
+void finish_setup (nn& n, vw& all)
+{
+  // TODO: output_layer audit
+
+  memset (&n.output_layer, 0, sizeof (n.output_layer));
+  n.output_layer.indices.push_back(nn_output_namespace);
+  feature output = {1., nn_constant << all.reg.stride_shift};
+
+  for (unsigned int i = 0; i < n.k; ++i)
+  {
+    n.output_layer.atomics[nn_output_namespace].push_back(output);
+    ++n.output_layer.num_features;
+    output.weight_index += (uint32_t)n.increment;
   }
 
-  static inline float
-  fastexp (float p)
+  if (! n.inpass)
   {
-    return fastpow2 (1.442695040f * p);
+    n.output_layer.atomics[nn_output_namespace].push_back(output);
+    ++n.output_layer.num_features;
   }
 
-  static inline float
-  fasttanh (float p)
-  {
-    return -1.0f + 2.0f / (1.0f + fastexp (-2.0f * p));
-  }
+  n.output_layer.in_use = true;
 
-  void finish_setup (nn& n, vw& all)
-  {
-    // TODO: output_layer audit
+  // TODO: not correct if --noconstant
+  memset (&n.hiddenbias, 0, sizeof (n.hiddenbias));
+  n.hiddenbias.indices.push_back(constant_namespace);
+  feature temp = {1,(uint32_t) constant};
+  n.hiddenbias.atomics[constant_namespace].push_back(temp);
+  n.hiddenbias.total_sum_feat_sq++;
+  n.hiddenbias.l.simple.label = FLT_MAX;
+  n.hiddenbias.l.simple.weight = 1;
+  n.hiddenbias.in_use = true;
 
-    memset (&n.output_layer, 0, sizeof (n.output_layer));
-    n.output_layer.indices.push_back(nn_output_namespace);
-    feature output = {1., nn_constant << all.reg.stride_shift};
+  memset (&n.outputweight, 0, sizeof (n.outputweight));
+  n.outputweight.indices.push_back(nn_output_namespace);
+  n.outputweight.atomics[nn_output_namespace].push_back(n.output_layer.atomics[nn_output_namespace][0]);
+  n.outputweight.atomics[nn_output_namespace][0].x = 1;
+  n.outputweight.total_sum_feat_sq++;
+  n.outputweight.l.simple.label = FLT_MAX;
+  n.outputweight.l.simple.weight = 1;
+  n.outputweight.in_use = true;
+
+  n.finished_setup = true;
+}
+
+void end_pass(nn& n)
+{
+  if (n.all->bfgs)
+    n.xsubi = n.save_xsubi;
+}
+
+template<bool is_learn, bool recompute_hidden>
+void predict_or_learn_multi(nn& n, base_learner& base, example& ec) {
+  bool shouldOutput = n.all->raw_prediction > 0;
+
+  if (! n.finished_setup)
+    finish_setup (n, *(n.all));
+
+  shared_data sd;
+  memcpy (&sd, n.all->sd, sizeof(shared_data));
+  shared_data* save_sd = n.all->sd;
+  n.all->sd = &sd;
+
+  label_data ld = ec.l.simple;
+  void (*save_set_minmax) (shared_data*, float) = n.all->set_minmax;
+  float save_min_label;
+  float save_max_label;
+  float dropscale = n.dropout ? 2.0f : 1.0f;
+  loss_function* save_loss = n.all->loss;
+
+  polyprediction* hidden_units = n.hidden_units_pred;
+  polyprediction* hiddenbias_pred = n.hiddenbias_pred;
+  bool* dropped_out = n.dropped_out;
+
+  ostringstream outputStringStream;
+
+  n.all->set_minmax = noop_mm;
+  n.all->loss = n.squared_loss;
+  save_min_label = n.all->sd->min_label;
+  n.all->sd->min_label = hidden_min_activation;
+  save_max_label = n.all->sd->max_label;
+  n.all->sd->max_label = hidden_max_activation;
+
+  uint32_t save_ft_offset = ec.ft_offset;
+
+  if (n.multitask)
+    ec.ft_offset = 0;
+
+  n.hiddenbias.ft_offset = ec.ft_offset;
+
+  if (recompute_hidden) {
+    base.multipredict(n.hiddenbias, 0, n.k, hiddenbias_pred, true);
 
     for (unsigned int i = 0; i < n.k; ++i)
+      // avoid saddle point at 0
+      if (hiddenbias_pred[i].scalar == 0)
       {
-        n.output_layer.atomics[nn_output_namespace].push_back(output);
-        ++n.output_layer.num_features;
-        output.weight_index += (uint32_t)n.increment;
+        n.hiddenbias.l.simple.label = (float) (frand48 () - 0.5);
+        base.learn(n.hiddenbias, i);
+        n.hiddenbias.l.simple.label = FLT_MAX;
       }
 
-    if (! n.inpass) 
-      {
-        n.output_layer.atomics[nn_output_namespace].push_back(output);
-        ++n.output_layer.num_features;
-      }
+    base.multipredict(ec, 0, n.k, hidden_units, true);
 
-    n.output_layer.in_use = true;
-
-    // TODO: not correct if --noconstant
-    memset (&n.hiddenbias, 0, sizeof (n.hiddenbias));
-    n.hiddenbias.indices.push_back(constant_namespace);
-    feature temp = {1,(uint32_t) constant};
-    n.hiddenbias.atomics[constant_namespace].push_back(temp);
-    n.hiddenbias.total_sum_feat_sq++;
-    n.hiddenbias.l.simple.label = FLT_MAX;
-    n.hiddenbias.l.simple.weight = 1;
-    n.hiddenbias.in_use = true;
-
-    memset (&n.outputweight, 0, sizeof (n.outputweight));
-    n.outputweight.indices.push_back(nn_output_namespace);
-    n.outputweight.atomics[nn_output_namespace].push_back(n.output_layer.atomics[nn_output_namespace][0]);
-    n.outputweight.atomics[nn_output_namespace][0].x = 1;
-    n.outputweight.total_sum_feat_sq++;
-    n.outputweight.l.simple.label = FLT_MAX;
-    n.outputweight.l.simple.weight = 1;
-    n.outputweight.in_use = true;
-
-    n.finished_setup = true;
+    for (unsigned int i = 0; i < n.k; ++i )
+      dropped_out[i] = (n.dropout && merand48 (n.xsubi) < 0.5);
   }
 
-  void end_pass(nn& n)
-  {
-    if (n.all->bfgs)
-      n.xsubi = n.save_xsubi;
-  }
-
-  template<bool is_learn, bool recompute_hidden>
-  void predict_or_learn_multi(nn& n, base_learner& base, example& ec) {
-    bool shouldOutput = n.all->raw_prediction > 0;
-
-    if (! n.finished_setup)
-      finish_setup (n, *(n.all));
-
-    shared_data sd;
-    memcpy (&sd, n.all->sd, sizeof(shared_data));
-    shared_data* save_sd = n.all->sd;
-    n.all->sd = &sd;
-
-    label_data ld = ec.l.simple;
-    void (*save_set_minmax) (shared_data*, float) = n.all->set_minmax;
-    float save_min_label;
-    float save_max_label;
-    float dropscale = n.dropout ? 2.0f : 1.0f;
-    loss_function* save_loss = n.all->loss;
-
-    polyprediction* hidden_units = n.hidden_units_pred;
-    polyprediction* hiddenbias_pred = n.hiddenbias_pred;
-    bool* dropped_out = n.dropped_out;
-  
-    ostringstream outputStringStream;
-
-    n.all->set_minmax = noop_mm;
-    n.all->loss = n.squared_loss;
-    save_min_label = n.all->sd->min_label;
-    n.all->sd->min_label = hidden_min_activation;
-    save_max_label = n.all->sd->max_label;
-    n.all->sd->max_label = hidden_max_activation;
-
-    uint32_t save_ft_offset = ec.ft_offset;
-
-    if (n.multitask)
-      ec.ft_offset = 0;
-
-    n.hiddenbias.ft_offset = ec.ft_offset;
-
-    if (recompute_hidden) {
-      base.multipredict(n.hiddenbias, 0, n.k, hiddenbias_pred, true);
-    
-      for (unsigned int i = 0; i < n.k; ++i)
-        // avoid saddle point at 0
-        if (hiddenbias_pred[i].scalar == 0)
-          {
-            n.hiddenbias.l.simple.label = (float) (frand48 () - 0.5);
-            base.learn(n.hiddenbias, i);
-            n.hiddenbias.l.simple.label = FLT_MAX;
-          }
-
-      base.multipredict(ec, 0, n.k, hidden_units, true);
-
-      for (unsigned int i = 0; i < n.k; ++i )
-        dropped_out[i] = (n.dropout && merand48 (n.xsubi) < 0.5);
+  if (shouldOutput)
+    for (unsigned int i = 0; i < n.k; ++i ) {
+      if (i > 0) outputStringStream << ' ';
+      outputStringStream << i << ':' << hidden_units[i].scalar << ',' << fasttanh (hidden_units[i].scalar); // TODO: huh, what was going on here?
     }
-    
-    if (shouldOutput)
-      for (unsigned int i = 0; i < n.k; ++i ) {
-        if (i > 0) outputStringStream << ' ';
-        outputStringStream << i << ':' << hidden_units[i].scalar << ',' << fasttanh (hidden_units[i].scalar); // TODO: huh, what was going on here?
-      }
 
-    n.all->loss = save_loss;
-    n.all->set_minmax = save_set_minmax;
-    n.all->sd->min_label = save_min_label;
-    n.all->sd->max_label = save_max_label;
-    ec.ft_offset = save_ft_offset;
+  n.all->loss = save_loss;
+  n.all->set_minmax = save_set_minmax;
+  n.all->sd->min_label = save_min_label;
+  n.all->sd->max_label = save_max_label;
+  ec.ft_offset = save_ft_offset;
 
-    bool converse = false;
-    float save_partial_prediction = 0;
-    float save_final_prediction = 0;
-    float save_ec_loss = 0;
+  bool converse = false;
+  float save_partial_prediction = 0;
+  float save_final_prediction = 0;
+  float save_ec_loss = 0;
 
 CONVERSE: // That's right, I'm using goto.  So sue me.
 
-    n.output_layer.total_sum_feat_sq = 1;
-    n.output_layer.sum_feat_sq[nn_output_namespace] = 1;
+  n.output_layer.total_sum_feat_sq = 1;
+  n.output_layer.sum_feat_sq[nn_output_namespace] = 1;
 
-    n.outputweight.ft_offset = ec.ft_offset;
+  n.outputweight.ft_offset = ec.ft_offset;
 
-    n.all->set_minmax = noop_mm;
-    n.all->loss = n.squared_loss;
-    save_min_label = n.all->sd->min_label;
-    n.all->sd->min_label = -1;
-    save_max_label = n.all->sd->max_label;
-    n.all->sd->max_label = 1;
+  n.all->set_minmax = noop_mm;
+  n.all->loss = n.squared_loss;
+  save_min_label = n.all->sd->min_label;
+  n.all->sd->min_label = -1;
+  save_max_label = n.all->sd->max_label;
+  n.all->sd->max_label = 1;
 
-    for (unsigned int i = 0; i < n.k; ++i)
-      {
-        float sigmah = 
-          (dropped_out[i]) ? 0.0f : dropscale * fasttanh (hidden_units[i].scalar);
-        n.output_layer.atomics[nn_output_namespace][i].x = sigmah;
+  for (unsigned int i = 0; i < n.k; ++i)
+  {
+    float sigmah =
+      (dropped_out[i]) ? 0.0f : dropscale * fasttanh (hidden_units[i].scalar);
+    n.output_layer.atomics[nn_output_namespace][i].x = sigmah;
 
-        n.output_layer.total_sum_feat_sq += sigmah * sigmah;
-        n.output_layer.sum_feat_sq[nn_output_namespace] += sigmah * sigmah;
+    n.output_layer.total_sum_feat_sq += sigmah * sigmah;
+    n.output_layer.sum_feat_sq[nn_output_namespace] += sigmah * sigmah;
 
-        n.outputweight.atomics[nn_output_namespace][0].weight_index = 
-          n.output_layer.atomics[nn_output_namespace][i].weight_index;
-        base.predict(n.outputweight, n.k);
-        float wf = n.outputweight.pred.scalar;
+    n.outputweight.atomics[nn_output_namespace][0].weight_index =
+      n.output_layer.atomics[nn_output_namespace][i].weight_index;
+    base.predict(n.outputweight, n.k);
+    float wf = n.outputweight.pred.scalar;
 
-        // avoid saddle point at 0
-        if (wf == 0)
-          {    
-            float sqrtk = sqrt ((float)n.k);
-            n.outputweight.l.simple.label = (float) (frand48 () - 0.5) / sqrtk;
-            base.update(n.outputweight, n.k);
-            n.outputweight.l.simple.label = FLT_MAX;
-          }
-      }
-
-    n.all->loss = save_loss;
-    n.all->set_minmax = save_set_minmax;
-    n.all->sd->min_label = save_min_label;
-    n.all->sd->max_label = save_max_label;
-
-    if (n.inpass) {
-      // TODO: this is not correct if there is something in the 
-      // nn_output_namespace but at least it will not leak memory
-      // in that case
-
-      ec.indices.push_back (nn_output_namespace);
-      v_array<feature> save_nn_output_namespace = ec.atomics[nn_output_namespace];
-      ec.atomics[nn_output_namespace] = n.output_layer.atomics[nn_output_namespace];
-      ec.sum_feat_sq[nn_output_namespace] = n.output_layer.sum_feat_sq[nn_output_namespace];
-      ec.total_sum_feat_sq += n.output_layer.sum_feat_sq[nn_output_namespace];
-      if (is_learn)
-	base.learn(ec, n.k);
-      else
-	base.predict(ec, n.k);
-      n.output_layer.partial_prediction = ec.partial_prediction;
-      n.output_layer.loss = ec.loss;
-      ec.total_sum_feat_sq -= n.output_layer.sum_feat_sq[nn_output_namespace];
-      ec.sum_feat_sq[nn_output_namespace] = 0;
-      ec.atomics[nn_output_namespace] = save_nn_output_namespace;
-      ec.indices.pop ();
+    // avoid saddle point at 0
+    if (wf == 0)
+    {
+      float sqrtk = sqrt ((float)n.k);
+      n.outputweight.l.simple.label = (float) (frand48 () - 0.5) / sqrtk;
+      base.update(n.outputweight, n.k);
+      n.outputweight.l.simple.label = FLT_MAX;
     }
-    else {
-      n.output_layer.ft_offset = ec.ft_offset;
-      n.output_layer.l = ec.l;
-      n.output_layer.partial_prediction = 0;
-      n.output_layer.example_t = ec.example_t;
-      if (is_learn)
-	base.learn(n.output_layer, n.k);
-      else
-	base.predict(n.output_layer, n.k);
-      ec.l = n.output_layer.l;
-    }
+  }
 
-    n.prediction = GD::finalize_prediction (n.all->sd, n.output_layer.partial_prediction);
+  n.all->loss = save_loss;
+  n.all->set_minmax = save_set_minmax;
+  n.all->sd->min_label = save_min_label;
+  n.all->sd->max_label = save_max_label;
 
-    if (shouldOutput) {
-      outputStringStream << ' ' << n.output_layer.partial_prediction;
-      n.all->print_text(n.all->raw_prediction, outputStringStream.str(), ec.tag);
-    }
-    
-    if (is_learn && n.all->training && ld.label != FLT_MAX) {
-      float gradient = n.all->loss->first_derivative(n.all->sd, 
-						     n.prediction,
-						     ld.label);
+  if (n.inpass) {
+    // TODO: this is not correct if there is something in the
+    // nn_output_namespace but at least it will not leak memory
+    // in that case
 
-      if (fabs (gradient) > 0) {
-        n.all->loss = n.squared_loss;
-        n.all->set_minmax = noop_mm;
-        save_min_label = n.all->sd->min_label;
-        n.all->sd->min_label = hidden_min_activation;
-        save_max_label = n.all->sd->max_label;
-        n.all->sd->max_label = hidden_max_activation;
-        save_ft_offset = ec.ft_offset;
+    ec.indices.push_back (nn_output_namespace);
+    v_array<feature> save_nn_output_namespace = ec.atomics[nn_output_namespace];
+    ec.atomics[nn_output_namespace] = n.output_layer.atomics[nn_output_namespace];
+    ec.sum_feat_sq[nn_output_namespace] = n.output_layer.sum_feat_sq[nn_output_namespace];
+    ec.total_sum_feat_sq += n.output_layer.sum_feat_sq[nn_output_namespace];
+    if (is_learn)
+      base.learn(ec, n.k);
+    else
+      base.predict(ec, n.k);
+    n.output_layer.partial_prediction = ec.partial_prediction;
+    n.output_layer.loss = ec.loss;
+    ec.total_sum_feat_sq -= n.output_layer.sum_feat_sq[nn_output_namespace];
+    ec.sum_feat_sq[nn_output_namespace] = 0;
+    ec.atomics[nn_output_namespace] = save_nn_output_namespace;
+    ec.indices.pop ();
+  }
+  else {
+    n.output_layer.ft_offset = ec.ft_offset;
+    n.output_layer.l = ec.l;
+    n.output_layer.partial_prediction = 0;
+    n.output_layer.example_t = ec.example_t;
+    if (is_learn)
+      base.learn(n.output_layer, n.k);
+    else
+      base.predict(n.output_layer, n.k);
+    ec.l = n.output_layer.l;
+  }
 
-        if (n.multitask)
-          ec.ft_offset = 0;
+  n.prediction = GD::finalize_prediction (n.all->sd, n.output_layer.partial_prediction);
 
-        for (unsigned int i = 0; i < n.k; ++i) {
-          if (! dropped_out[i]) {
-            float sigmah = 
-              n.output_layer.atomics[nn_output_namespace][i].x / dropscale;
-            float sigmahprime = dropscale * (1.0f - sigmah * sigmah);
-            n.outputweight.atomics[nn_output_namespace][0].weight_index = 
-              n.output_layer.atomics[nn_output_namespace][i].weight_index;
-            base.predict(n.outputweight, n.k);
-            float nu = n.outputweight.pred.scalar;
-            float gradhw = 0.5f * nu * gradient * sigmahprime;
+  if (shouldOutput) {
+    outputStringStream << ' ' << n.output_layer.partial_prediction;
+    n.all->print_text(n.all->raw_prediction, outputStringStream.str(), ec.tag);
+  }
 
-            ec.l.simple.label = GD::finalize_prediction (n.all->sd, hidden_units[i].scalar - gradhw);
-            ec.pred.scalar = hidden_units[i].scalar;
-            if (ec.l.simple.label != hidden_units[i].scalar) 
-              base.update(ec, i);
-          }
+  if (is_learn && n.all->training && ld.label != FLT_MAX) {
+    float gradient = n.all->loss->first_derivative(n.all->sd,
+                     n.prediction,
+                     ld.label);
+
+    if (fabs (gradient) > 0) {
+      n.all->loss = n.squared_loss;
+      n.all->set_minmax = noop_mm;
+      save_min_label = n.all->sd->min_label;
+      n.all->sd->min_label = hidden_min_activation;
+      save_max_label = n.all->sd->max_label;
+      n.all->sd->max_label = hidden_max_activation;
+      save_ft_offset = ec.ft_offset;
+
+      if (n.multitask)
+        ec.ft_offset = 0;
+
+      for (unsigned int i = 0; i < n.k; ++i) {
+        if (! dropped_out[i]) {
+          float sigmah =
+            n.output_layer.atomics[nn_output_namespace][i].x / dropscale;
+          float sigmahprime = dropscale * (1.0f - sigmah * sigmah);
+          n.outputweight.atomics[nn_output_namespace][0].weight_index =
+            n.output_layer.atomics[nn_output_namespace][i].weight_index;
+          base.predict(n.outputweight, n.k);
+          float nu = n.outputweight.pred.scalar;
+          float gradhw = 0.5f * nu * gradient * sigmahprime;
+
+          ec.l.simple.label = GD::finalize_prediction (n.all->sd, hidden_units[i].scalar - gradhw);
+          ec.pred.scalar = hidden_units[i].scalar;
+          if (ec.l.simple.label != hidden_units[i].scalar)
+            base.update(ec, i);
         }
-
-        n.all->loss = save_loss;
-        n.all->set_minmax = save_set_minmax;
-        n.all->sd->min_label = save_min_label;
-        n.all->sd->max_label = save_max_label;
-        ec.ft_offset = save_ft_offset;
-      }
-    }
-
-    ec.l.simple.label = ld.label;
-
-    if (! converse) {
-      save_partial_prediction = n.output_layer.partial_prediction;
-      save_final_prediction = n.prediction;
-      save_ec_loss = n.output_layer.loss;
-    }
-
-    if (n.dropout && ! converse)
-      {
-        for (unsigned int i = 0; i < n.k; ++i)
-          {
-            dropped_out[i] = ! dropped_out[i];
-          }
-
-        converse = true;
-        goto CONVERSE;
       }
 
-    ec.partial_prediction = save_partial_prediction;
-    ec.pred.scalar = save_final_prediction;
-    ec.loss = save_ec_loss;
-
-    n.all->sd = save_sd;
-    n.all->set_minmax (n.all->sd, sd.min_label);
-    n.all->set_minmax (n.all->sd, sd.max_label);
-  }
-
-  void multipredict(nn& n, base_learner& base, example& ec, size_t count, size_t step, polyprediction*pred, bool finalize_predictions) {
-    for (size_t c=0; c<count; c++) {
-      if (c == 0)
-        predict_or_learn_multi<false,true>(n, base, ec);
-      else
-        predict_or_learn_multi<false,false>(n, base, ec);
-      if (finalize_predictions) pred[c] = ec.pred;
-      else pred[c].scalar = ec.partial_prediction;
-      ec.ft_offset += step;
+      n.all->loss = save_loss;
+      n.all->set_minmax = save_set_minmax;
+      n.all->sd->min_label = save_min_label;
+      n.all->sd->max_label = save_max_label;
+      ec.ft_offset = save_ft_offset;
     }
-    ec.ft_offset -= step*count;
   }
 
-  void finish_example(vw& all, nn&, example& ec)
-  {
-    int save_raw_prediction = all.raw_prediction;
-    all.raw_prediction = -1;
-    return_simple_example(all, nullptr, ec);
-    all.raw_prediction = save_raw_prediction;
+  ec.l.simple.label = ld.label;
+
+  if (! converse) {
+    save_partial_prediction = n.output_layer.partial_prediction;
+    save_final_prediction = n.prediction;
+    save_ec_loss = n.output_layer.loss;
   }
 
-  void finish(nn& n)
+  if (n.dropout && ! converse)
   {
-    delete n.squared_loss;
-    free(n.hidden_units);
-    free(n.dropped_out);
-    free(n.hidden_units_pred);
-    free(n.hiddenbias_pred);
-	VW::dealloc_example(nullptr, n.output_layer);
-	VW::dealloc_example(nullptr, n.hiddenbias);
-	VW::dealloc_example(nullptr, n.outputweight);
-  }
-
-  base_learner* nn_setup(vw& all)
-  {
-    if (missing_option<size_t, true>(all, "nn", "Sigmoidal feedforward network with <k> hidden units"))
-      return nullptr;
-    new_options(all, "Neural Network options")
-      ("inpass", "Train or test sigmoidal feedforward network with input passthrough.")
-      ("multitask", "Share hidden layer across all reduced tasks.")
-      ("dropout", "Train or test sigmoidal feedforward network using dropout.")
-      ("meanfield", "Train or test sigmoidal feedforward network using mean field.");
-    add_options(all);
-    
-    po::variables_map& vm = all.vm;
-    nn& n = calloc_or_die<nn>();
-    n.all = &all;
-    //first parse for number of hidden units
-    n.k = (uint32_t)vm["nn"].as<size_t>();
-
-    if ( vm.count("dropout") ) {
-      n.dropout = true;
-      *all.file_options << " --dropout ";
+    for (unsigned int i = 0; i < n.k; ++i)
+    {
+      dropped_out[i] = ! dropped_out[i];
     }
 
-    if ( vm.count("multitask") ) {
-      n.multitask = true;
-      *all.file_options << " --multitask ";
-    }
+    converse = true;
+    goto CONVERSE;
+  }
 
-    if (n.multitask && ! all.quiet)
-      std::cerr << "using multitask sharing for neural network "
-                << (all.training ? "training" : "testing") 
+  ec.partial_prediction = save_partial_prediction;
+  ec.pred.scalar = save_final_prediction;
+  ec.loss = save_ec_loss;
+
+  n.all->sd = save_sd;
+  n.all->set_minmax (n.all->sd, sd.min_label);
+  n.all->set_minmax (n.all->sd, sd.max_label);
+}
+
+void multipredict(nn& n, base_learner& base, example& ec, size_t count, size_t step, polyprediction*pred, bool finalize_predictions) {
+  for (size_t c=0; c<count; c++) {
+    if (c == 0)
+      predict_or_learn_multi<false,true>(n, base, ec);
+    else
+      predict_or_learn_multi<false,false>(n, base, ec);
+    if (finalize_predictions) pred[c] = ec.pred;
+    else pred[c].scalar = ec.partial_prediction;
+    ec.ft_offset += step;
+  }
+  ec.ft_offset -= step*count;
+}
+
+void finish_example(vw& all, nn&, example& ec)
+{
+  int save_raw_prediction = all.raw_prediction;
+  all.raw_prediction = -1;
+  return_simple_example(all, nullptr, ec);
+  all.raw_prediction = save_raw_prediction;
+}
+
+void finish(nn& n)
+{
+  delete n.squared_loss;
+  free(n.hidden_units);
+  free(n.dropped_out);
+  free(n.hidden_units_pred);
+  free(n.hiddenbias_pred);
+  VW::dealloc_example(nullptr, n.output_layer);
+  VW::dealloc_example(nullptr, n.hiddenbias);
+  VW::dealloc_example(nullptr, n.outputweight);
+}
+
+base_learner* nn_setup(vw& all)
+{
+  if (missing_option<size_t, true>(all, "nn", "Sigmoidal feedforward network with <k> hidden units"))
+    return nullptr;
+  new_options(all, "Neural Network options")
+  ("inpass", "Train or test sigmoidal feedforward network with input passthrough.")
+  ("multitask", "Share hidden layer across all reduced tasks.")
+  ("dropout", "Train or test sigmoidal feedforward network using dropout.")
+  ("meanfield", "Train or test sigmoidal feedforward network using mean field.");
+  add_options(all);
+
+  po::variables_map& vm = all.vm;
+  nn& n = calloc_or_die<nn>();
+  n.all = &all;
+  //first parse for number of hidden units
+  n.k = (uint32_t)vm["nn"].as<size_t>();
+
+  if ( vm.count("dropout") ) {
+    n.dropout = true;
+    *all.file_options << " --dropout ";
+  }
+
+  if ( vm.count("multitask") ) {
+    n.multitask = true;
+    *all.file_options << " --multitask ";
+  }
+
+  if (n.multitask && ! all.quiet)
+    std::cerr << "using multitask sharing for neural network "
+              << (all.training ? "training" : "testing")
+              << std::endl;
+
+  if ( vm.count("meanfield") ) {
+    n.dropout = false;
+    if (! all.quiet)
+      std::cerr << "using mean field for neural network "
+                << (all.training ? "training" : "testing")
                 << std::endl;
-    
-    if ( vm.count("meanfield") ) {
-      n.dropout = false;
-      if (! all.quiet) 
-        std::cerr << "using mean field for neural network " 
-                  << (all.training ? "training" : "testing") 
-                  << std::endl;
-    }
+  }
 
-    if (n.dropout) 
-      if (! all.quiet)
-        std::cerr << "using dropout for neural network "
-                  << (all.training ? "training" : "testing") 
-                  << std::endl;
-
-    if (vm.count ("inpass")) {
-      n.inpass = true;
-      *all.file_options << " --inpass";
-
-    }
-
-    if (n.inpass && ! all.quiet)
-      std::cerr << "using input passthrough for neural network "
-                << (all.training ? "training" : "testing") 
+  if (n.dropout)
+    if (! all.quiet)
+      std::cerr << "using dropout for neural network "
+                << (all.training ? "training" : "testing")
                 << std::endl;
 
-    n.finished_setup = false;
-    n.squared_loss = getLossFunction (all, "squared", 0);
+  if (vm.count ("inpass")) {
+    n.inpass = true;
+    *all.file_options << " --inpass";
 
-    n.xsubi = all.random_seed;
-
-    n.save_xsubi = n.xsubi;
-
-    n.hidden_units = calloc_or_die<float>(n.k);
-    n.dropped_out = calloc_or_die<bool>(n.k);
-    n.hidden_units_pred = calloc_or_die<polyprediction>(n.k);
-    n.hiddenbias_pred = calloc_or_die<polyprediction>(n.k);
-    
-    base_learner* base = setup_base(all);
-    n.increment = base->increment;//Indexing of output layer is odd.
-    learner<nn>&l = init_learner(&n, base,
-                                 predict_or_learn_multi<true,true>, 
-                                 predict_or_learn_multi<false,true>,
-                                 n.k+1);
-    if (n.multitask)
-      l.set_multipredict(multipredict);      
-    l.set_finish(finish);
-    l.set_finish_example(finish_example);
-    l.set_end_pass(end_pass);
-    
-    return make_base(l);
   }
+
+  if (n.inpass && ! all.quiet)
+    std::cerr << "using input passthrough for neural network "
+              << (all.training ? "training" : "testing")
+              << std::endl;
+
+  n.finished_setup = false;
+  n.squared_loss = getLossFunction (all, "squared", 0);
+
+  n.xsubi = all.random_seed;
+
+  n.save_xsubi = n.xsubi;
+
+  n.hidden_units = calloc_or_die<float>(n.k);
+  n.dropped_out = calloc_or_die<bool>(n.k);
+  n.hidden_units_pred = calloc_or_die<polyprediction>(n.k);
+  n.hiddenbias_pred = calloc_or_die<polyprediction>(n.k);
+
+  base_learner* base = setup_base(all);
+  n.increment = base->increment;//Indexing of output layer is odd.
+  learner<nn>&l = init_learner(&n, base,
+                               predict_or_learn_multi<true,true>,
+                               predict_or_learn_multi<false,true>,
+                               n.k+1);
+  if (n.multitask)
+    l.set_multipredict(multipredict);
+  l.set_finish(finish);
+  l.set_finish_example(finish_example);
+  l.set_end_pass(end_pass);
+
+  return make_base(l);
+}
 
 /*
 

--- a/vowpalwabbit/noop.cc
+++ b/vowpalwabbit/noop.cc
@@ -12,6 +12,6 @@ void learn(char&, LEARNER::base_learner&, example&) {}
 LEARNER::base_learner* noop_setup(vw& all)
 {
   if (missing_option(all, true, "noop", "do no learning")) return nullptr;
-  
-  return &LEARNER::init_learner<char>(nullptr, learn, 1); 
+
+  return &LEARNER::init_learner<char>(nullptr, learn, 1);
 }

--- a/vowpalwabbit/oaa.cc
+++ b/vowpalwabbit/oaa.cc
@@ -30,7 +30,7 @@ void learn_randomized(oaa& o, LEARNER::base_learner& base, example& ec) {
 
   size_t prediction = ld.label;
   float best_partial_prediction = ec.partial_prediction;
-  
+
   ec.l.simple.label = -1.;
   ec.l.simple.weight *= ((float)o.k) / (float)o.num_subsample;
   size_t p = o.subsample_id;
@@ -66,43 +66,46 @@ void predict_or_learn(oaa& o, LEARNER::base_learner& base, example& ec) {
   for (uint32_t i=2; i<=o.k; i++)
     if (o.pred[i-1].scalar > o.pred[prediction-1].scalar)
       prediction = i;
-  
+
   if (is_learn) {
     for (uint32_t i=1; i<=o.k; i++) {
       ec.l.simple = { (mc_label_data.label == i) ? 1.f : -1.f, mc_label_data.weight, 0.f };
       ec.pred.scalar = o.pred[i-1].scalar;
       base.update(ec, i-1);
     }
-  } 
+  }
 
   if (print_all) {
     outputStringStream << "1:" << o.pred[0].scalar;
     for (uint32_t i=2; i<=o.k; i++) outputStringStream << ' ' << i << ':' << o.pred[i-1].scalar;
     o.all->print_text(o.all->raw_prediction, outputStringStream.str(), ec.tag);
   }
-  
+
   ec.pred.multiclass = prediction;
   ec.l.multi = mc_label_data;
 }
 
-void finish(oaa&o) { free(o.pred); free(o.subsample_order); }
+void finish(oaa&o) {
+  free(o.pred);
+  free(o.subsample_order);
+}
 
 LEARNER::base_learner* oaa_setup(vw& all)
 {
-  if (missing_option<size_t, true>(all, "oaa", "One-against-all multiclass with <k> labels")) 
+  if (missing_option<size_t, true>(all, "oaa", "One-against-all multiclass with <k> labels"))
     return nullptr;
   new_options(all, "oaa options")
-      ("oaa_subsample", po::value<size_t>(), "subsample this number of negative examples when learning");
+  ("oaa_subsample", po::value<size_t>(), "subsample this number of negative examples when learning");
   add_options(all);
-  
+
   oaa* data_ptr = calloc_or_die<oaa>(1);
   oaa& data = *data_ptr;
   data.k = all.vm["oaa"].as<size_t>();
 
-  if (all.sd->ldict && (data.k != all.sd->ldict->getK())) 
-	  THROW("error: you have " << all.sd->ldict->getK() << " named labels; use that as the argument to oaa")
-  
-  data.all = &all;
+  if (all.sd->ldict && (data.k != all.sd->ldict->getK()))
+    THROW("error: you have " << all.sd->ldict->getK() << " named labels; use that as the argument to oaa")
+
+    data.all = &all;
   data.pred = calloc_or_die<polyprediction>(data.k);
   data.num_subsample = 0;
   data.subsample_order = nullptr;
@@ -123,17 +126,17 @@ LEARNER::base_learner* oaa_setup(vw& all)
       }
     }
   }
-  
+
   LEARNER::learner<oaa>* l;
   if (all.raw_prediction > 0)
-    l = &LEARNER::init_multiclass_learner(data_ptr, setup_base(all), predict_or_learn<true, true>, 
-					  predict_or_learn<false, true>, all.p, data.k);
+    l = &LEARNER::init_multiclass_learner(data_ptr, setup_base(all), predict_or_learn<true, true>,
+                                          predict_or_learn<false, true>, all.p, data.k);
   else
-    l = &LEARNER::init_multiclass_learner(data_ptr, setup_base(all),predict_or_learn<true, false>, 
-					  predict_or_learn<false, false>, all.p, data.k);
+    l = &LEARNER::init_multiclass_learner(data_ptr, setup_base(all),predict_or_learn<true, false>,
+                                          predict_or_learn<false, false>, all.p, data.k);
   if (data.num_subsample > 0)
     l->set_learn(learn_randomized);
   l->set_finish(finish);
-  
+
   return make_base(*l);
 }

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -146,9 +146,9 @@ void parse_dictionary_argument(vw&all, string str) {
     cerr << "scanned dictionary '" << s << "' from '" << fname << "', hash=" << hex << fd_hash << endl;
 
   // see if we've already read this dictionary
-  for (size_t id=0; id<all.read_dictionaries.size(); id++)
-    if (all.read_dictionaries[id].file_hash == fd_hash) {
-      all.namespace_dictionaries[(size_t)ns].push_back(all.read_dictionaries[id].dict);
+  for (size_t id=0; id<all.loaded_dictionaries.size(); id++)
+    if (all.loaded_dictionaries[id].file_hash == fd_hash) {
+      all.namespace_dictionaries[(size_t)ns].push_back(all.loaded_dictionaries[id].dict);
       return;
     }
 
@@ -219,7 +219,7 @@ void parse_dictionary_argument(vw&all, string str) {
   all.namespace_dictionaries[(size_t)ns].push_back(map);
   dictionary_info info = { calloc_or_die<char>(strlen(s)+1), fd_hash, map };
   strcpy(info.name, s);
-  all.read_dictionaries.push_back(info);
+  all.loaded_dictionaries.push_back(info);
 }
 
 void parse_affix_argument(vw&all, string str) {
@@ -1324,11 +1324,11 @@ namespace VW {
       if (all.final_prediction_sink[i] != 1)
 	io_buf::close_file_or_socket(all.final_prediction_sink[i]);
     all.final_prediction_sink.delete_v();
-    for (size_t i=0; i<all.read_dictionaries.size(); i++) {
-      free(all.read_dictionaries[i].name);
-      all.read_dictionaries[i].dict->iter(delete_dictionary_entry);
-      all.read_dictionaries[i].dict->delete_v();
-      delete all.read_dictionaries[i].dict;
+    for (size_t i=0; i<all.loaded_dictionaries.size(); i++) {
+      free(all.loaded_dictionaries[i].name);
+      all.loaded_dictionaries[i].dict->iter(delete_dictionary_entry);
+      all.loaded_dictionaries[i].dict->delete_v();
+      delete all.loaded_dictionaries[i].dict;
     }
     delete all.loss;
 

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -846,7 +846,7 @@ void parse_output_preds(vw& all)
     if (!all.quiet) {
       cerr << "raw predictions = " <<  vm["raw_predictions"].as< string >() << endl;
       if (vm.count("binary"))
-        cerr << "Warning: --raw has no defined value when --binary specified, expect no output" << endl;
+        cerr << "Warning: --raw_predictions has no defined value when --binary specified, expect no output" << endl;
     }
     if (strcmp(vm["raw_predictions"].as< string >().c_str(), "stdout") == 0)
       all.raw_prediction = 1;//stdout

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -63,11 +63,11 @@ using namespace std;
 //
 bool ends_with(string const &fullString, string const &ending)
 {
-    if (fullString.length() > ending.length()) {
-        return (fullString.compare(fullString.length() - ending.length(), ending.length(), ending) == 0);
-    } else {
-        return false;
-    }
+  if (fullString.length() > ending.length()) {
+    return (fullString.compare(fullString.length() - ending.length(), ending.length(), ending) == 0);
+  } else {
+    return false;
+  }
 }
 
 unsigned long long hash_file_contents(io_buf *io, int f) {
@@ -79,7 +79,7 @@ unsigned long long hash_file_contents(io_buf *io, int f) {
     for (size_t i=0; i<n; i++) {
       v *= 341789041;
       v += buf[i];
-}  
+    }
   }
   return v;
 }
@@ -100,21 +100,21 @@ string find_in_path(vector<string> paths, string fname) {
 #else
   string delimiter = "/";
 #endif
-  for (string path : paths) {
+for (string path : paths) {
     string full = ends_with(path, delimiter) ? (path + fname) : (path + delimiter + fname);
     ifstream f(full.c_str());
     if (f.good())
       return full;
   }
   return "";
-/*
-  for (string path : paths) {
-    boost::filesystem::path p(path);
-    p /= fname;
-    if (boost::filesystem::exists(p) && !boost::filesystem::is_directory(p))
-      return p;
-  }
-*/
+  /*
+    for (string path : paths) {
+      boost::filesystem::path p(path);
+      p /= fname;
+      if (boost::filesystem::exists(p) && !boost::filesystem::is_directory(p))
+        return p;
+    }
+  */
 }
 
 void parse_dictionary_argument(vw&all, string str) {
@@ -130,7 +130,7 @@ void parse_dictionary_argument(vw&all, string str) {
   }
 
   string fname = find_in_path(all.dictionary_path, string(s));
-  if (fname == "")  
+  if (fname == "")
     THROW("error: cannot find dictionary '" << s << "' in path; try adding --dictionary_path");
 
   bool is_gzip = ends_with(fname, ".gz");
@@ -153,7 +153,7 @@ void parse_dictionary_argument(vw&all, string str) {
     }
 
   feature_dict* map = new feature_dict(1023, nullptr, substring_equal);
-  
+
   example *ec = VW::alloc_examples(all.p->lp.label_size, 1);
   fd = io->open_file(fname.c_str(), all.stdin_off, io_buf::READ);
   if (fd < 0)
@@ -172,8 +172,8 @@ void parse_dictionary_argument(vw&all, string str) {
       if (pos >= size - 1) {
         size *= 2;
         buffer = (char*)realloc(buffer, size);
-        if (buffer == nullptr) 
-	  THROW("error: memory allocation failed in reading dictionary");
+        if (buffer == nullptr)
+          THROW("error: memory allocation failed in reading dictionary");
       }
     } while ( (rc != EOF) && (rc != '\n') && (nread > 0) );
     buffer[pos] = 0;
@@ -207,14 +207,18 @@ void parse_dictionary_argument(vw&all, string str) {
     map->put(ss, hash, arr);
 
     // clear up ec
-    ec->tag.erase(); ec->indices.erase();
-    for (size_t i=0; i<256; i++) { ec->atomics[i].erase(); ec->audit_features[i].erase(); }
+    ec->tag.erase();
+    ec->indices.erase();
+    for (size_t i=0; i<256; i++) {
+      ec->atomics[i].erase();
+      ec->audit_features[i].erase();
+    }
   } while ((rc != EOF) && (nread > 0));
   free(buffer);
   io->close_file();
   VW::dealloc_example(all.p->lp.delete_label, *ec);
   free(ec);
-  
+
   cerr << "dictionary " << s << " contains " << map->size() << " item" << (map->size() == 1 ? "\n" : "s\n");
   all.namespace_dictionaries[(size_t)ns].push_back(map);
   dictionary_info info = { calloc_or_die<char>(strlen(s)+1), fd_hash, map };
@@ -231,9 +235,14 @@ void parse_affix_argument(vw&all, string str) {
   while (p != 0) {
     char*q = p;
     uint16_t prefix = 1;
-    if (q[0] == '+') { q++; }
-    else if (q[0] == '-') { prefix = 0; q++; }
-    if ((q[0] < '1') || (q[0] > '7')) 
+    if (q[0] == '+') {
+      q++;
+    }
+    else if (q[0] == '-') {
+      prefix = 0;
+      q++;
+    }
+    if ((q[0] < '1') || (q[0] > '7'))
       THROW("malformed affix argument (length must be 1..7): " << p);
 
     uint16_t len = (uint16_t)(q[0] - '0');
@@ -241,11 +250,11 @@ void parse_affix_argument(vw&all, string str) {
     if (q[1] != 0) {
       if (valid_ns(q[1]))
         ns = (uint16_t)q[1];
-      else 
-	THROW("malformed affix argument (invalid namespace): " << p);
+      else
+        THROW("malformed affix argument (invalid namespace): " << p);
 
-      if (q[2] != 0) 
-	THROW("malformed affix argument (too long): " << p);
+      if (q[2] != 0)
+        THROW("malformed affix argument (too long): " << p);
     }
 
     uint16_t afx = (len << 1) | (prefix & 0x1);
@@ -261,11 +270,11 @@ void parse_affix_argument(vw&all, string str) {
 void parse_diagnostics(vw& all, int argc)
 {
   new_options(all, "Diagnostic options")
-    ("version","Version information")
-    ("audit,a", "print weights of features")
-    ("progress,P", po::value< string >(), "Progress update frequency. int: additive, float: multiplicative")
-    ("quiet", "Don't output disgnostics and progress updates")
-    ("help,h","Look here: http://hunch.net/~vw/ and click on Tutorial.");
+  ("version","Version information")
+  ("audit,a", "print weights of features")
+  ("progress,P", po::value< string >(), "Progress update frequency. int: additive, float: multiplicative")
+  ("quiet", "Don't output disgnostics and progress updates")
+  ("help,h","Look here: http://hunch.net/~vw/ and click on Tutorial.");
   add_options(all);
 
   po::variables_map& vm = all.vm;
@@ -318,9 +327,9 @@ void parse_diagnostics(vw& all, int argc)
         all.sd->dump_interval = 1.0;
       }
     }
-  }  
+  }
 
-  if (vm.count("audit")){
+  if (vm.count("audit")) {
     all.audit = true;
   }
 }
@@ -328,45 +337,45 @@ void parse_diagnostics(vw& all, int argc)
 void parse_source(vw& all)
 {
   new_options(all, "Input options")
-    ("data,d", po::value< string >(), "Example Set")
-    ("daemon", "persistent daemon mode on port 26542")
-    ("port", po::value<size_t>(),"port to listen on; use 0 to pick unused port")
-    ("num_children", po::value<size_t>(&(all.num_children)), "number of children for persistent daemon mode")
-    ("pid_file", po::value< string >(), "Write pid file in persistent daemon mode")
-    ("port_file", po::value< string >(), "Write port used in persistent daemon mode")
-    ("cache,c", "Use a cache.  The default is <data>.cache")
-    ("cache_file", po::value< vector<string> >(), "The location(s) of cache_file.")
-    ("kill_cache,k", "do not reuse existing cache: create a new one always")
-    ("compressed", "use gzip format whenever possible. If a cache file is being created, this option creates a compressed cache file. A mixture of raw-text & compressed inputs are supported with autodetection.")
-    ("no_stdin", "do not default to reading from stdin");
+  ("data,d", po::value< string >(), "Example Set")
+  ("daemon", "persistent daemon mode on port 26542")
+  ("port", po::value<size_t>(),"port to listen on; use 0 to pick unused port")
+  ("num_children", po::value<size_t>(&(all.num_children)), "number of children for persistent daemon mode")
+  ("pid_file", po::value< string >(), "Write pid file in persistent daemon mode")
+  ("port_file", po::value< string >(), "Write port used in persistent daemon mode")
+  ("cache,c", "Use a cache.  The default is <data>.cache")
+  ("cache_file", po::value< vector<string> >(), "The location(s) of cache_file.")
+  ("kill_cache,k", "do not reuse existing cache: create a new one always")
+  ("compressed", "use gzip format whenever possible. If a cache file is being created, this option creates a compressed cache file. A mixture of raw-text & compressed inputs are supported with autodetection.")
+  ("no_stdin", "do not default to reading from stdin");
   add_options(all);
 
   // Be friendly: if -d was left out, treat positional param as data file
-  po::positional_options_description p;  
+  po::positional_options_description p;
   p.add("data", -1);
   po::parsed_options pos = po::command_line_parser(all.args).
-    style(po::command_line_style::default_style ^ po::command_line_style::allow_guessing).
-    options(all.opts).positional(p).run();
+                           style(po::command_line_style::default_style ^ po::command_line_style::allow_guessing).
+                           options(all.opts).positional(p).run();
   all.vm = po::variables_map();
   po::store(pos, all.vm);
   po::variables_map& vm = all.vm;
- 
+
   //begin input source
   if (vm.count("no_stdin"))
     all.stdin_off = true;
-  
+
   if ( (vm.count("total") || vm.count("node") || vm.count("unique_id")) && !(vm.count("total") && vm.count("node") && vm.count("unique_id")) )
     THROW("you must specificy unique_id, total, and node if you specify any");
-  
+
   if (vm.count("daemon") || vm.count("pid_file") || (vm.count("port") && !all.active) ) {
     all.daemon = true;
-    
+
     // allow each child to process up to 1e5 connections
     all.numpasses = (size_t) 1e5;
   }
 
   if (vm.count("compressed"))
-      set_compressed(all.p);
+    set_compressed(all.p);
 
   if (vm.count("data")) {
     all.data_filename = vm["data"].as<string>();
@@ -379,10 +388,10 @@ void parse_source(vw& all)
     THROW("invert_hash is incompatible with a cache file.  Use it in single pass mode only.");
 
   if(!all.holdout_set_off && (vm.count("output_feature_regularizer_binary") || vm.count("output_feature_regularizer_text")))
-    {
-      all.holdout_set_off = true;
-      cerr<<"Making holdout_set_off=true since output regularizer specified\n";
-    }
+  {
+    all.holdout_set_off = true;
+    cerr<<"Making holdout_set_off=true since output regularizer specified\n";
+  }
 }
 
 bool interactions_settings_doubled = false; // local setting setted in parse_modules()
@@ -390,37 +399,37 @@ bool interactions_settings_doubled = false; // local setting setted in parse_mod
 void parse_feature_tweaks(vw& all)
 {
   new_options(all, "Feature options")
-    ("hash", po::value< string > (), "how to hash the features. Available options: strings, all")
-    ("ignore", po::value< vector<unsigned char> >(), "ignore namespaces beginning with character <arg>")
-    ("keep", po::value< vector<unsigned char> >(), "keep namespaces beginning with character <arg>")
-    ("redefine", po::value< vector<string> >(), "redefine namespaces beginning with characters of string S as namespace N. <arg> shall be in form 'N:=S' where := is operator. Empty N or S are treated as default namespace. Use ':' as a wildcard in S.")
-    ("bit_precision,b", po::value<size_t>(), "number of bits in the feature table")
-    ("noconstant", "Don't add a constant feature")
-    ("constant,C", po::value<float>(&(all.initial_constant)), "Set initial value of constant")
-    ("ngram", po::value< vector<string> >(), "Generate N grams. To generate N grams for a single namespace 'foo', arg should be fN.")
-    ("skips", po::value< vector<string> >(), "Generate skips in N grams. This in conjunction with the ngram tag can be used to generate generalized n-skip-k-gram. To generate n-skips for a single namespace 'foo', arg should be fN.")
-    ("feature_limit", po::value< vector<string> >(), "limit to N features. To apply to a single namespace 'foo', arg should be fN")
-    ("affix", po::value<string>(), "generate prefixes/suffixes of features; argument '+2a,-3b,+1' means generate 2-char prefixes for namespace a, 3-char suffixes for b and 1 char prefixes for default namespace")
-    ("spelling", po::value< vector<string> >(), "compute spelling features for a give namespace (use '_' for default namespace)")
-    ("dictionary", po::value< vector<string> >(), "read a dictionary for additional features (arg either 'x:file' or just 'file')")
-    ("dictionary_path", po::value< vector<string> >(), "look in this directory for dictionaries; defaults to current directory or env{PATH}")
-    ("interactions", po::value< vector<string> > (), "Create feature interactions of any level between namespaces.")
-    ("permutations", "Use permutations instead of combinations for feature interactions of same namespace.")
-    ("leave_duplicate_interactions", "Don't remove interactions with duplicate combinations of namespaces. For ex. this is a duplicate: '-q ab -q ba' and a lot more in '-q ::'.")
-    ("quadratic,q", po::value< vector<string> > (), "Create and use quadratic features")
-    ("q:", po::value< string >(), ": corresponds to a wildcard for all printable characters")
-    ("cubic", po::value< vector<string> > (),
-     "Create and use cubic features");
+  ("hash", po::value< string > (), "how to hash the features. Available options: strings, all")
+  ("ignore", po::value< vector<unsigned char> >(), "ignore namespaces beginning with character <arg>")
+  ("keep", po::value< vector<unsigned char> >(), "keep namespaces beginning with character <arg>")
+  ("redefine", po::value< vector<string> >(), "redefine namespaces beginning with characters of string S as namespace N. <arg> shall be in form 'N:=S' where := is operator. Empty N or S are treated as default namespace. Use ':' as a wildcard in S.")
+  ("bit_precision,b", po::value<size_t>(), "number of bits in the feature table")
+  ("noconstant", "Don't add a constant feature")
+  ("constant,C", po::value<float>(&(all.initial_constant)), "Set initial value of constant")
+  ("ngram", po::value< vector<string> >(), "Generate N grams. To generate N grams for a single namespace 'foo', arg should be fN.")
+  ("skips", po::value< vector<string> >(), "Generate skips in N grams. This in conjunction with the ngram tag can be used to generate generalized n-skip-k-gram. To generate n-skips for a single namespace 'foo', arg should be fN.")
+  ("feature_limit", po::value< vector<string> >(), "limit to N features. To apply to a single namespace 'foo', arg should be fN")
+  ("affix", po::value<string>(), "generate prefixes/suffixes of features; argument '+2a,-3b,+1' means generate 2-char prefixes for namespace a, 3-char suffixes for b and 1 char prefixes for default namespace")
+  ("spelling", po::value< vector<string> >(), "compute spelling features for a give namespace (use '_' for default namespace)")
+  ("dictionary", po::value< vector<string> >(), "read a dictionary for additional features (arg either 'x:file' or just 'file')")
+  ("dictionary_path", po::value< vector<string> >(), "look in this directory for dictionaries; defaults to current directory or env{PATH}")
+  ("interactions", po::value< vector<string> > (), "Create feature interactions of any level between namespaces.")
+  ("permutations", "Use permutations instead of combinations for feature interactions of same namespace.")
+  ("leave_duplicate_interactions", "Don't remove interactions with duplicate combinations of namespaces. For ex. this is a duplicate: '-q ab -q ba' and a lot more in '-q ::'.")
+  ("quadratic,q", po::value< vector<string> > (), "Create and use quadratic features")
+  ("q:", po::value< string >(), ": corresponds to a wildcard for all printable characters")
+  ("cubic", po::value< vector<string> > (),
+   "Create and use cubic features");
   add_options(all);
 
   po::variables_map& vm = all.vm;
 
   //feature manipulation
   string hash_function("strings");
-  if(vm.count("hash")) 
+  if(vm.count("hash"))
     hash_function = vm["hash"].as<string>();
   all.p->hasher = getHasher(hash_function);
-      
+
   if (vm.count("spelling")) {
     vector<string> spelling_ns = vm["spelling"].as< vector<string> >();
     for (size_t id=0; id<spelling_ns.size(); id++) {
@@ -435,7 +444,7 @@ void parse_feature_tweaks(vw& all)
     *all.file_options << " --affix " << vm["affix"].as<string>();
   }
 
-  if(vm.count("ngram")){
+  if(vm.count("ngram")) {
     if(vm.count("sort_features"))
       THROW("ngram is incompatible with sort_features.");
 
@@ -444,259 +453,259 @@ void parse_feature_tweaks(vw& all)
   }
 
   if(vm.count("skips"))
-    {
-      if(!vm.count("ngram"))
-	THROW("You can not skip unless ngram is > 1");
+  {
+    if(!vm.count("ngram"))
+      THROW("You can not skip unless ngram is > 1");
 
-      all.skip_strings = vm["skips"].as<vector<string> >();
-      compile_gram(all.skip_strings, all.skips, (char*)"skips", all.quiet);
-    }
+    all.skip_strings = vm["skips"].as<vector<string> >();
+    compile_gram(all.skip_strings, all.skips, (char*)"skips", all.quiet);
+  }
 
   if(vm.count("feature_limit"))
-    {
-      all.limit_strings = vm["feature_limit"].as< vector<string> >();
-      compile_limits(all.limit_strings, all.limit, all.quiet);
-    }
+  {
+    all.limit_strings = vm["feature_limit"].as< vector<string> >();
+    compile_limits(all.limit_strings, all.limit, all.quiet);
+  }
 
   if (vm.count("bit_precision"))
-    {
-      uint32_t new_bits = (uint32_t)vm["bit_precision"].as< size_t>();
-      if (all.default_bits == false && new_bits != all.num_bits)
-	THROW("Number of bits is set to " << new_bits << " and " << all.num_bits << " by argument and model.  That does not work.");
+  {
+    uint32_t new_bits = (uint32_t)vm["bit_precision"].as< size_t>();
+    if (all.default_bits == false && new_bits != all.num_bits)
+      THROW("Number of bits is set to " << new_bits << " and " << all.num_bits << " by argument and model.  That does not work.");
 
-      all.default_bits = false;
-      all.num_bits = new_bits;
-      if (all.num_bits > min(31, sizeof(size_t)*8 - 3))
-	THROW("Only " << min(31, sizeof(size_t)*8 - 3) << " or fewer bits allowed.  If this is a serious limit, speak up.");
-    }
+    all.default_bits = false;
+    all.num_bits = new_bits;
+    if (all.num_bits > min(31, sizeof(size_t)*8 - 3))
+      THROW("Only " << min(31, sizeof(size_t)*8 - 3) << " or fewer bits allowed.  If this is a serious limit, speak up.");
+  }
 
   all.permutations = vm.count("permutations");
 
-     // prepare namespace interactions
-     v_array<v_string> expanded_interactions = v_init<v_string>();
-     
+  // prepare namespace interactions
+  v_array<v_string> expanded_interactions = v_init<v_string>();
+
   if ( ( ((!all.pairs.empty() || !all.triples.empty() || !all.interactions.empty()) && /*data was restored from old model file directly to v_array and will be overriden automatically*/
-       (vm.count("quadratic") || vm.count("cubic") || vm.count("interactions")) ) )
-         ||
+          (vm.count("quadratic") || vm.count("cubic") || vm.count("interactions")) ) )
+       ||
        interactions_settings_doubled /*settings were restored from model file to file_options and overriden by params from command line*/)
   {
-      cerr << "WARNING: model file has set of {-q, --cubic, --interactions} settings stored, but they'll be OVERRIDEN by set of {-q, --cubic, --interactions} settings from command line.\n";
+    cerr << "WARNING: model file has set of {-q, --cubic, --interactions} settings stored, but they'll be OVERRIDEN by set of {-q, --cubic, --interactions} settings from command line.\n";
 
-      // in case arrays were already filled in with values from old model file - reset them
-      if (!all.pairs.empty()) all.pairs.clear();
-      if (!all.triples.empty()) all.triples.clear();
-      if (all.interactions.size() > 0)
-      {
-          for (v_string* i = all.interactions.begin; i != all.interactions.end; ++i) i->delete_v();
-          all.interactions.delete_v();
-      }
+    // in case arrays were already filled in with values from old model file - reset them
+    if (!all.pairs.empty()) all.pairs.clear();
+    if (!all.triples.empty()) all.triples.clear();
+    if (all.interactions.size() > 0)
+    {
+      for (v_string* i = all.interactions.begin; i != all.interactions.end; ++i) i->delete_v();
+      all.interactions.delete_v();
+    }
   }
 
-     if (vm.count("quadratic"))
-     {
-         const vector<string> vec_arg = vm["quadratic"].as< vector<string> >();
-         if (!all.quiet)
-         {
-             cerr << "creating quadratic features for pairs: ";
+  if (vm.count("quadratic"))
+  {
+    const vector<string> vec_arg = vm["quadratic"].as< vector<string> >();
+    if (!all.quiet)
+    {
+      cerr << "creating quadratic features for pairs: ";
 
-             for (vector<string>::const_iterator i = vec_arg.begin(); i != vec_arg.end(); ++i)
-          {
-                 if (!all.quiet) cerr << *i << " ";
-              *all.file_options << " --quadratic " << *i;
-         }
+      for (vector<string>::const_iterator i = vec_arg.begin(); i != vec_arg.end(); ++i)
+      {
+        if (!all.quiet) cerr << *i << " ";
+        *all.file_options << " --quadratic " << *i;
       }
-         expanded_interactions = INTERACTIONS::expand_interactions(vec_arg, 2, "error, quadratic features must involve two sets.");
-     
-         if (!all.quiet) cerr << endl;
-     }
-     
-     if (vm.count("cubic"))
-     {
-         vector<string> vec_arg = vm["cubic"].as< vector<string> >();
-         if (!all.quiet)
-         {
-             cerr << "creating cubic features for triples: ";
-             for (vector<string>::const_iterator i = vec_arg.begin(); i != vec_arg.end(); ++i)
-          {
-                 if (!all.quiet) cerr << *i << " ";
-              *all.file_options << " --cubic " << *i;
-         }
-      }
-     
-         v_array<v_string> exp_cubic = INTERACTIONS::expand_interactions(vec_arg, 3, "error, cubic features must involve three sets.");
-         push_many(expanded_interactions, exp_cubic.begin, exp_cubic.size());
-         exp_cubic.delete_v();
-     
-         if (!all.quiet) cerr << endl;
-     }
-     
-     if (vm.count("interactions"))
-     {
-         vector<string> vec_arg = vm["interactions"].as< vector<string> >();
-         if (!all.quiet)
-         {
-             cerr << "creating features for following interactions: ";
-             for (vector<string>::const_iterator i = vec_arg.begin(); i != vec_arg.end(); ++i)
-          {
-                 if (!all.quiet) cerr << *i << " ";
-              *all.file_options << " --interactions " << *i;
-         }
-      }
-     
-         v_array<v_string> exp_inter = INTERACTIONS::expand_interactions(vec_arg, 0, "");
-         push_many(expanded_interactions, exp_inter.begin, exp_inter.size());
-         exp_inter.delete_v();
-     
-         if (!all.quiet) cerr << endl;
-     }
-     
-     if (expanded_interactions.size() > 0)
-     {
-     
-         size_t removed_cnt;
-         size_t sorted_cnt;
-         INTERACTIONS::sort_and_filter_duplicate_interactions(expanded_interactions, !vm.count("leave_duplicate_interactions"), removed_cnt, sorted_cnt);
-     
-         if (removed_cnt > 0)
-             cerr << "WARNING: duplicate namespace interactions were found. Removed: " << removed_cnt << '.' << endl << "You can use --leave_duplicate_interactions to disable this behaviour." << endl;
-         if (sorted_cnt > 0)
-             cerr << "WARNING: some interactions contain duplicate characters and their characters order has been changed. Interactions affected: " << sorted_cnt << '.' << endl;
-     
+    }
+    expanded_interactions = INTERACTIONS::expand_interactions(vec_arg, 2, "error, quadratic features must involve two sets.");
 
-      if (all.interactions.size() > 0)
-      { // should be empty, but just in case...
-          for (v_string* i = all.interactions.begin; i != all.interactions.end; ++i) i->delete_v();
-          all.interactions.delete_v();
-      }
+    if (!all.quiet) cerr << endl;
+  }
 
-         all.interactions = expanded_interactions;
-     
-         // copy interactions of size 2 and 3 to old vectors for backward compatibility
-         for (v_string* i = expanded_interactions.begin; i != expanded_interactions.end; ++i)
-         {
-             const size_t len = i->size();
-             if (len == 2)
-                 all.pairs.push_back(v_string2string(*i));
-             else if (len == 3)
-                 all.triples.push_back(v_string2string(*i));
-         }
-     }
+  if (vm.count("cubic"))
+  {
+    vector<string> vec_arg = vm["cubic"].as< vector<string> >();
+    if (!all.quiet)
+    {
+      cerr << "creating cubic features for triples: ";
+      for (vector<string>::const_iterator i = vec_arg.begin(); i != vec_arg.end(); ++i)
+      {
+        if (!all.quiet) cerr << *i << " ";
+        *all.file_options << " --cubic " << *i;
+      }
+    }
+
+    v_array<v_string> exp_cubic = INTERACTIONS::expand_interactions(vec_arg, 3, "error, cubic features must involve three sets.");
+    push_many(expanded_interactions, exp_cubic.begin, exp_cubic.size());
+    exp_cubic.delete_v();
+
+    if (!all.quiet) cerr << endl;
+  }
+
+  if (vm.count("interactions"))
+  {
+    vector<string> vec_arg = vm["interactions"].as< vector<string> >();
+    if (!all.quiet)
+    {
+      cerr << "creating features for following interactions: ";
+      for (vector<string>::const_iterator i = vec_arg.begin(); i != vec_arg.end(); ++i)
+      {
+        if (!all.quiet) cerr << *i << " ";
+        *all.file_options << " --interactions " << *i;
+      }
+    }
+
+    v_array<v_string> exp_inter = INTERACTIONS::expand_interactions(vec_arg, 0, "");
+    push_many(expanded_interactions, exp_inter.begin, exp_inter.size());
+    exp_inter.delete_v();
+
+    if (!all.quiet) cerr << endl;
+  }
+
+  if (expanded_interactions.size() > 0)
+  {
+
+    size_t removed_cnt;
+    size_t sorted_cnt;
+    INTERACTIONS::sort_and_filter_duplicate_interactions(expanded_interactions, !vm.count("leave_duplicate_interactions"), removed_cnt, sorted_cnt);
+
+    if (removed_cnt > 0)
+      cerr << "WARNING: duplicate namespace interactions were found. Removed: " << removed_cnt << '.' << endl << "You can use --leave_duplicate_interactions to disable this behaviour." << endl;
+    if (sorted_cnt > 0)
+      cerr << "WARNING: some interactions contain duplicate characters and their characters order has been changed. Interactions affected: " << sorted_cnt << '.' << endl;
+
+
+    if (all.interactions.size() > 0)
+    { // should be empty, but just in case...
+      for (v_string* i = all.interactions.begin; i != all.interactions.end; ++i) i->delete_v();
+      all.interactions.delete_v();
+    }
+
+    all.interactions = expanded_interactions;
+
+    // copy interactions of size 2 and 3 to old vectors for backward compatibility
+    for (v_string* i = expanded_interactions.begin; i != expanded_interactions.end; ++i)
+    {
+      const size_t len = i->size();
+      if (len == 2)
+        all.pairs.push_back(v_string2string(*i));
+      else if (len == 3)
+        all.triples.push_back(v_string2string(*i));
+    }
+  }
 
 
   for (size_t i = 0; i < 256; i++)
     all.ignore[i] = false;
   all.ignore_some = false;
-  
+
   if (vm.count("ignore"))
+  {
+    all.ignore_some = true;
+
+    vector<unsigned char> ignore = vm["ignore"].as< vector<unsigned char> >();
+    for (vector<unsigned char>::iterator i = ignore.begin(); i != ignore.end(); i++)
     {
-      all.ignore_some = true;
-
-      vector<unsigned char> ignore = vm["ignore"].as< vector<unsigned char> >();
-      for (vector<unsigned char>::iterator i = ignore.begin(); i != ignore.end();i++)
-	{
-	  all.ignore[*i] = true;
-	}
-      if (!all.quiet)
-	{
-	  cerr << "ignoring namespaces beginning with: ";
-	  for (vector<unsigned char>::iterator i = ignore.begin(); i != ignore.end();i++)
-	    cerr << *i << " ";
-
-	  cerr << endl;
-	}
+      all.ignore[*i] = true;
     }
+    if (!all.quiet)
+    {
+      cerr << "ignoring namespaces beginning with: ";
+      for (vector<unsigned char>::iterator i = ignore.begin(); i != ignore.end(); i++)
+        cerr << *i << " ";
+
+      cerr << endl;
+    }
+  }
 
   if (vm.count("keep"))
+  {
+    for (size_t i = 0; i < 256; i++)
+      all.ignore[i] = true;
+
+    all.ignore_some = true;
+
+    vector<unsigned char> keep = vm["keep"].as< vector<unsigned char> >();
+    for (vector<unsigned char>::iterator i = keep.begin(); i != keep.end(); i++)
     {
-      for (size_t i = 0; i < 256; i++)
-        all.ignore[i] = true;
-
-      all.ignore_some = true;
-
-      vector<unsigned char> keep = vm["keep"].as< vector<unsigned char> >();
-      for (vector<unsigned char>::iterator i = keep.begin(); i != keep.end();i++)
-	{
-	  all.ignore[*i] = false;
-	}
-      if (!all.quiet)
-	{
-	  cerr << "using namespaces beginning with: ";
-	  for (vector<unsigned char>::iterator i = keep.begin(); i != keep.end();i++)
-	    cerr << *i << " ";
-
-	  cerr << endl;
-	}
+      all.ignore[*i] = false;
     }
+    if (!all.quiet)
+    {
+      cerr << "using namespaces beginning with: ";
+      for (vector<unsigned char>::iterator i = keep.begin(); i != keep.end(); i++)
+        cerr << *i << " ";
+
+      cerr << endl;
+    }
+  }
 
   // --redefine param code
   all.redefine_some = false; // false by default
 
   if (vm.count("redefine"))
   {
-      // initail values: i-th namespace is redefined to i itself
-      for (size_t i = 0; i < 256; i++)
-          all.redefine[i] = (unsigned char)i;
+    // initail values: i-th namespace is redefined to i itself
+    for (size_t i = 0; i < 256; i++)
+      all.redefine[i] = (unsigned char)i;
 
-      // note: --redefine declaration order is matter
-      // so --redefine :=L --redefine ab:=M  --ignore L  will ignore all except a and b under new M namspace
+    // note: --redefine declaration order is matter
+    // so --redefine :=L --redefine ab:=M  --ignore L  will ignore all except a and b under new M namspace
 
-      vector< string > arg_list = vm["redefine"].as< vector< string > >();
-      for (vector<string>::iterator arg_iter = arg_list.begin(); arg_iter != arg_list.end(); arg_iter++)
+    vector< string > arg_list = vm["redefine"].as< vector< string > >();
+    for (vector<string>::iterator arg_iter = arg_list.begin(); arg_iter != arg_list.end(); arg_iter++)
+    {
+      string arg = *arg_iter;
+      size_t arg_len = arg.length();
+
+      size_t operator_pos = 0; //keeps operator pos + 1 to stay unsigned type
+      bool operator_found = false;
+      unsigned char new_namespace = ' ';
+
+      // let's find operator ':=' position in N:=S
+      for (size_t i = 0; i < arg_len; i++)
       {
-          string arg = *arg_iter;
-          size_t arg_len = arg.length();
-
-          size_t operator_pos = 0; //keeps operator pos + 1 to stay unsigned type
-          bool operator_found = false;
-          unsigned char new_namespace = ' ';
-
-          // let's find operator ':=' position in N:=S
-          for (size_t i = 0; i < arg_len; i++)
-          {
-              if (operator_found)
-              {
-                  if (i > 2) { new_namespace = arg[0];} //N is not empty
-                  break;
-              } else
-                  if (arg[i] == ':')
-                      operator_pos = i+1;
-                  else
-                      if ( (arg[i] == '=') && (operator_pos == i) )
-                          operator_found = true;
+        if (operator_found)
+        {
+          if (i > 2) {
+            new_namespace = arg[0]; //N is not empty
           }
-
-          if (!operator_found)
-	    THROW("argument of --redefine is malformed. Valid format is N:=S, :=S or N:=");
-
-          if (++operator_pos > 3) // seek operator end
-              cerr << "WARNING: multiple namespaces are used in target part of --redefine argument. Only first one ('" << new_namespace << "') will be used as target namespace." << endl;
-
-          all.redefine_some = true;         
-
-          // case ':=S' doesn't require any additional code as new_namespace = ' ' by default
-
-          if (operator_pos == arg_len) // S is empty, default namespace shall be used
-              all.redefine[(int) ' '] = new_namespace;
-          else
-              for (size_t i = operator_pos; i < arg_len; i++)
-              { // all namespaces from S are redefined to N
-                  unsigned char c = arg[i];
-                  if (c != ':')
-                      all.redefine[c] = new_namespace;
-                  else
-                  { // wildcard found: redefine all except default and break
-                      for (size_t i = 0; i < 256; i++)
-                         all.redefine[i] = new_namespace;
-                      break; //break processing S
-                  }
-              }
-
+          break;
+        } else if (arg[i] == ':')
+          operator_pos = i+1;
+        else if ( (arg[i] == '=') && (operator_pos == i) )
+          operator_found = true;
       }
+
+      if (!operator_found)
+        THROW("argument of --redefine is malformed. Valid format is N:=S, :=S or N:=");
+
+      if (++operator_pos > 3) // seek operator end
+        cerr << "WARNING: multiple namespaces are used in target part of --redefine argument. Only first one ('" << new_namespace << "') will be used as target namespace." << endl;
+
+      all.redefine_some = true;
+
+      // case ':=S' doesn't require any additional code as new_namespace = ' ' by default
+
+      if (operator_pos == arg_len) // S is empty, default namespace shall be used
+        all.redefine[(int) ' '] = new_namespace;
+      else
+        for (size_t i = operator_pos; i < arg_len; i++)
+        { // all namespaces from S are redefined to N
+          unsigned char c = arg[i];
+          if (c != ':')
+            all.redefine[c] = new_namespace;
+          else
+          { // wildcard found: redefine all except default and break
+            for (size_t i = 0; i < 256; i++)
+              all.redefine[i] = new_namespace;
+            break; //break processing S
+          }
+        }
+
+    }
   }
 
   if (vm.count("dictionary")) {
     if (vm.count("dictionary_path"))
-      for (string path : vm["dictionary_path"].as< vector<string> >())
+for (string path : vm["dictionary_path"].as< vector<string> >())
         if (directory_exists(path))
           all.dictionary_path.push_back(path);
     if (directory_exists("."))
@@ -718,14 +727,14 @@ void parse_feature_tweaks(vw& all)
       }
       all.dictionary_path.push_back( PATH.substr(previous) );
     }
-    
+
     vector<string> dictionary_ns = vm["dictionary"].as< vector<string> >();
     for (size_t id=0; id<dictionary_ns.size(); id++) {
       parse_dictionary_argument(all, dictionary_ns[id]);
       *all.file_options << " --dictionary " << dictionary_ns[id];
     }
   }
-  
+
   if (vm.count("noconstant"))
     all.add_constant = false;
 }
@@ -734,45 +743,45 @@ void parse_example_tweaks(vw& all)
 {
   string named_labels;
   new_options(all, "Example options")
-    ("testonly,t", "Ignore label information and just test")
-    ("holdout_off", "no holdout data in multiple passes")
-    ("holdout_period", po::value<uint32_t>(&(all.holdout_period)), "holdout period for test only, default 10")
-    ("holdout_after", po::value<uint32_t>(&(all.holdout_after)), "holdout after n training examples, default off (disables holdout_period)")
-    ("early_terminate", po::value<size_t>(), "Specify the number of passes tolerated when holdout loss doesn't decrease before early termination, default is 3")
-    ("passes", po::value<size_t>(&(all.numpasses)),"Number of Training Passes")
-    ("initial_pass_length", po::value<size_t>(&(all.pass_length)), "initial number of examples per pass")
-    ("examples", po::value<size_t>(&(all.max_examples)), "number of examples to parse")
-    ("min_prediction", po::value<float>(&(all.sd->min_label)), "Smallest prediction to output")
-    ("max_prediction", po::value<float>(&(all.sd->max_label)), "Largest prediction to output")
-    ("sort_features", "turn this on to disregard order in which features have been defined. This will lead to smaller cache sizes")
-    ("loss_function", po::value<string>()->default_value("squared"), "Specify the loss function to be used, uses squared by default. Currently available ones are squared, classic, hinge, logistic and quantile.")
-    ("quantile_tau", po::value<float>()->default_value(0.5), "Parameter \\tau associated with Quantile loss. Defaults to 0.5")
-    ("l1", po::value<float>(&(all.l1_lambda)), "l_1 lambda")
-    ("l2", po::value<float>(&(all.l2_lambda)), "l_2 lambda")
-    ("named_labels", po::value<string>(&named_labels), "use names for labels (multiclass, etc.) rather than integers, argument specified all possible labels, comma-sep, eg \"--named_labels Noun,Verb,Adj,Punc\"");
+  ("testonly,t", "Ignore label information and just test")
+  ("holdout_off", "no holdout data in multiple passes")
+  ("holdout_period", po::value<uint32_t>(&(all.holdout_period)), "holdout period for test only, default 10")
+  ("holdout_after", po::value<uint32_t>(&(all.holdout_after)), "holdout after n training examples, default off (disables holdout_period)")
+  ("early_terminate", po::value<size_t>(), "Specify the number of passes tolerated when holdout loss doesn't decrease before early termination, default is 3")
+  ("passes", po::value<size_t>(&(all.numpasses)),"Number of Training Passes")
+  ("initial_pass_length", po::value<size_t>(&(all.pass_length)), "initial number of examples per pass")
+  ("examples", po::value<size_t>(&(all.max_examples)), "number of examples to parse")
+  ("min_prediction", po::value<float>(&(all.sd->min_label)), "Smallest prediction to output")
+  ("max_prediction", po::value<float>(&(all.sd->max_label)), "Largest prediction to output")
+  ("sort_features", "turn this on to disregard order in which features have been defined. This will lead to smaller cache sizes")
+  ("loss_function", po::value<string>()->default_value("squared"), "Specify the loss function to be used, uses squared by default. Currently available ones are squared, classic, hinge, logistic and quantile.")
+  ("quantile_tau", po::value<float>()->default_value(0.5), "Parameter \\tau associated with Quantile loss. Defaults to 0.5")
+  ("l1", po::value<float>(&(all.l1_lambda)), "l_1 lambda")
+  ("l2", po::value<float>(&(all.l2_lambda)), "l_2 lambda")
+  ("named_labels", po::value<string>(&named_labels), "use names for labels (multiclass, etc.) rather than integers, argument specified all possible labels, comma-sep, eg \"--named_labels Noun,Verb,Adj,Punc\"");
   add_options(all);
 
   po::variables_map& vm = all.vm;
   if (vm.count("testonly") || all.eta == 0.)
-    {
-      if (!all.quiet)
-	cerr << "only testing" << endl;
-      all.training = false;
-      if (all.lda > 0)
-        all.eta = 0;
-    }
+  {
+    if (!all.quiet)
+      cerr << "only testing" << endl;
+    all.training = false;
+    if (all.lda > 0)
+      all.eta = 0;
+  }
   else
     all.training = true;
 
   if(all.numpasses > 1)
-      all.holdout_set_off = false;
+    all.holdout_set_off = false;
 
   if(vm.count("holdout_off"))
-      all.holdout_set_off = true;
+    all.holdout_set_off = true;
 
   if(vm.count("sort_features"))
     all.p->sort_features = true;
-  
+
   if (vm.count("min_prediction"))
     all.sd->min_label = vm["min_prediction"].as<float>();
   if (vm.count("max_prediction"))
@@ -785,7 +794,7 @@ void parse_example_tweaks(vw& all)
     all.sd->ldict = new namedlabels(named_labels);
     cerr << "parsed " << all.sd->ldict->getK() << " named labels" << endl;
   }
-  
+
   string loss_function = vm["loss_function"].as<string>();
   float loss_parameter = 0.0;
   if(vm.count("quantile_tau"))
@@ -804,19 +813,19 @@ void parse_example_tweaks(vw& all)
   all.reg_mode += (all.l1_lambda > 0.) ? 1 : 0;
   all.reg_mode += (all.l2_lambda > 0.) ? 2 : 0;
   if (!all.quiet)
-    {
-      if (all.reg_mode %2 && !vm.count("bfgs"))
-	cerr << "using l1 regularization = " << all.l1_lambda << endl;
-      if (all.reg_mode > 1)
-	cerr << "using l2 regularization = " << all.l2_lambda << endl;
-    }
+  {
+    if (all.reg_mode %2 && !vm.count("bfgs"))
+      cerr << "using l1 regularization = " << all.l1_lambda << endl;
+    if (all.reg_mode > 1)
+      cerr << "using l2 regularization = " << all.l2_lambda << endl;
+  }
 }
 
 void parse_output_preds(vw& all)
 {
   new_options(all, "Output options")
-    ("predictions,p", po::value< string >(), "File to output predictions to")
-    ("raw_predictions,r", po::value< string >(), "File to output unnormalized predictions to");
+  ("predictions,p", po::value< string >(), "File to output predictions to")
+  ("raw_predictions,r", po::value< string >(), "File to output unnormalized predictions to");
   add_options(all);
 
   po::variables_map& vm = all.vm;
@@ -824,22 +833,22 @@ void parse_output_preds(vw& all)
     if (!all.quiet)
       cerr << "predictions = " <<  vm["predictions"].as< string >() << endl;
     if (strcmp(vm["predictions"].as< string >().c_str(), "stdout") == 0)
-      {
-	all.final_prediction_sink.push_back((size_t) 1);//stdout
-      }
+    {
+      all.final_prediction_sink.push_back((size_t) 1);//stdout
+    }
     else
-      {
-	const char* fstr = (vm["predictions"].as< string >().c_str());
-	int f;
+    {
+      const char* fstr = (vm["predictions"].as< string >().c_str());
+      int f;
 #ifdef _WIN32
-	_sopen_s(&f, fstr, _O_CREAT|_O_WRONLY|_O_BINARY|_O_TRUNC, _SH_DENYWR, _S_IREAD|_S_IWRITE);
+      _sopen_s(&f, fstr, _O_CREAT|_O_WRONLY|_O_BINARY|_O_TRUNC, _SH_DENYWR, _S_IREAD|_S_IWRITE);
 #else
-	f = open(fstr, O_CREAT|O_WRONLY|O_LARGEFILE|O_TRUNC,0666);
+      f = open(fstr, O_CREAT|O_WRONLY|O_LARGEFILE|O_TRUNC,0666);
 #endif
-	if (f < 0)
-	  cerr << "Error opening the predictions file: " << fstr << endl;
-	all.final_prediction_sink.push_back((size_t) f);
-      }
+      if (f < 0)
+        cerr << "Error opening the predictions file: " << fstr << endl;
+      all.final_prediction_sink.push_back((size_t) f);
+    }
   }
 
   if (vm.count("raw_predictions")) {
@@ -851,29 +860,29 @@ void parse_output_preds(vw& all)
     if (strcmp(vm["raw_predictions"].as< string >().c_str(), "stdout") == 0)
       all.raw_prediction = 1;//stdout
     else
-	{
-	  const char* t = vm["raw_predictions"].as< string >().c_str();
-	  int f;
+    {
+      const char* t = vm["raw_predictions"].as< string >().c_str();
+      int f;
 #ifdef _WIN32
-	  _sopen_s(&f, t, _O_CREAT|_O_WRONLY|_O_BINARY|_O_TRUNC, _SH_DENYWR, _S_IREAD|_S_IWRITE);
+      _sopen_s(&f, t, _O_CREAT|_O_WRONLY|_O_BINARY|_O_TRUNC, _SH_DENYWR, _S_IREAD|_S_IWRITE);
 #else
-	  f = open(t, O_CREAT|O_WRONLY|O_LARGEFILE|O_TRUNC,0666);
+      f = open(t, O_CREAT|O_WRONLY|O_LARGEFILE|O_TRUNC,0666);
 #endif
-	  all.raw_prediction = f;
-	}
+      all.raw_prediction = f;
+    }
   }
 }
 
 void parse_output_model(vw& all)
 {
   new_options(all, "Output model")
-    ("final_regressor,f", po::value< string >(), "Final regressor")
-    ("readable_model", po::value< string >(), "Output human-readable final regressor with numeric features")
-    ("invert_hash", po::value< string >(), "Output human-readable final regressor with feature names.  Computationally expensive.")
-    ("save_resume", "save extra state so learning can be resumed later with new data")
-    ("save_per_pass", "Save the model after every pass over data")
-    ("output_feature_regularizer_binary", po::value< string >(&(all.per_feature_regularizer_output)), "Per feature regularization output file")
-    ("output_feature_regularizer_text", po::value< string >(&(all.per_feature_regularizer_text)), "Per feature regularization output file, in text");  
+  ("final_regressor,f", po::value< string >(), "Final regressor")
+  ("readable_model", po::value< string >(), "Output human-readable final regressor with numeric features")
+  ("invert_hash", po::value< string >(), "Output human-readable final regressor with feature names.  Computationally expensive.")
+  ("save_resume", "save extra state so learning can be resumed later with new data")
+  ("save_per_pass", "Save the model after every pass over data")
+  ("output_feature_regularizer_binary", po::value< string >(&(all.per_feature_regularizer_output)), "Per feature regularization output file")
+  ("output_feature_regularizer_text", po::value< string >(&(all.per_feature_regularizer_text)), "Per feature regularization output file, in text");
   add_options(all);
 
   po::variables_map& vm = all.vm;
@@ -888,7 +897,7 @@ void parse_output_model(vw& all)
   if (vm.count("readable_model"))
     all.text_regressor_name = vm["readable_model"].as<string>();
 
-  if (vm.count("invert_hash")){
+  if (vm.count("invert_hash")) {
     all.inv_hash_regressor_name = vm["invert_hash"].as<string>();
     all.hash_inv = true;
   }
@@ -928,7 +937,7 @@ LEARNER::base_learner* setup_base(vw& all)
   LEARNER::base_learner* ret = all.reduction_stack.pop()(all);
   if (ret == nullptr)
     return setup_base(all);
-  else 
+  else
     return ret;
 }
 
@@ -992,21 +1001,21 @@ void add_to_args(vw& all, int argc, char* argv[], int excl_param_count = 0, cons
   {
     if (skip_next)
     {
-        skip_next = false;
-        continue;
+      skip_next = false;
+      continue;
     }
 
     for (int j = 0; j < excl_param_count; j++)
-        if (std::strcmp(argv[i], excl_params[j]) == 0)
-        {
-            skip_next = true; //skip param arguement
-            break;
-        }
+      if (std::strcmp(argv[i], excl_params[j]) == 0)
+      {
+        skip_next = true; //skip param arguement
+        break;
+      }
 
     if (skip_next) continue;
 
     all.args.push_back(string(argv[i]));
-}
+  }
 }
 
 vw& parse_args(int argc, char *argv[])
@@ -1021,31 +1030,31 @@ vw& parse_args(int argc, char *argv[])
   time(&all.init_time);
 
   new_options(all, "VW options")
-    ("random_seed", po::value<size_t>(&(all.random_seed)), "seed random number generator")
-    ("ring_size", po::value<size_t>(&(all.p->ring_size)), "size of example ring");
+  ("random_seed", po::value<size_t>(&(all.random_seed)), "seed random number generator")
+  ("ring_size", po::value<size_t>(&(all.p->ring_size)), "size of example ring");
   add_options(all);
 
   new_options(all, "Update options")
-    ("learning_rate,l", po::value<float>(&(all.eta)), "Set learning rate")
-    ("power_t", po::value<float>(&(all.power_t)), "t power value")
-		("decay_learning_rate", po::value<float>(&(all.eta_decay_rate)),
-     "Set Decay factor for learning_rate between passes")
-    ("initial_t", po::value<double>(&((all.sd->t))), "initial t value")
-    ("feature_mask", po::value< string >(), "Use existing regressor to determine which parameters may be updated.  If no initial_regressor given, also used for initial weights.");
+  ("learning_rate,l", po::value<float>(&(all.eta)), "Set learning rate")
+  ("power_t", po::value<float>(&(all.power_t)), "t power value")
+  ("decay_learning_rate", po::value<float>(&(all.eta_decay_rate)),
+   "Set Decay factor for learning_rate between passes")
+  ("initial_t", po::value<double>(&((all.sd->t))), "initial t value")
+  ("feature_mask", po::value< string >(), "Use existing regressor to determine which parameters may be updated.  If no initial_regressor given, also used for initial weights.");
   add_options(all);
 
   new_options(all, "Weight options")
-    ("initial_regressor,i", po::value< vector<string> >(), "Initial regressor(s)")
-    ("initial_weight", po::value<float>(&(all.initial_weight)), "Set all weights to an initial value of arg.")
-    ("random_weights", po::value<bool>(&(all.random_weights)), "make initial weights random")
-    ("input_feature_regularizer", po::value< string >(&(all.per_feature_regularizer_input)), "Per feature regularization input file");
+  ("initial_regressor,i", po::value< vector<string> >(), "Initial regressor(s)")
+  ("initial_weight", po::value<float>(&(all.initial_weight)), "Set all weights to an initial value of arg.")
+  ("random_weights", po::value<bool>(&(all.random_weights)), "make initial weights random")
+  ("input_feature_regularizer", po::value< string >(&(all.per_feature_regularizer_input)), "Per feature regularization input file");
   add_options(all);
 
   new_options(all, "Parallelization options")
-    ("span_server", po::value<string>(&(all.span_server)), "Location of server for setting up spanning tree")
-		("unique_id", po::value<size_t>(&(all.unique_id)), "unique id used for cluster parallel jobs")
-		("total", po::value<size_t>(&(all.total)), "total number of nodes used in cluster parallel job")
-		("node", po::value<size_t>(&(all.node)), "node number in cluster parallel job");
+  ("span_server", po::value<string>(&(all.span_server)), "Location of server for setting up spanning tree")
+  ("unique_id", po::value<size_t>(&(all.unique_id)), "unique id used for cluster parallel jobs")
+  ("total", po::value<size_t>(&(all.total)), "total number of nodes used in cluster parallel job")
+  ("node", po::value<size_t>(&(all.node)), "node number in cluster parallel job");
   add_options(all);
 
   msrand48(all.random_seed);
@@ -1054,50 +1063,50 @@ vw& parse_args(int argc, char *argv[])
   all.sd->weighted_unlabeled_examples = all.sd->t;
   all.initial_t = (float)all.sd->t;
 
-	return all;
+  return all;
 }
 
 bool check_interaction_settings_collision(vw& all)
 {
-    bool args_has_inter = std::find(all.args.begin(), all.args.end(), std::string("-q")) != all.args.end();
-    args_has_inter = args_has_inter || ( std::find(all.args.begin(), all.args.end(), std::string("--quadratic")) != all.args.end() );
-    args_has_inter = args_has_inter || ( std::find(all.args.begin(), all.args.end(), std::string("--cubic")) != all.args.end() );
-    args_has_inter = args_has_inter || ( std::find(all.args.begin(), all.args.end(), std::string("--interactions")) != all.args.end() );
+  bool args_has_inter = std::find(all.args.begin(), all.args.end(), std::string("-q")) != all.args.end();
+  args_has_inter = args_has_inter || ( std::find(all.args.begin(), all.args.end(), std::string("--quadratic")) != all.args.end() );
+  args_has_inter = args_has_inter || ( std::find(all.args.begin(), all.args.end(), std::string("--cubic")) != all.args.end() );
+  args_has_inter = args_has_inter || ( std::find(all.args.begin(), all.args.end(), std::string("--interactions")) != all.args.end() );
 
-    if (!args_has_inter) return false;
+  if (!args_has_inter) return false;
 
-    // we don't use -q to save pairs in all.file_options, so only 3 options checked
-    bool opts_has_inter = all.file_options->str().find("--quadratic") != std::string::npos;
-    opts_has_inter = opts_has_inter || (all.file_options->str().find("--cubic") != std::string::npos);
-    opts_has_inter = opts_has_inter || (all.file_options->str().find("--interactions") != std::string::npos);
+  // we don't use -q to save pairs in all.file_options, so only 3 options checked
+  bool opts_has_inter = all.file_options->str().find("--quadratic") != std::string::npos;
+  opts_has_inter = opts_has_inter || (all.file_options->str().find("--cubic") != std::string::npos);
+  opts_has_inter = opts_has_inter || (all.file_options->str().find("--interactions") != std::string::npos);
 
-    return opts_has_inter;
+  return opts_has_inter;
 }
 
 void parse_modules(vw& all, io_buf& model)
 {
-	save_load_header(all, model, true, false);
-  
+  save_load_header(all, model, true, false);
+
   interactions_settings_doubled = check_interaction_settings_collision(all);
 
   int temp_argc = 0;
   char** temp_argv = VW::get_argv_from_string(all.file_options->str(), temp_argc);
 
   if (interactions_settings_doubled)
-  {   //remove
-      const char* interaction_params[] = {"--quadratic", "--cubic", "--interactions"};
-      add_to_args(all, temp_argc, temp_argv, 3, interaction_params);
+  { //remove
+    const char* interaction_params[] = {"--quadratic", "--cubic", "--interactions"};
+    add_to_args(all, temp_argc, temp_argv, 3, interaction_params);
   } else
-  add_to_args(all, temp_argc, temp_argv);
+    add_to_args(all, temp_argc, temp_argv);
   for (int i = 0; i < temp_argc; i++)
     free(temp_argv[i]);
   free(temp_argv);
-  
-  po::parsed_options pos = po::command_line_parser(all.args).
-    style(po::command_line_style::default_style ^ po::command_line_style::allow_guessing).
-    options(all.opts).allow_unregistered().run();
 
-	po::variables_map& vm = all.vm;
+  po::parsed_options pos = po::command_line_parser(all.args).
+                           style(po::command_line_style::default_style ^ po::command_line_style::allow_guessing).
+                           options(all.opts).allow_unregistered().run();
+
+  po::variables_map& vm = all.vm;
   vm = po::variables_map();
 
   po::store(pos, vm);
@@ -1109,20 +1118,20 @@ void parse_modules(vw& all, io_buf& model)
   parse_example_tweaks(all); //example manipulation
 
   parse_output_model(all);
-  
+
   parse_output_preds(all);
 
   parse_reductions(all);
 
   if (!all.quiet)
-    {
-      cerr << "Num weight bits = " << all.num_bits << endl;
-      cerr << "learning rate = " << all.eta << endl;
-      cerr << "initial_t = " << all.sd->t << endl;
-      cerr << "power_t = " << all.power_t << endl;
-      if (all.numpasses > 1)
-	cerr << "decay_learning_rate = " << all.eta_decay_rate << endl;
-    }
+  {
+    cerr << "Num weight bits = " << all.num_bits << endl;
+    cerr << "learning rate = " << all.eta << endl;
+    cerr << "initial_t = " << all.sd->t << endl;
+    cerr << "power_t = " << all.power_t << endl;
+    if (all.numpasses > 1)
+      cerr << "decay_learning_rate = " << all.eta_decay_rate << endl;
+  }
 }
 
 void parse_sources(vw& all, io_buf& model)
@@ -1149,196 +1158,197 @@ void parse_sources(vw& all, io_buf& model)
 
 
 namespace VW {
-  void cmd_string_replace_value( std::stringstream*& ss, string flag_to_replace, string new_value )
+void cmd_string_replace_value( std::stringstream*& ss, string flag_to_replace, string new_value )
+{
+  flag_to_replace.append(" "); //add a space to make sure we obtain the right flag in case 2 flags start with the same set of characters
+  string cmd = ss->str();
+  size_t pos = cmd.find(flag_to_replace);
+  if( pos == string::npos )
+    //flag currently not present in command string, so just append it to command string
+    *ss << " " << flag_to_replace << new_value;
+  else {
+    //flag is present, need to replace old value with new value
+
+    //compute position after flag_to_replace
+    pos += flag_to_replace.size();
+
+    //now pos is position where value starts
+    //find position of next space
+    size_t pos_after_value = cmd.find(" ",pos);
+    if(pos_after_value == string::npos)
+      //we reach the end of the string, so replace the all characters after pos by new_value
+      cmd.replace(pos,cmd.size()-pos,new_value);
+    else
+      //replace characters between pos and pos_after_value by new_value
+      cmd.replace(pos,pos_after_value-pos,new_value);
+    ss->str(cmd);
+  }
+}
+
+char** get_argv_from_string(string s, int& argc)
+{
+  char* c = calloc_or_die<char>(s.length()+3);
+  c[0] = 'b';
+  c[1] = ' ';
+  strcpy(c+2, s.c_str());
+  substring ss = {c, c+s.length()+2};
+  v_array<substring> foo = v_init<substring>();
+  tokenize(' ', ss, foo);
+
+  char** argv = calloc_or_die<char*>(foo.size());
+  for (size_t i = 0; i < foo.size(); i++)
   {
-    flag_to_replace.append(" "); //add a space to make sure we obtain the right flag in case 2 flags start with the same set of characters
-    string cmd = ss->str();
-    size_t pos = cmd.find(flag_to_replace);
-    if( pos == string::npos )
-      //flag currently not present in command string, so just append it to command string
-      *ss << " " << flag_to_replace << new_value;
+    *(foo[i].end) = '\0';
+    argv[i] = calloc_or_die<char>(foo[i].end-foo[i].begin+1);
+    sprintf(argv[i],"%s",foo[i].begin);
+  }
+
+  argc = (int)foo.size();
+  free(c);
+  foo.delete_v();
+  return argv;
+}
+
+vw* initialize(string s)
+{
+  int argc = 0;
+  s += " --no_stdin";
+  char** argv = get_argv_from_string(s,argc);
+
+  vw& all = parse_args(argc, argv);
+  io_buf model;
+  parse_regressor_args(all, model);
+  parse_modules(all, model);
+  parse_sources(all, model);
+
+  initialize_parser_datastructures(all);
+
+  for(int i = 0; i < argc; i++)
+    free(argv[i]);
+  free(argv);
+
+  return &all;
+}
+
+// Create a new VW instance while sharing the model with another instance
+// The extra arguments will be appended to those of the other VW instance
+vw* seed_vw_model(vw* vw_model, const string extra_args)
+{
+  vector<string> model_args = vw_model->args;
+  model_args.push_back(extra_args);
+
+  std::ostringstream init_args;
+  for (size_t i = 0; i < model_args.size(); i++)
+  {
+    if (model_args[i] == "--no_stdin" || // ignore this since it will be added by vw::initialize
+        model_args[i] == "-i" || // ignore -i since we don't want to reload the model
+        (i > 0 && model_args[i - 1] == "-i"))
+    {
+      continue;
+    }
+    init_args << model_args[i] << " ";
+  }
+
+  vw* new_model = VW::initialize(init_args.str().c_str());
+
+  // reference model states stored in the specified VW instance
+  new_model->reg = vw_model->reg; // regressor
+  new_model->sd = vw_model->sd; // shared data
+
+  new_model->seeded = true;
+
+  return new_model;
+}
+
+void delete_dictionary_entry(substring ss, v_array<feature>*A) {
+  free(ss.begin);
+  A->delete_v();
+  delete A;
+}
+
+void finish(vw& all, bool delete_all)
+{
+  if (!all.quiet)
+  {
+    cerr.precision(6);
+    cerr << endl << "finished run";
+    if(all.current_pass == 0)
+      cerr << endl << "number of examples = " << all.sd->example_number;
     else {
-      //flag is present, need to replace old value with new value
-
-      //compute position after flag_to_replace
-      pos += flag_to_replace.size();
-
-      //now pos is position where value starts
-      //find position of next space
-      size_t pos_after_value = cmd.find(" ",pos);
-      if(pos_after_value == string::npos) 
-        //we reach the end of the string, so replace the all characters after pos by new_value
-        cmd.replace(pos,cmd.size()-pos,new_value);
-      else 
-        //replace characters between pos and pos_after_value by new_value
-        cmd.replace(pos,pos_after_value-pos,new_value);
-      ss->str(cmd);
+      cerr << endl << "number of examples per pass = " << all.sd->example_number / all.current_pass;
+      cerr << endl << "passes used = " << all.current_pass;
     }
-  }
+    cerr << endl << "weighted example sum = " << all.sd->weighted_examples;
+    cerr << endl << "weighted label sum = " << all.sd->weighted_labels;
+    if(all.holdout_set_off || (all.sd->holdout_best_loss == FLT_MAX))
+      cerr << endl << "average loss = " << all.sd->sum_loss / all.sd->weighted_examples;
+    else
+      cerr << endl << "average loss = " << all.sd->holdout_best_loss << " h";
 
-  char** get_argv_from_string(string s, int& argc)
-  {
-    char* c = calloc_or_die<char>(s.length()+3);
-    c[0] = 'b';
-    c[1] = ' ';
-    strcpy(c+2, s.c_str());
-    substring ss = {c, c+s.length()+2};
-    v_array<substring> foo = v_init<substring>();
-    tokenize(' ', ss, foo);
-
-    char** argv = calloc_or_die<char*>(foo.size());
-    for (size_t i = 0; i < foo.size(); i++)
-      {
-	*(foo[i].end) = '\0';
-	argv[i] = calloc_or_die<char>(foo[i].end-foo[i].begin+1);
-        sprintf(argv[i],"%s",foo[i].begin);
-      }
-
-    argc = (int)foo.size();
-    free(c);
-    foo.delete_v();
-    return argv;
-  }
-
-  vw* initialize(string s)
-  {
-    int argc = 0;
-    s += " --no_stdin";
-    char** argv = get_argv_from_string(s,argc);
-
-    vw& all = parse_args(argc, argv);
-	io_buf model;
-	parse_regressor_args(all, model);
-	parse_modules(all, model);
-	parse_sources(all, model);
-
-    initialize_parser_datastructures(all);
-    
-    for(int i = 0; i < argc; i++)
-      free(argv[i]);
-    free(argv);
-
-    return &all;
-  }
-
-  // Create a new VW instance while sharing the model with another instance
-  // The extra arguments will be appended to those of the other VW instance
-  vw* seed_vw_model(vw* vw_model, const string extra_args)
-  {
-    vector<string> model_args = vw_model->args;
-    model_args.push_back(extra_args);
-
-    std::ostringstream init_args;
-    for (size_t i = 0; i < model_args.size(); i++)
+    float best_constant;
+    float best_constant_loss;
+    if (get_best_constant(all, best_constant, best_constant_loss))
     {
-      if (model_args[i] == "--no_stdin" || // ignore this since it will be added by vw::initialize
-          model_args[i] == "-i" || // ignore -i since we don't want to reload the model
-          (i > 0 && model_args[i - 1] == "-i"))
-      {
-        continue;
-      }
-      init_args << model_args[i] << " ";
+      cerr << endl << "best constant = " << best_constant;
+      if (best_constant_loss != FLT_MIN)
+        cerr << endl << "best constant's loss = " << best_constant_loss;
     }
 
-    vw* new_model = VW::initialize(init_args.str().c_str());
-    
-    // reference model states stored in the specified VW instance
-    new_model->reg = vw_model->reg; // regressor
-    new_model->sd = vw_model->sd; // shared data
-
-    new_model->seeded = true;
-
-    return new_model;
+    cerr << endl << "total feature number = " << all.sd->total_features;
+    if (all.sd->queries > 0)
+      cerr << endl << "total queries = " << all.sd->queries << endl;
+    cerr << endl;
   }
 
-  void delete_dictionary_entry(substring ss, v_array<feature>*A) {
-    free(ss.begin);
-    A->delete_v();
-    delete A;
-  }
-  
-  void finish(vw& all, bool delete_all)
+  // implement finally.
+  // finalize_regressor can throw if it can't write the file.
+  // we still want to free up all the memory.
+  vw_exception finalize_regressor_exception(__FILE__, __LINE__, "empty");
+  bool finalize_regressor_exception_thrown = false;
+  try
   {
-    if (!all.quiet)
-        {
-        cerr.precision(6);
-        cerr << endl << "finished run";
-        if(all.current_pass == 0)
-            cerr << endl << "number of examples = " << all.sd->example_number;
-        else{
-            cerr << endl << "number of examples per pass = " << all.sd->example_number / all.current_pass;
-            cerr << endl << "passes used = " << all.current_pass;
-        }
-        cerr << endl << "weighted example sum = " << all.sd->weighted_examples;
-        cerr << endl << "weighted label sum = " << all.sd->weighted_labels;
-        if(all.holdout_set_off || (all.sd->holdout_best_loss == FLT_MAX))
-	  cerr << endl << "average loss = " << all.sd->sum_loss / all.sd->weighted_examples;
-	else
-	  cerr << endl << "average loss = " << all.sd->holdout_best_loss << " h";
-
-        float best_constant; float best_constant_loss;
-        if (get_best_constant(all, best_constant, best_constant_loss))
-	  {
-            cerr << endl << "best constant = " << best_constant;
-            if (best_constant_loss != FLT_MIN)
-	      cerr << endl << "best constant's loss = " << best_constant_loss;
-	  }
-	
-        cerr << endl << "total feature number = " << all.sd->total_features;
-        if (all.sd->queries > 0)
-	  cerr << endl << "total queries = " << all.sd->queries << endl;
-        cerr << endl;
-        }
-    
-	// implement finally.
-	// finalize_regressor can throw if it can't write the file.
-	// we still want to free up all the memory.
-	vw_exception finalize_regressor_exception(__FILE__, __LINE__, "empty");
-	bool finalize_regressor_exception_thrown = false;
-	try
-	{
     finalize_regressor(all, all.final_regressor_name);
-	}
-	catch (vw_exception& e)
-	{
-		finalize_regressor_exception = e;
-		finalize_regressor_exception_thrown = true;
-	}
-
-    all.l->finish();
-    free_it(all.l);
-    if (all.reg.weight_vector != nullptr && !all.seeded) // don't free weight vector if it is shared with another instance
-      free(all.reg.weight_vector);
-    free_parser(all);
-    finalize_source(all.p);
-    all.p->parse_name.erase();
-    all.p->parse_name.delete_v();
-    free(all.p);
-    if (!all.seeded)
-    {
-      free(all.sd);
-    }
-    all.reduction_stack.delete_v();
-    delete all.file_options;
-    for (size_t i = 0; i < all.final_prediction_sink.size(); i++)
-      if (all.final_prediction_sink[i] != 1)
-	io_buf::close_file_or_socket(all.final_prediction_sink[i]);
-    all.final_prediction_sink.delete_v();
-    for (size_t i=0; i<all.loaded_dictionaries.size(); i++) {
-      free(all.loaded_dictionaries[i].name);
-      all.loaded_dictionaries[i].dict->iter(delete_dictionary_entry);
-      all.loaded_dictionaries[i].dict->delete_v();
-      delete all.loaded_dictionaries[i].dict;
-    }
-    delete all.loss;
-
-    // destroy all interactions and array of them
-    for (v_string* i = all.interactions.begin; i != all.interactions.end; ++i) i->delete_v();
-    all.interactions.delete_v();
-
-    if (delete_all) delete &all;
-
-	if (finalize_regressor_exception_thrown)
-		throw finalize_regressor_exception;
   }
+  catch (vw_exception& e)
+  {
+    finalize_regressor_exception = e;
+    finalize_regressor_exception_thrown = true;
+  }
+
+  all.l->finish();
+  free_it(all.l);
+  if (all.reg.weight_vector != nullptr && !all.seeded) // don't free weight vector if it is shared with another instance
+    free(all.reg.weight_vector);
+  free_parser(all);
+  finalize_source(all.p);
+  all.p->parse_name.erase();
+  all.p->parse_name.delete_v();
+  free(all.p);
+  if (!all.seeded)
+  {
+    free(all.sd);
+  }
+  all.reduction_stack.delete_v();
+  delete all.file_options;
+  for (size_t i = 0; i < all.final_prediction_sink.size(); i++)
+    if (all.final_prediction_sink[i] != 1)
+      io_buf::close_file_or_socket(all.final_prediction_sink[i]);
+  all.final_prediction_sink.delete_v();
+  for (size_t i=0; i<all.loaded_dictionaries.size(); i++) {
+    free(all.loaded_dictionaries[i].name);
+    all.loaded_dictionaries[i].dict->iter(delete_dictionary_entry);
+    all.loaded_dictionaries[i].dict->delete_v();
+    delete all.loaded_dictionaries[i].dict;
+  }
+  delete all.loss;
+
+  // destroy all interactions and array of them
+  for (v_string* i = all.interactions.begin; i != all.interactions.end; ++i) i->delete_v();
+  all.interactions.delete_v();
+
+  if (delete_all) delete &all;
+
+  if (finalize_regressor_exception_thrown)
+    throw finalize_regressor_exception;
+}
 }

--- a/vowpalwabbit/parse_example.cc
+++ b/vowpalwabbit/parse_example.cc
@@ -25,14 +25,14 @@ char* copy(char* base)
 
 template<bool audit>
 class TC_parser {
-  
+
 public:
   char* beginLine;
   char* reading_head;
   char* endLine;
   float cur_channel_v;
   bool  new_index;
-  size_t anon; 
+  size_t anon;
   size_t channel_hash;
   char* base;
   unsigned char index;
@@ -47,18 +47,18 @@ public:
 
   vector<feature_dict*>* namespace_dictionaries;
 
-  ~TC_parser(){ }
-  
-  inline float featureValue(){
+  ~TC_parser() { }
+
+  inline float featureValue() {
     if(*reading_head == ' ' || *reading_head == '\t' || *reading_head == '|' || reading_head == endLine || *reading_head == '\r')
       return 1.;
-    else if(*reading_head == ':'){
+    else if(*reading_head == ':') {
       // featureValue --> ':' 'Float'
       ++reading_head;
       char *end_read = nullptr;
       v = parseFloat(reading_head,&end_read);
-      if(end_read == reading_head){
-	cout << "malformed example !\nFloat expected after : \"" << std::string(beginLine, reading_head - beginLine).c_str()<< "\"" << endl;
+      if(end_read == reading_head) {
+        cout << "malformed example !\nFloat expected after : \"" << std::string(beginLine, reading_head - beginLine).c_str()<< "\"" << endl;
       }
       if(nanpattern(v)) {
         v = 0.f;
@@ -66,14 +66,14 @@ public:
       }
       reading_head = end_read;
       return v;
-    }else{
+    } else {
       // syntax error
       cout << "malformed example !\n'|' , ':' , space or EOL expected after : \"" << std::string(beginLine, reading_head - beginLine).c_str()<< "\"" << endl;
       return 0.f;
     }
   }
 
-  inline substring read_name(){
+  inline substring read_name() {
     substring ret;
     ret.begin = reading_head;
     while( !(*reading_head == ' ' || *reading_head == ':' || *reading_head == '\t' || *reading_head == '|' || reading_head == endLine || *reading_head == '\r' ))
@@ -82,29 +82,29 @@ public:
 
     return ret;
   }
-  
-  inline void maybeFeature(){
-    if(*reading_head == ' ' || *reading_head == '\t' || *reading_head == '|'|| reading_head == endLine || *reading_head == '\r' ){
+
+  inline void maybeFeature() {
+    if(*reading_head == ' ' || *reading_head == '\t' || *reading_head == '|'|| reading_head == endLine || *reading_head == '\r' ) {
       // maybeFeature --> ø
-    }else {
+    } else {
       // maybeFeature --> 'String' FeatureValue
       substring feature_name=read_name();
       v = cur_channel_v * featureValue();
       size_t word_hash;
       if (feature_name.end != feature_name.begin)
-	word_hash = (p->hasher(feature_name,(uint32_t)channel_hash));
+        word_hash = (p->hasher(feature_name,(uint32_t)channel_hash));
       else
-	word_hash = channel_hash + anon++;
+        word_hash = channel_hash + anon++;
       if(v == 0) return; //dont add 0 valued features to list of features
       feature f = {v,(uint32_t)word_hash };
       ae->sum_feat_sq[index] += v*v;
       ae->atomics[index].push_back(f);
-      if(audit){
-	v_array<char> feature_v = v_init<char>();
-	push_many(feature_v, feature_name.begin, feature_name.end - feature_name.begin);
-	feature_v.push_back('\0');
-    audit_data ad = {copy(base),feature_v.begin,word_hash,v,true};
-	ae->audit_features[index].push_back(ad);
+      if(audit) {
+        v_array<char> feature_v = v_init<char>();
+        push_many(feature_v, feature_name.begin, feature_name.end - feature_name.begin);
+        feature_v.push_back('\0');
+        audit_data ad = {copy(base),feature_v.begin,word_hash,v,true};
+        ae->audit_features[index].push_back(ad);
       }
       if ((affix_features[index] > 0) && (feature_name.end != feature_name.begin)) {
         if (ae->atomics[affix_namespace].size() == 0)
@@ -135,7 +135,7 @@ public:
             audit_data ad = {copy((char*)"affix"),affix_v.begin,word_hash,v,true};
             ae->audit_features[affix_namespace].push_back(ad);
           }
-          
+
           affix >>= 4;
         }
       }
@@ -152,7 +152,7 @@ public:
           else if  (*c == '.')                 d = '.';
           else                                 d = '#';
           //if ((spelling.size() == 0) || (spelling.last() != d))
-            spelling.push_back(d);
+          spelling.push_back(d);
         }
         substring spelling_ss = { spelling.begin, spelling.end };
         size_t word_hash = hashstring(spelling_ss, (uint32_t)channel_hash);
@@ -161,7 +161,10 @@ public:
         ae->atomics[spelling_namespace].push_back(f2);
         if (audit) {
           v_array<char> spelling_v = v_init<char>();
-          if (index != ' ') { spelling_v.push_back(index); spelling_v.push_back('_'); }
+          if (index != ' ') {
+            spelling_v.push_back(index);
+            spelling_v.push_back('_');
+          }
           push_many(spelling_v, spelling_ss.begin, spelling_ss.end - spelling_ss.begin);
           spelling_v.push_back('\0');
           audit_data ad = {copy((char*)"spelling"),spelling_v.begin,word_hash,v,true};
@@ -199,128 +202,128 @@ public:
       }
     }
   }
-  
-  inline void nameSpaceInfoValue(){
-    if(*reading_head == ' ' || *reading_head == '\t' || reading_head == endLine || *reading_head == '|' || *reading_head == '\r' ){
+
+  inline void nameSpaceInfoValue() {
+    if(*reading_head == ' ' || *reading_head == '\t' || reading_head == endLine || *reading_head == '|' || *reading_head == '\r' ) {
       // nameSpaceInfoValue -->  ø
-    }else if(*reading_head == ':'){
+    } else if(*reading_head == ':') {
       // nameSpaceInfoValue --> ':' 'Float'
       ++reading_head;
       char *end_read = nullptr;
       cur_channel_v = parseFloat(reading_head,&end_read);
-      if(end_read == reading_head){
-	cout << "malformed example !\nFloat expected after : \"" << std::string(beginLine, reading_head - beginLine).c_str()<< "\"" << endl;
+      if(end_read == reading_head) {
+        cout << "malformed example !\nFloat expected after : \"" << std::string(beginLine, reading_head - beginLine).c_str()<< "\"" << endl;
       }
       if(nanpattern(cur_channel_v)) {
         cur_channel_v = 1.f;
         cout << "warning: invalid namespace value:\"" << std::string(reading_head, end_read - reading_head).c_str() << "\" read as NaN. Replacing with 1." << endl;
       }
       reading_head = end_read;
-    }else{
+    } else {
       // syntax error
       cout << "malformed example !\n'|' , ':' , space or EOL expected after : \"" << std::string(beginLine, reading_head - beginLine).c_str()<< "\"" << endl;
     }
   }
-  
-  inline void nameSpaceInfo(){
-    if(reading_head == endLine ||*reading_head == '|' || *reading_head == ' ' || *reading_head == '\t' || *reading_head == ':' || *reading_head == '\r'){
+
+  inline void nameSpaceInfo() {
+    if(reading_head == endLine ||*reading_head == '|' || *reading_head == ' ' || *reading_head == '\t' || *reading_head == ':' || *reading_head == '\r') {
       // syntax error
       cout << "malformed example !\nString expected after : " << std::string(beginLine, reading_head - beginLine).c_str()<< "\"" << endl;
-    }else{
+    } else {
       // NameSpaceInfo --> 'String' NameSpaceInfoValue
       index = (unsigned char)(*reading_head);
       if (redefine_some) index = (*redefine)[index]; //redefine index
       if(ae->atomics[index].begin == ae->atomics[index].end)
-	new_index = true;
+        new_index = true;
       substring name = read_name();
-      if(audit){
-	v_array<char> base_v_array = v_init<char>();
-	push_many(base_v_array, name.begin, name.end - name.begin);
-	base_v_array.push_back('\0');
-	if (base != nullptr)
-	  free(base);
-	base = base_v_array.begin;
+      if(audit) {
+        v_array<char> base_v_array = v_init<char>();
+        push_many(base_v_array, name.begin, name.end - name.begin);
+        base_v_array.push_back('\0');
+        if (base != nullptr)
+          free(base);
+        base = base_v_array.begin;
       }
       channel_hash = p->hasher(name, hash_base);
       nameSpaceInfoValue();
     }
   }
-  
-  inline void listFeatures(){
-    while(*reading_head == ' ' || *reading_head == '\t'){
+
+  inline void listFeatures() {
+    while(*reading_head == ' ' || *reading_head == '\t') {
       //listFeatures --> ' ' MaybeFeature ListFeatures
       ++reading_head;
       maybeFeature();
     }
-    if(!(*reading_head == '|' || reading_head == endLine || *reading_head == '\r')){
+    if(!(*reading_head == '|' || reading_head == endLine || *reading_head == '\r')) {
       //syntax error
       cout << "malformed example !\n'|' , space or EOL expected after : \"" << std::string(beginLine, reading_head - beginLine).c_str() << "\"" << endl;
     }
   }
-    
-  inline void nameSpace(){
+
+  inline void nameSpace() {
     cur_channel_v = 1.0;
     index = 0;
     new_index = false;
     anon = 0;
-    if(*reading_head == ' ' || *reading_head == '\t' || reading_head == endLine || *reading_head == '|' || *reading_head == '\r' ){
+    if(*reading_head == ' ' || *reading_head == '\t' || reading_head == endLine || *reading_head == '|' || *reading_head == '\r' ) {
       // NameSpace --> ListFeatures
       index = (unsigned char)' ';
       if(ae->atomics[index].begin == ae->atomics[index].end)
-	new_index = true;
+        new_index = true;
       if(audit)
-	{
-	  if (base != nullptr)
-	    free(base);
-	  base = calloc_or_die<char>(2);
-	  base[0] = ' ';
-	  base[1] = '\0';
-	}
+      {
+        if (base != nullptr)
+          free(base);
+        base = calloc_or_die<char>(2);
+        base[0] = ' ';
+        base[1] = '\0';
+      }
       channel_hash = 0;
       listFeatures();
-    }else if(*reading_head != ':'){
+    } else if(*reading_head != ':') {
       // NameSpace --> NameSpaceInfo ListFeatures
       nameSpaceInfo();
       listFeatures();
-    }else{
+    } else {
       // syntax error
       cout << "malformed example !\n'|' , String, space or EOL expected after : \"" << std::string(beginLine, reading_head - beginLine).c_str()<< "\"" << endl;
     }
     if(new_index && ae->atomics[index].begin != ae->atomics[index].end)
       ae->indices.push_back(index);
   }
-  
-  inline void listNameSpace(){
-    while(*reading_head == '|'){ // ListNameSpace --> '|' NameSpace ListNameSpace
+
+  inline void listNameSpace() {
+    while(*reading_head == '|') { // ListNameSpace --> '|' NameSpace ListNameSpace
       ++reading_head;
       nameSpace();
     }
     if(reading_head != endLine && *reading_head != '\r')
-      {
-	// syntax error
-	cout << "malformed example !\n'|' or EOL expected after : \"" << std::string(beginLine, reading_head - beginLine).c_str()<< "\"" << endl;
-      }
+    {
+      // syntax error
+      cout << "malformed example !\n'|' or EOL expected after : \"" << std::string(beginLine, reading_head - beginLine).c_str()<< "\"" << endl;
+    }
   }
 
-  TC_parser(char* reading_head, char* endLine, vw& all, example* ae){
+  TC_parser(char* reading_head, char* endLine, vw& all, example* ae) {
     spelling = v_init<char>();
     if (endLine != reading_head)
-      {
-	this->beginLine = reading_head;
-	this->reading_head = reading_head;
-	this->endLine = endLine;
-	this->p = all.p;
-	this->redefine_some = all.redefine_some;
-	this->redefine = &all.redefine;
-	this->ae = ae;
-	this->affix_features = all.affix_features;
-	this->spelling_features = all.spelling_features;
-	this->namespace_dictionaries = all.namespace_dictionaries;
-	this->base = nullptr;
-	listNameSpace();
-	if (base != nullptr)
-	  free(base);
-      }
+    {
+      this->beginLine = reading_head;
+      this->reading_head = reading_head;
+      this->endLine = endLine;
+      this->p = all.p;
+      this->redefine_some = all.redefine_some;
+      this->redefine = &all.redefine;
+      this->ae = ae;
+      this->affix_features = all.affix_features;
+      this->spelling_features = all.spelling_features;
+      this->namespace_dictionaries = all.namespace_dictionaries;
+      this->base = nullptr;
+      listNameSpace();
+      if (base != nullptr)
+        free(base);
+    }
   }
 };
 
@@ -330,29 +333,29 @@ void substring_to_example(vw* all, example* ae, substring example)
   char* bar_location = safe_index(example.begin, '|', example.end);
   char* tab_location = safe_index(example.begin, '\t', bar_location);
   substring label_space;
-  if (tab_location != bar_location){
+  if (tab_location != bar_location) {
     label_space.begin = tab_location + 1;
-  }else{
+  } else {
     label_space.begin = example.begin;
   }
   label_space.end = bar_location;
-  
+
   if (*example.begin == '|')	{
     all->p->words.erase();
   } else 	{
     tokenize(' ', label_space, all->p->words);
     if (all->p->words.size() > 0 && (all->p->words.last().end == label_space.end	|| *(all->p->words.last().begin) == '\'')) //The last field is a tag, so record and strip it off
-      {
-	substring tag = all->p->words.pop();
-	if (*tag.begin == '\'')
-	  tag.begin++;
-	push_many(ae->tag, tag.begin, tag.end - tag.begin);
-      }
+    {
+      substring tag = all->p->words.pop();
+      if (*tag.begin == '\'')
+        tag.begin++;
+      push_many(ae->tag, tag.begin, tag.end - tag.begin);
+    }
   }
 
   if (all->p->words.size() > 0)
     all->p->lp.parse_label(all->p, all->sd, &ae->l, all->p->words);
-  
+
   if (all->audit || all->hash_inv)
     TC_parser<true> parser_line(bar_location,example.end,*all,ae);
   else
@@ -386,5 +389,5 @@ void read_line(vw& all, example* ex, char* line)
 {
   substring ss = {line, line+strlen(line)};
   while ((ss.end >= ss.begin) && (*(ss.end-1) == '\n')) ss.end--;
-  substring_to_example(&all, ex, ss);  
+  substring_to_example(&all, ex, ss);
 }

--- a/vowpalwabbit/parse_primitives.cc
+++ b/vowpalwabbit/parse_primitives.cc
@@ -18,7 +18,7 @@ license as described in the file LICENSE.
 
 bool substring_equal(substring&a, substring&b) {
   return (a.end - a.begin == b.end - b.begin) // same length
-      && (strncmp(a.begin, b.begin, a.end - a.begin) == 0);
+         && (strncmp(a.begin, b.begin, a.end - a.begin) == 0);
 }
 
 void tokenize(char delim, substring s, v_array<substring>& ret, bool allow_empty)
@@ -28,18 +28,18 @@ void tokenize(char delim, substring s, v_array<substring>& ret, bool allow_empty
   for (; s.begin != s.end; s.begin++) {
     if (*s.begin == delim) {
       if (allow_empty || (s.begin != last))
-	{
-	  substring temp = {last, s.begin};
-	  ret.push_back(temp);
-	}
+      {
+        substring temp = {last, s.begin};
+        ret.push_back(temp);
+      }
       last = s.begin+1;
     }
   }
   if (allow_empty || (s.begin != last))
-    {
-      substring final = {last, s.begin};
-      ret.push_back(final);
-    }
+  {
+    substring final = {last, s.begin};
+    ret.push_back(final);
+  }
 }
 
 size_t hashstring (substring s, uint32_t h)
@@ -61,9 +61,11 @@ size_t hashstring (substring s, uint32_t h)
 }
 
 size_t hashall (substring s, uint32_t h)
-{ return uniform_hash((unsigned char *)s.begin, s.end - s.begin, h); }
+{
+  return uniform_hash((unsigned char *)s.begin, s.end - s.begin, h);
+}
 
-hash_func_t getHasher(const std::string& s){
+hash_func_t getHasher(const std::string& s) {
   if (s=="strings")
     return hashstring;
   else if(s=="all")
@@ -78,19 +80,19 @@ std::ostream& operator<<(std::ostream& os, const substring& ss) {
 }
 
 std::ostream& operator<<(std::ostream& os, const v_array<substring>& ss) {
-	auto it = ss.begin;
+  auto it = ss.begin;
 
-	if (it == ss.end)
-	{
-		return os;
-	}
+  if (it == ss.end)
+  {
+    return os;
+  }
 
-	os << *it;
-	
-	for (it++; it != ss.end; it++) {
-		os << ",";
-		os << *it;
-	}
+  os << *it;
 
-	return os;
+  for (it++; it != ss.end; it++) {
+    os << ",";
+    os << *it;
+  }
+
+  return os;
 }

--- a/vowpalwabbit/parse_primitives.h
+++ b/vowpalwabbit/parse_primitives.h
@@ -58,19 +58,20 @@ hash_func_t getHasher(const std::string& s);
 inline float parseFloat(char * p, char **end)
 {
   char* start = p;
-  
+
   if (!*p)
-    {
-      *end = p;
-      return 0;
-    }
+  {
+    *end = p;
+    return 0;
+  }
   int s = 1;
   while (*p == ' ') p++;
-  
+
   if (*p == '-') {
-    s = -1; p++;
+    s = -1;
+    p++;
   }
-  
+
   float acc = 0;
   while (*p >= '0' && *p <= '9')
     acc = acc * 10 + *p++ - '0';
@@ -79,47 +80,52 @@ inline float parseFloat(char * p, char **end)
   if (*p == '.') {
     while (*(++p) >= '0' && *p <= '9') {
       if (num_dec < 35)
-	{
-	  acc = acc *10 + (*p - '0');
-	  num_dec++;
-	}
+      {
+        acc = acc *10 + (*p - '0');
+        num_dec++;
+      }
     }
   }
 
   int exp_acc = 0;
-  if(*p == 'e' || *p == 'E'){
+  if(*p == 'e' || *p == 'E') {
     p++;
     int exp_s = 1;
     if (*p == '-') {
-      exp_s = -1; p++;
+      exp_s = -1;
+      p++;
     }
     while (*p >= '0' && *p <= '9')
       exp_acc = exp_acc * 10 + *p++ - '0';
     exp_acc *= exp_s;
-    
+
   }
   if (*p == ' ' || *p == '\n' || *p == '\t')//easy case succeeded.
-    {
-      acc *= powf(10,(float)(exp_acc-num_dec));
-      *end = p;
-      return s * acc;
-    }
+  {
+    acc *= powf(10,(float)(exp_acc-num_dec));
+    *end = p;
+    return s * acc;
+  }
   else
     return (float)strtod(start,end);
 }
 
-inline bool nanpattern( float value ) { return ((*(uint32_t*)&value) & 0x7fC00000) == 0x7fC00000; } 
-inline bool infpattern( float value ) { return ((*(uint32_t*)&value) & 0x7fC00000) == 0x7f800000; } 
+inline bool nanpattern( float value ) {
+  return ((*(uint32_t*)&value) & 0x7fC00000) == 0x7fC00000;
+}
+inline bool infpattern( float value ) {
+  return ((*(uint32_t*)&value) & 0x7fC00000) == 0x7f800000;
+}
 
 inline float float_of_substring(substring s)
 {
   char* endptr = s.end;
   float f = parseFloat(s.begin,&endptr);
   if ((endptr == s.begin && s.begin != s.end) || nanpattern(f))
-    {
-      std::cout << "warning: " << std::string(s.begin, s.end-s.begin).c_str() << " is not a good float, replacing with 0" << std::endl;
-      f = 0;
-    }
+  {
+    std::cout << "warning: " << std::string(s.begin, s.end-s.begin).c_str() << " is not a good float, replacing with 0" << std::endl;
+    f = 0;
+  }
   return f;
 }
 
@@ -127,11 +133,11 @@ inline int int_of_substring(substring s)
 {
   char* endptr = s.end;
   int i = strtol(s.begin,&endptr,10);
-  if (endptr == s.begin && s.begin != s.end)  
-    {
-      std::cout << "warning: " << std::string(s.begin, s.end-s.begin).c_str() << " is not a good int, replacing with 0" << std::endl;
-      i = 0;
-    }
+  if (endptr == s.begin && s.begin != s.end)
+  {
+    std::cout << "warning: " << std::string(s.begin, s.end-s.begin).c_str() << " is not a good int, replacing with 0" << std::endl;
+    i = 0;
+  }
 
   return i;
 }

--- a/vowpalwabbit/parse_regressor.cc
+++ b/vowpalwabbit/parse_regressor.cc
@@ -37,19 +37,18 @@ void initialize_regressor(vw& all)
   all.reg.weight_mask = (length << all.reg.stride_shift) - 1;
   all.reg.weight_vector = calloc_or_die<weight>(length << all.reg.stride_shift);
   if (all.reg.weight_vector == nullptr)
-    { THROW(" Failed to allocate weight array with " << all.num_bits << " bits: try decreasing -b <bits>"); }
-  else
-    if (all.initial_weight != 0.)
-      for (size_t j = 0; j < length << all.reg.stride_shift; j+= ( ((size_t)1) << all.reg.stride_shift))
-	all.reg.weight_vector[j] = all.initial_weight;      
-    else
-      if (all.random_positive_weights)
-	for (size_t j = 0; j < length; j++)
-	  all.reg.weight_vector[j << all.reg.stride_shift] = (float)(0.1 * frand48());
-      else      
-	if (all.random_weights)
-	  for (size_t j = 0; j < length; j++)
-	    all.reg.weight_vector[j << all.reg.stride_shift] = (float)(frand48() - 0.5);
+  {
+    THROW(" Failed to allocate weight array with " << all.num_bits << " bits: try decreasing -b <bits>");
+  }
+  else if (all.initial_weight != 0.)
+    for (size_t j = 0; j < length << all.reg.stride_shift; j+= ( ((size_t)1) << all.reg.stride_shift))
+      all.reg.weight_vector[j] = all.initial_weight;
+  else if (all.random_positive_weights)
+    for (size_t j = 0; j < length; j++)
+      all.reg.weight_vector[j << all.reg.stride_shift] = (float)(0.1 * frand48());
+  else if (all.random_weights)
+    for (size_t j = 0; j < length; j++)
+      all.reg.weight_vector[j << all.reg.stride_shift] = (float)(frand48() - 0.5);
 }
 
 const size_t buf_size = 512;
@@ -61,265 +60,265 @@ void save_load_header(vw& all, io_buf& model_file, bool read, bool text)
   uint32_t text_len;
 
   if (model_file.files.size() > 0)
+  {
+    uint32_t v_length = (uint32_t)version.to_string().length() + 1;
+    text_len = sprintf(buff, "Version %s\n", version.to_string().c_str());
+    memcpy(buff2, version.to_string().c_str(), v_length);
+    if (read)
+      v_length = buf_size;
+    bin_text_read_write(model_file, buff2, v_length,
+                        "", read,
+                        buff, text_len, text);
+    all.model_file_ver = buff2; //stord in all to check save_resume fix in gd
+    if (all.model_file_ver < LAST_COMPATIBLE_VERSION)
+      THROW("Model has possibly incompatible version! " << all.model_file_ver.to_string());
+
+    char model = 'm';
+    bin_text_read_write_fixed(model_file, &model, 1,
+                              "file is not a model file", read,
+                              "", 0, text);
+
+    text_len = sprintf(buff, "Min label:%f\n", all.sd->min_label);
+    bin_text_read_write_fixed(model_file, (char*)&all.sd->min_label, sizeof(all.sd->min_label),
+                              "", read,
+                              buff, text_len, text);
+
+    if (read && find(all.args.begin(), all.args.end(), "--min_prediction") == all.args.end())
     {
-		uint32_t v_length = (uint32_t)version.to_string().length() + 1;
-      text_len = sprintf(buff, "Version %s\n", version.to_string().c_str());
-		memcpy(buff2, version.to_string().c_str(), v_length);
-      if (read)
-	v_length = buf_size;
-      bin_text_read_write(model_file, buff2, v_length, 
-			  "", read, 
-			  buff, text_len, text);
-      all.model_file_ver = buff2; //stord in all to check save_resume fix in gd
-      if (all.model_file_ver < LAST_COMPATIBLE_VERSION)
-	THROW("Model has possibly incompatible version! " << all.model_file_ver.to_string());
-      
-      char model = 'm';
-		bin_text_read_write_fixed(model_file, &model, 1,
-				"file is not a model file", read, 
-				"", 0, text);
-      
-      text_len = sprintf(buff, "Min label:%f\n", all.sd->min_label);
-		bin_text_read_write_fixed(model_file, (char*)&all.sd->min_label, sizeof(all.sd->min_label),
-				"", read, 
-				buff, text_len, text);
-      
-		if (read && find(all.args.begin(), all.args.end(), "--min_prediction") == all.args.end())
-		{
-			all.args.push_back("--min_prediction");
-			all.args.push_back(boost::lexical_cast<std::string>(all.sd->min_label));
-		}
-
-      text_len = sprintf(buff, "Max label:%f\n", all.sd->max_label);
-		bin_text_read_write_fixed(model_file, (char*)&all.sd->max_label, sizeof(all.sd->max_label),
-				"", read, 
-				buff, text_len, text);
-      
-		if (read && find(all.args.begin(), all.args.end(), "--max_prediction") == all.args.end())
-		{
-			all.args.push_back("--max_prediction");
-			all.args.push_back(boost::lexical_cast<std::string>(all.sd->max_label));
-		}
-
-      text_len = sprintf(buff, "bits:%d\n", (int)all.num_bits);
-      uint32_t local_num_bits = all.num_bits;
-		bin_text_read_write_fixed(model_file, (char *)&local_num_bits, sizeof(local_num_bits),
-				"", read, 
-				buff, text_len, text);
-
-		if (read && find(all.args.begin(), all.args.end(), "--bit_precision") == all.args.end())
-		{
-			all.args.push_back("--bit_precision");
-			all.args.push_back(boost::lexical_cast<std::string>(local_num_bits));
-		}
-
-		if (all.default_bits != true && all.num_bits != local_num_bits)
-		  THROW("-b bits mismatch: command-line " << all.num_bits << " != " << local_num_bits << " stored in model");
-
-      all.default_bits = false;
-      all.num_bits = local_num_bits;
-      
-      if (all.model_file_ver < VERSION_FILE_WITH_INTERACTIONS_IN_FO)
-      {  // -q, --cubic and --interactions are saved in vw::file_options
-          uint32_t pair_len = (uint32_t)all.pairs.size();
-          text_len = sprintf(buff, "%d pairs: ", (int)pair_len);
-          bin_text_read_write_fixed(model_file, (char *)&pair_len, sizeof(pair_len),
-                                    "", read,
-                                    buff, text_len, text);
-
-          for (size_t i = 0; i < pair_len; i++)
-          {
-              char pair[3] = { 0, 0, 0 };
-              if (!read)
-              {
-                  memcpy(pair, all.pairs[i].c_str(), 2);
-                  text_len = sprintf(buff, "%s ", all.pairs[i].c_str());
-              }
-
-              bin_text_read_write_fixed(model_file, pair, 2,
-                                        "", read,
-                                        buff, text_len, text);
-              if (read)
-              {
-                  string temp(pair);
-                  if (count(all.pairs.begin(), all.pairs.end(), temp) == 0)
-                      all.pairs.push_back(temp);
-              }
-          }
-
-          bin_text_read_write_fixed(model_file, buff, 0,
-                                    "", read,
-                                    "\n", 1, text);
-
-          uint32_t triple_len = (uint32_t)all.triples.size();
-          text_len = sprintf(buff, "%d triples: ", (int)triple_len);
-          bin_text_read_write_fixed(model_file, (char *)&triple_len, sizeof(triple_len),
-                                    "", read,
-                                    buff, text_len, text);
-
-          for (size_t i = 0; i < triple_len; i++)
-          {
-              char triple[4] = { 0, 0, 0, 0 };
-              if (!read)
-              {
-                  text_len = sprintf(buff, "%s ", all.triples[i].c_str());
-                  memcpy(triple, all.triples[i].c_str(), 3);
-              }
-              bin_text_read_write_fixed(model_file, triple, 3,
-                                        "", read,
-                                        buff, text_len, text);
-              if (read)
-              {
-                  string temp(triple);
-                  if (count(all.triples.begin(), all.triples.end(), temp) == 0)
-                      all.triples.push_back(temp);
-              }
-          }
-          bin_text_read_write_fixed(model_file, buff, 0,
-                                    "", read,
-                                    "\n", 1, text);
-
-          if (all.model_file_ver >= VERSION_FILE_WITH_INTERACTIONS) // && < VERSION_FILE_WITH_INTERACTIONS_IN_FO (previous if)
-          { // the only version that saves interacions among pairs and triples
-              uint32_t len = (uint32_t)all.interactions.size();
-              text_len = sprintf(buff, "%d interactions: ", (int)len);
-              bin_text_read_write_fixed(model_file, (char *)&len, sizeof(len),
-                                        "", read,
-                                        buff, text_len, text);
-
-              for (size_t i = 0; i < len; i++)
-              {
-                  uint32_t inter_len = 0;
-                  if (!read)
-                  {
-                      inter_len = (uint32_t)all.interactions[i].size();
-                      text_len = sprintf(buff, "len: %d ", inter_len);
-                  }
-                  bin_text_read_write_fixed(model_file, (char *)&inter_len, sizeof(inter_len),
-                                            "", read,
-                                            buff, text_len, text);
-                  if (read)
-                  {
-                      v_string s = v_init<unsigned char>();
-                      s.resize(inter_len);
-                      s.end += inter_len;
-                      all.interactions.push_back(s);
-                  }
-                  else
-                      text_len = sprintf(buff, "interaction: %.*s ", inter_len, all.interactions[i].begin);
-
-                  bin_text_read_write_fixed(model_file, (char*)all.interactions[i].begin, inter_len,
-                                            "", read,
-                                            buff, text_len, text);
-
-              }
-
-              bin_text_read_write_fixed(model_file, buff, 0,
-                                        "", read,
-                                        "\n", 1, text);
-          } else { // < VERSION_FILE_WITH_INTERACTIONS
-              //pairs and triples may be restored but not reflected in interactions
-              for (size_t i = 0; i < all.pairs.size(); i++)
-                  all.interactions.push_back(string2v_string(all.pairs[i]));
-              for (size_t i = 0; i < all.triples.size(); i++)
-                  all.interactions.push_back(string2v_string(all.triples[i]));
-          }
-      }
-
-      if (all.model_file_ver <= VERSION_FILE_WITH_RANK_IN_HEADER)
-      { // to fix compatibility that was broken in 7.9
-          uint32_t rank = 0;
-          text_len = sprintf(buff, "rank:%d\n", (int)rank);
-			bin_text_read_write_fixed(model_file, (char*)&rank, sizeof(rank),
-                                    "", read,
-                                    buff,text_len, text);
-          if (rank != 0)
-          {
-            if (std::find(all.args.begin(), all.args.end(), "--rank") == all.args.end())
-            {
-                all.args.push_back("--rank");
-                sprintf(buff, "%d", (int)rank);
-                all.args.push_back(buff);
-            } else
-                cerr << "WARNING: this model file contains 'rank: " << rank << "' value but it will be ignored as another value specified via the command line." << endl;
-          }
-
-      }
-      
-      text_len = sprintf(buff, "lda:%d\n", (int)all.lda);
-		bin_text_read_write_fixed(model_file, (char*)&all.lda, sizeof(all.lda),
-				"", read, 
-			buff, text_len, text);
-
-      uint32_t ngram_len = (uint32_t)all.ngram_strings.size();
-      text_len = sprintf(buff, "%d ngram: ", (int)ngram_len);
-		bin_text_read_write_fixed(model_file, (char *)&ngram_len, sizeof(ngram_len),
-				"", read, 
-			buff, text_len, text);
-      for (size_t i = 0; i < ngram_len; i++)
-	{
-			// have '\0' at the end for sure
-			char ngram[4] = { 0, 0, 0, 0 };
-	  if (!read) {
-	    text_len = sprintf(buff, "%s ", all.ngram_strings[i].c_str());
-	    memcpy(ngram, all.ngram_strings[i].c_str(), min(3, all.ngram_strings[i].size()));
-	  }
-			bin_text_read_write_fixed(model_file, ngram, 3,
-				    "", read,
-				buff, text_len, text);
-	  if (read)
-	    {
-				string temp(ngram);
-	      all.ngram_strings.push_back(temp);
-
-				all.args.push_back("--ngram");
-				all.args.push_back(boost::lexical_cast<std::string>(temp));
-	    }
-	}
-      
-		bin_text_read_write_fixed(model_file, buff, 0,
-				"", read, 
-			"\n", 1, text);
-      
-      uint32_t skip_len = (uint32_t)all.skip_strings.size();
-      text_len = sprintf(buff, "%d skip: ", (int)skip_len);
-		bin_text_read_write_fixed(model_file, (char *)&skip_len, sizeof(skip_len),
-				"", read, 
-			buff, text_len, text);
-      for (size_t i = 0; i < skip_len; i++)
-	{
-			char skip[4] = { 0, 0, 0, 0 };
-	  if (!read) {
-	    text_len = sprintf(buff, "%s ", all.skip_strings[i].c_str());
-	    memcpy(skip, all.skip_strings[i].c_str(), min(3, all.skip_strings[i].size()));
-	  }
-			bin_text_read_write_fixed(model_file, skip, 3,
-				    "", read,
-				buff, text_len, text);
-	  if (read)
-	    {
-				string temp(skip);
-	      all.skip_strings.push_back(temp);
-
-				all.args.push_back("--skips");
-				all.args.push_back(boost::lexical_cast<std::string>(temp));
-	    }
-	}
-		bin_text_read_write_fixed(model_file, buff, 0,
-				"", read, 
-			"\n", 1, text);
-      
-      text_len = sprintf(buff, "options:%s\n", all.file_options->str().c_str());
-		uint32_t len = (uint32_t)all.file_options->str().length() + 1;
-		memcpy(buff2, all.file_options->str().c_str(), len);
-      if (read)
-	len = buf_size;
-		bin_text_read_write(model_file, buff2, len,
-			  "", read,
-			  buff, text_len, text);
-      if (read)
-	all.file_options->str(buff2);
+      all.args.push_back("--min_prediction");
+      all.args.push_back(boost::lexical_cast<std::string>(all.sd->min_label));
     }
+
+    text_len = sprintf(buff, "Max label:%f\n", all.sd->max_label);
+    bin_text_read_write_fixed(model_file, (char*)&all.sd->max_label, sizeof(all.sd->max_label),
+                              "", read,
+                              buff, text_len, text);
+
+    if (read && find(all.args.begin(), all.args.end(), "--max_prediction") == all.args.end())
+    {
+      all.args.push_back("--max_prediction");
+      all.args.push_back(boost::lexical_cast<std::string>(all.sd->max_label));
+    }
+
+    text_len = sprintf(buff, "bits:%d\n", (int)all.num_bits);
+    uint32_t local_num_bits = all.num_bits;
+    bin_text_read_write_fixed(model_file, (char *)&local_num_bits, sizeof(local_num_bits),
+                              "", read,
+                              buff, text_len, text);
+
+    if (read && find(all.args.begin(), all.args.end(), "--bit_precision") == all.args.end())
+    {
+      all.args.push_back("--bit_precision");
+      all.args.push_back(boost::lexical_cast<std::string>(local_num_bits));
+    }
+
+    if (all.default_bits != true && all.num_bits != local_num_bits)
+      THROW("-b bits mismatch: command-line " << all.num_bits << " != " << local_num_bits << " stored in model");
+
+    all.default_bits = false;
+    all.num_bits = local_num_bits;
+
+    if (all.model_file_ver < VERSION_FILE_WITH_INTERACTIONS_IN_FO)
+    { // -q, --cubic and --interactions are saved in vw::file_options
+      uint32_t pair_len = (uint32_t)all.pairs.size();
+      text_len = sprintf(buff, "%d pairs: ", (int)pair_len);
+      bin_text_read_write_fixed(model_file, (char *)&pair_len, sizeof(pair_len),
+                                "", read,
+                                buff, text_len, text);
+
+      for (size_t i = 0; i < pair_len; i++)
+      {
+        char pair[3] = { 0, 0, 0 };
+        if (!read)
+        {
+          memcpy(pair, all.pairs[i].c_str(), 2);
+          text_len = sprintf(buff, "%s ", all.pairs[i].c_str());
+        }
+
+        bin_text_read_write_fixed(model_file, pair, 2,
+                                  "", read,
+                                  buff, text_len, text);
+        if (read)
+        {
+          string temp(pair);
+          if (count(all.pairs.begin(), all.pairs.end(), temp) == 0)
+            all.pairs.push_back(temp);
+        }
+      }
+
+      bin_text_read_write_fixed(model_file, buff, 0,
+                                "", read,
+                                "\n", 1, text);
+
+      uint32_t triple_len = (uint32_t)all.triples.size();
+      text_len = sprintf(buff, "%d triples: ", (int)triple_len);
+      bin_text_read_write_fixed(model_file, (char *)&triple_len, sizeof(triple_len),
+                                "", read,
+                                buff, text_len, text);
+
+      for (size_t i = 0; i < triple_len; i++)
+      {
+        char triple[4] = { 0, 0, 0, 0 };
+        if (!read)
+        {
+          text_len = sprintf(buff, "%s ", all.triples[i].c_str());
+          memcpy(triple, all.triples[i].c_str(), 3);
+        }
+        bin_text_read_write_fixed(model_file, triple, 3,
+                                  "", read,
+                                  buff, text_len, text);
+        if (read)
+        {
+          string temp(triple);
+          if (count(all.triples.begin(), all.triples.end(), temp) == 0)
+            all.triples.push_back(temp);
+        }
+      }
+      bin_text_read_write_fixed(model_file, buff, 0,
+                                "", read,
+                                "\n", 1, text);
+
+      if (all.model_file_ver >= VERSION_FILE_WITH_INTERACTIONS) // && < VERSION_FILE_WITH_INTERACTIONS_IN_FO (previous if)
+      { // the only version that saves interacions among pairs and triples
+        uint32_t len = (uint32_t)all.interactions.size();
+        text_len = sprintf(buff, "%d interactions: ", (int)len);
+        bin_text_read_write_fixed(model_file, (char *)&len, sizeof(len),
+                                  "", read,
+                                  buff, text_len, text);
+
+        for (size_t i = 0; i < len; i++)
+        {
+          uint32_t inter_len = 0;
+          if (!read)
+          {
+            inter_len = (uint32_t)all.interactions[i].size();
+            text_len = sprintf(buff, "len: %d ", inter_len);
+          }
+          bin_text_read_write_fixed(model_file, (char *)&inter_len, sizeof(inter_len),
+                                    "", read,
+                                    buff, text_len, text);
+          if (read)
+          {
+            v_string s = v_init<unsigned char>();
+            s.resize(inter_len);
+            s.end += inter_len;
+            all.interactions.push_back(s);
+          }
+          else
+            text_len = sprintf(buff, "interaction: %.*s ", inter_len, all.interactions[i].begin);
+
+          bin_text_read_write_fixed(model_file, (char*)all.interactions[i].begin, inter_len,
+                                    "", read,
+                                    buff, text_len, text);
+
+        }
+
+        bin_text_read_write_fixed(model_file, buff, 0,
+                                  "", read,
+                                  "\n", 1, text);
+      } else { // < VERSION_FILE_WITH_INTERACTIONS
+        //pairs and triples may be restored but not reflected in interactions
+        for (size_t i = 0; i < all.pairs.size(); i++)
+          all.interactions.push_back(string2v_string(all.pairs[i]));
+        for (size_t i = 0; i < all.triples.size(); i++)
+          all.interactions.push_back(string2v_string(all.triples[i]));
+      }
+    }
+
+    if (all.model_file_ver <= VERSION_FILE_WITH_RANK_IN_HEADER)
+    { // to fix compatibility that was broken in 7.9
+      uint32_t rank = 0;
+      text_len = sprintf(buff, "rank:%d\n", (int)rank);
+      bin_text_read_write_fixed(model_file, (char*)&rank, sizeof(rank),
+                                "", read,
+                                buff,text_len, text);
+      if (rank != 0)
+      {
+        if (std::find(all.args.begin(), all.args.end(), "--rank") == all.args.end())
+        {
+          all.args.push_back("--rank");
+          sprintf(buff, "%d", (int)rank);
+          all.args.push_back(buff);
+        } else
+          cerr << "WARNING: this model file contains 'rank: " << rank << "' value but it will be ignored as another value specified via the command line." << endl;
+      }
+
+    }
+
+    text_len = sprintf(buff, "lda:%d\n", (int)all.lda);
+    bin_text_read_write_fixed(model_file, (char*)&all.lda, sizeof(all.lda),
+                              "", read,
+                              buff, text_len, text);
+
+    uint32_t ngram_len = (uint32_t)all.ngram_strings.size();
+    text_len = sprintf(buff, "%d ngram: ", (int)ngram_len);
+    bin_text_read_write_fixed(model_file, (char *)&ngram_len, sizeof(ngram_len),
+                              "", read,
+                              buff, text_len, text);
+    for (size_t i = 0; i < ngram_len; i++)
+    {
+      // have '\0' at the end for sure
+      char ngram[4] = { 0, 0, 0, 0 };
+      if (!read) {
+        text_len = sprintf(buff, "%s ", all.ngram_strings[i].c_str());
+        memcpy(ngram, all.ngram_strings[i].c_str(), min(3, all.ngram_strings[i].size()));
+      }
+      bin_text_read_write_fixed(model_file, ngram, 3,
+                                "", read,
+                                buff, text_len, text);
+      if (read)
+      {
+        string temp(ngram);
+        all.ngram_strings.push_back(temp);
+
+        all.args.push_back("--ngram");
+        all.args.push_back(boost::lexical_cast<std::string>(temp));
+      }
+    }
+
+    bin_text_read_write_fixed(model_file, buff, 0,
+                              "", read,
+                              "\n", 1, text);
+
+    uint32_t skip_len = (uint32_t)all.skip_strings.size();
+    text_len = sprintf(buff, "%d skip: ", (int)skip_len);
+    bin_text_read_write_fixed(model_file, (char *)&skip_len, sizeof(skip_len),
+                              "", read,
+                              buff, text_len, text);
+    for (size_t i = 0; i < skip_len; i++)
+    {
+      char skip[4] = { 0, 0, 0, 0 };
+      if (!read) {
+        text_len = sprintf(buff, "%s ", all.skip_strings[i].c_str());
+        memcpy(skip, all.skip_strings[i].c_str(), min(3, all.skip_strings[i].size()));
+      }
+      bin_text_read_write_fixed(model_file, skip, 3,
+                                "", read,
+                                buff, text_len, text);
+      if (read)
+      {
+        string temp(skip);
+        all.skip_strings.push_back(temp);
+
+        all.args.push_back("--skips");
+        all.args.push_back(boost::lexical_cast<std::string>(temp));
+      }
+    }
+    bin_text_read_write_fixed(model_file, buff, 0,
+                              "", read,
+                              "\n", 1, text);
+
+    text_len = sprintf(buff, "options:%s\n", all.file_options->str().c_str());
+    uint32_t len = (uint32_t)all.file_options->str().length() + 1;
+    memcpy(buff2, all.file_options->str().c_str(), len);
+    if (read)
+      len = buf_size;
+    bin_text_read_write(model_file, buff2, len,
+                        "", read,
+                        buff, text_len, text);
+    if (read)
+      all.file_options->str(buff2);
+  }
 
 }
 
@@ -331,7 +330,7 @@ void dump_regressor(vw& all, string reg_name, bool as_text)
   io_buf io_temp;
 
   io_temp.open_file(start_name.c_str(), all.stdin_off, io_buf::WRITE);
-  
+
   save_load_header(all, io_temp, false, as_text);
   all.l->save_load(io_temp, false, as_text);
 
@@ -352,14 +351,14 @@ void save_predictor(vw& all, string reg_name, size_t current_pass)
 
 void finalize_regressor(vw& all, string reg_name)
 {
-  if (!all.early_terminate){
+  if (!all.early_terminate) {
     if (all.per_feature_regularizer_output.length() > 0)
       dump_regressor(all, all.per_feature_regularizer_output, false);
     else
       dump_regressor(all, reg_name, false);
     if (all.per_feature_regularizer_text.length() > 0)
       dump_regressor(all, all.per_feature_regularizer_text, true);
-    else{
+    else {
       dump_regressor(all, all.text_regressor_name, true);
       all.print_invert = true;
       dump_regressor(all, all.inv_hash_regressor_name, true);
@@ -381,7 +380,7 @@ void parse_regressor_args(vw& all, io_buf& io_temp)
   if (regs.size() > 0) {
     io_temp.open_file(regs[0].c_str(), all.stdin_off, io_buf::READ);
     if (!all.quiet) {
-        //cerr << "initial_regressor = " << regs[0] << endl;
+      //cerr << "initial_regressor = " << regs[0] << endl;
       if (regs.size() > 1) {
         cerr << "warning: ignoring remaining " << (regs.size() - 1) << " initial regressors" << endl;
       }
@@ -393,15 +392,15 @@ void parse_mask_regressor_args(vw& all)
 {
   po::variables_map& vm = all.vm;
   if (vm.count("feature_mask")) {
-    size_t length = ((size_t)1) << all.num_bits;  
+    size_t length = ((size_t)1) << all.num_bits;
     string mask_filename = vm["feature_mask"].as<string>();
-    if (vm.count("initial_regressor")){ 
+    if (vm.count("initial_regressor")) {
       vector<string> init_filename = vm["initial_regressor"].as< vector<string> >();
-      if(mask_filename == init_filename[0]){//-i and -mask are from same file, just generate mask
+      if(mask_filename == init_filename[0]) { //-i and -mask are from same file, just generate mask
         return;
       }
     }
-    
+
     //all other cases, including from different file, or -i does not exist, need to read in the mask file
     io_buf io_temp_mask;
     io_temp_mask.open_file(mask_filename.c_str(), false, io_buf::READ);
@@ -420,7 +419,7 @@ void parse_mask_regressor_args(vw& all)
       io_temp.close_file();
 
       // Re-zero the weights, in case weights of initial regressor use different indices
-      for (size_t j = 0; j < length; j++){
+      for (size_t j = 0; j < length; j++) {
         all.reg.weight_vector[j << all.reg.stride_shift] = 0.;
       }
     } else {
@@ -432,9 +431,9 @@ void parse_mask_regressor_args(vw& all)
 
 namespace VW
 {
-	void save_predictor(vw& all, string reg_name)
-	{
-		dump_regressor(all, reg_name, false);
-	}
+void save_predictor(vw& all, string reg_name)
+{
+  dump_regressor(all, reg_name, false);
+}
 }
 

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -24,12 +24,12 @@ typedef int socklen_t;
 
 int daemon(int a, int b)
 {
-	exit(0);
-	return 0;
+  exit(0);
+  return 0;
 }
 int getpid()
 {
-	return (int) ::GetCurrentProcessId();
+  return (int) ::GetCurrentProcessId();
 }
 #else
 #include <netdb.h>
@@ -60,16 +60,16 @@ void initialize_mutex(MUTEX * pm)
 #ifndef _WIN32
   pthread_mutex_init(pm, nullptr);
 #else
-	::InitializeCriticalSection(pm);
+  ::InitializeCriticalSection(pm);
 #endif
 }
 
 void delete_mutex(MUTEX * pm)
 {
 #ifndef _WIN32
-	// no operation necessary here
+  // no operation necessary here
 #else
-	::DeleteCriticalSection(pm);
+  ::DeleteCriticalSection(pm);
 #endif
 }
 
@@ -78,52 +78,52 @@ void initialize_condition_variable(CV * pcv)
 #ifndef _WIN32
   pthread_cond_init(pcv, nullptr);
 #else
-	::InitializeConditionVariable(pcv);
+  ::InitializeConditionVariable(pcv);
 #endif
 }
 
 void mutex_lock(MUTEX * pm)
 {
 #ifndef _WIN32
-	pthread_mutex_lock(pm);
+  pthread_mutex_lock(pm);
 #else
-	::EnterCriticalSection(pm);
+  ::EnterCriticalSection(pm);
 #endif
 }
 
 void mutex_unlock(MUTEX * pm)
 {
 #ifndef _WIN32
-	pthread_mutex_unlock(pm);
+  pthread_mutex_unlock(pm);
 #else
-	::LeaveCriticalSection(pm);
+  ::LeaveCriticalSection(pm);
 #endif
 }
 
 void condition_variable_wait(CV * pcv, MUTEX * pm)
 {
 #ifndef _WIN32
-	pthread_cond_wait(pcv, pm);
+  pthread_cond_wait(pcv, pm);
 #else
-	::SleepConditionVariableCS(pcv, pm, INFINITE);
+  ::SleepConditionVariableCS(pcv, pm, INFINITE);
 #endif
 }
 
 void condition_variable_signal(CV * pcv)
 {
 #ifndef _WIN32
-	pthread_cond_signal(pcv);
+  pthread_cond_signal(pcv);
 #else
-	::WakeConditionVariable(pcv);
+  ::WakeConditionVariable(pcv);
 #endif
 }
 
 void condition_variable_signal_all(CV * pcv)
 {
 #ifndef _WIN32
-	pthread_cond_broadcast(pcv);
+  pthread_cond_broadcast(pcv);
 #else
-	::WakeAllConditionVariable(pcv);
+  ::WakeAllConditionVariable(pcv);
 #endif
 }
 
@@ -159,7 +159,7 @@ parser* new_parser()
   return &ret;
 }
 
-void set_compressed(parser* par){
+void set_compressed(parser* par) {
   finalize_source(par);
   par->input = new comp_io_buf;
   par->output = new comp_io_buf;
@@ -176,7 +176,7 @@ uint32_t cache_numbits(io_buf* buf, int filepointer)
 
   if (v_length == 0)
     THROW("cache version too short, cache file is probably invalid");
-    
+
   t.erase();
   if (t.size() < v_length)
     t.resize(v_length);
@@ -184,27 +184,27 @@ uint32_t cache_numbits(io_buf* buf, int filepointer)
   buf->read_file(filepointer,t.begin,v_length);
   version_struct v_tmp(t.begin);
   if ( v_tmp != version )
-    {
-      cout << "cache has possibly incompatible version, rebuilding" << endl;
-      t.delete_v();
-      return 0;
-    }
+  {
+    cout << "cache has possibly incompatible version, rebuilding" << endl;
+    t.delete_v();
+    return 0;
+  }
 
   char temp;
-  if (buf->read_file(filepointer, &temp, 1) < 1) 
+  if (buf->read_file(filepointer, &temp, 1) < 1)
     THROW("failed to read");
 
   if (temp != 'c')
     THROW("data file is not a cache file");
 
   t.delete_v();
-  
+
   const int total = sizeof(uint32_t);
   char* p[total];
-  if (buf->read_file(filepointer, p, total) < total) 
-    {
-      return true;
-    }
+  if (buf->read_file(filepointer, p, total) < total)
+  {
+    return true;
+  }
 
   uint32_t cache_numbits = *(uint32_t *)p;
   return cache_numbits;
@@ -223,67 +223,67 @@ void reset_source(vw& all, size_t numbits)
   io_buf* input = all.p->input;
   input->current = 0;
   if (all.p->write_cache)
-    {
-      all.p->output->flush();
-      all.p->write_cache = false;
-      all.p->output->close_file();
-      remove(all.p->output->finalname.begin);
-      rename(all.p->output->currentname.begin, all.p->output->finalname.begin);
-      while(input->num_files() > 0)
-	if (input->compressed())
-	  input->close_file();
-	else
-	  {
-	    int fd = input->files.pop();
-	    if (!member(all.final_prediction_sink, (size_t) fd))
-	      io_buf::close_file_or_socket(fd);
-	  }
-      input->open_file(all.p->output->finalname.begin, all.stdin_off, io_buf::READ); //pushing is merged into open_file
-      all.p->reader = read_cached_features;
-    }
+  {
+    all.p->output->flush();
+    all.p->write_cache = false;
+    all.p->output->close_file();
+    remove(all.p->output->finalname.begin);
+    rename(all.p->output->currentname.begin, all.p->output->finalname.begin);
+    while(input->num_files() > 0)
+      if (input->compressed())
+        input->close_file();
+      else
+      {
+        int fd = input->files.pop();
+        if (!member(all.final_prediction_sink, (size_t) fd))
+          io_buf::close_file_or_socket(fd);
+      }
+    input->open_file(all.p->output->finalname.begin, all.stdin_off, io_buf::READ); //pushing is merged into open_file
+    all.p->reader = read_cached_features;
+  }
   if ( all.p->resettable == true )
+  {
+    if (all.daemon)
     {
-      if (all.daemon)
-	{
-	  // wait for all predictions to be sent back to client
-	  mutex_lock(&all.p->output_lock);
-	  while (all.p->local_example_number != all.p->end_parsed_examples)
-	    condition_variable_wait(&all.p->output_done, &all.p->output_lock);
-	  mutex_unlock(&all.p->output_lock);
-	  
-	  // close socket, erase final prediction sink and socket
-	  io_buf::close_file_or_socket(all.p->input->files[0]);
-	  all.final_prediction_sink.erase();
-	  all.p->input->files.erase();
-	  
-	  sockaddr_in client_address;
-	  socklen_t size = sizeof(client_address);
-	  int f = (int)accept(all.p->bound_sock,(sockaddr*)&client_address,&size);
-	  if (f < 0)
-	    THROW("accept: " << strerror(errno));
-	  
-	  // note: breaking cluster parallel online learning by dropping support for id
-	  
-	  all.final_prediction_sink.push_back((size_t) f);
-	  all.p->input->files.push_back(f);
+      // wait for all predictions to be sent back to client
+      mutex_lock(&all.p->output_lock);
+      while (all.p->local_example_number != all.p->end_parsed_examples)
+        condition_variable_wait(&all.p->output_done, &all.p->output_lock);
+      mutex_unlock(&all.p->output_lock);
 
-	  if (isbinary(*(all.p->input))) {
-	    all.p->reader = read_cached_features;
-	    all.print = binary_print_result;
-	  } else {
-	    all.p->reader = read_features;
-	    all.print = print_result;
-	  }
-	}
-      else {
-	for (size_t i = 0; i < input->files.size();i++)
-	  {
-	    input->reset_file(input->files[i]);
-	    if (cache_numbits(input, input->files[i]) < numbits)
-	      THROW("argh, a bug in caching of some sort!");
-	  }
+      // close socket, erase final prediction sink and socket
+      io_buf::close_file_or_socket(all.p->input->files[0]);
+      all.final_prediction_sink.erase();
+      all.p->input->files.erase();
+
+      sockaddr_in client_address;
+      socklen_t size = sizeof(client_address);
+      int f = (int)accept(all.p->bound_sock,(sockaddr*)&client_address,&size);
+      if (f < 0)
+        THROW("accept: " << strerror(errno));
+
+      // note: breaking cluster parallel online learning by dropping support for id
+
+      all.final_prediction_sink.push_back((size_t) f);
+      all.p->input->files.push_back(f);
+
+      if (isbinary(*(all.p->input))) {
+        all.p->reader = read_cached_features;
+        all.print = binary_print_result;
+      } else {
+        all.p->reader = read_features;
+        all.print = print_result;
       }
     }
+    else {
+      for (size_t i = 0; i < input->files.size(); i++)
+      {
+        input->reset_file(input->files[i]);
+        if (cache_numbits(input, input->files[i]) < numbits)
+          THROW("argh, a bug in caching of some sort!");
+      }
+    }
+  }
 }
 
 void finalize_source(parser* p)
@@ -305,14 +305,14 @@ void finalize_source(parser* p)
 void make_write_cache(vw& all, string &newname, bool quiet)
 {
   io_buf* output = all.p->output;
-  if (output->files.size() != 0){
+  if (output->files.size() != 0) {
     cerr << "Warning: you tried to make two write caches.  Only the first one will be made." << endl;
     return;
   }
 
   string temp = newname+string(".writing");
   push_many(output->currentname,temp.c_str(),temp.length()+1);
-  
+
   int f = output->open_file(temp.c_str(), all.stdin_off, io_buf::WRITE);
   if (f == -1) {
     cerr << "can't create cache file !" << endl;
@@ -325,7 +325,7 @@ void make_write_cache(vw& all, string &newname, bool quiet)
   output->write_file(f,version.to_string().c_str(),v_length);
   output->write_file(f,"c",1);
   output->write_file(f, &all.num_bits, sizeof(all.num_bits));
-  
+
   push_many(output->finalname,newname.c_str(),newname.length()+1);
   all.p->write_cache = true;
   if (!quiet)
@@ -333,7 +333,7 @@ void make_write_cache(vw& all, string &newname, bool quiet)
 }
 
 void parse_cache(vw& all, po::variables_map &vm, string source,
-		 bool quiet)
+                 bool quiet)
 {
   vector<string> caches;
   if (vm.count("cache_file"))
@@ -344,41 +344,43 @@ void parse_cache(vw& all, po::variables_map &vm, string source,
   all.p->write_cache = false;
 
   for (size_t i = 0; i < caches.size(); i++)
-    {
-      int f = -1;
-      if (!vm.count("kill_cache"))
-	try {
+  {
+    int f = -1;
+    if (!vm.count("kill_cache"))
+      try {
         f = all.p->input->open_file(caches[i].c_str(), all.stdin_off, io_buf::READ);
-	}
-	catch (exception e){ f = -1;}
-      if (f == -1)
-	make_write_cache(all, caches[i], quiet);
+      }
+      catch (exception e) {
+        f = -1;
+      }
+    if (f == -1)
+      make_write_cache(all, caches[i], quiet);
+    else {
+      uint32_t c = cache_numbits(all.p->input, f);
+      if (c < all.num_bits) {
+        all.p->input->close_file();
+        make_write_cache(all, caches[i], quiet);
+      }
       else {
-	uint32_t c = cache_numbits(all.p->input, f);
-	if (c < all.num_bits) {
-          all.p->input->close_file();          
-	  make_write_cache(all, caches[i], quiet);
-	}
-	else {
-	  if (!quiet)
-	    cerr << "using cache_file = " << caches[i].c_str() << endl;
-	  all.p->reader = read_cached_features;
-	  if (c == all.num_bits)
-	    all.p->sorted_cache = true;
-	  else
-	    all.p->sorted_cache = false;
-	  all.p->resettable = true;
-	}
+        if (!quiet)
+          cerr << "using cache_file = " << caches[i].c_str() << endl;
+        all.p->reader = read_cached_features;
+        if (c == all.num_bits)
+          all.p->sorted_cache = true;
+        else
+          all.p->sorted_cache = false;
+        all.p->resettable = true;
       }
     }
-  
+  }
+
   all.parse_mask = (1 << all.num_bits) - 1;
   if (caches.size() == 0)
-    {
-      if (!quiet)
-	cerr << "using no cache" << endl;
-      all.p->output->space.delete_v();
-    }
+  {
+    if (!quiet)
+      cerr << "using no cache" << endl;
+    all.p->output->space.delete_v();
+  }
 }
 
 //For macs
@@ -392,226 +394,226 @@ void enable_sources(vw& all, bool quiet, size_t passes)
   parse_cache(all, all.vm, all.data_filename, quiet);
 
   if (all.daemon || all.active)
+  {
+#ifdef _WIN32
+    WSAData wsaData;
+    WSAStartup(MAKEWORD(2,2), &wsaData);
+    int lastError = WSAGetLastError();
+#endif
+    all.p->bound_sock = (int)socket(PF_INET, SOCK_STREAM, 0);
+    if (all.p->bound_sock < 0) {
+      stringstream msg;
+      msg << "socket: " << strerror(errno);
+      cerr << msg.str() << endl;
+      THROW(msg.str().c_str());
+    }
+
+    int on = 1;
+    if (setsockopt(all.p->bound_sock, SOL_SOCKET, SO_REUSEADDR, (char*)&on, sizeof(on)) < 0)
+      cerr << "setsockopt SO_REUSEADDR: " << strerror(errno) << endl;
+
+    // Enable TCP Keep Alive to prevent socket leaks
+    int enableTKA = 1;
+    if (setsockopt(all.p->bound_sock, SOL_SOCKET, SO_KEEPALIVE, (char*)&enableTKA, sizeof(enableTKA)) < 0)
+      cerr << "setsockopt SO_KEEPALIVE: " << strerror(errno) << endl;
+
+    sockaddr_in address;
+    address.sin_family = AF_INET;
+    address.sin_addr.s_addr = htonl(INADDR_ANY);
+    short unsigned int port = 26542;
+    if (all.vm.count("port"))
+      port = (uint16_t)all.vm["port"].as<size_t>();
+    address.sin_port = htons(port);
+
+    // attempt to bind to socket
+    if ( ::bind(all.p->bound_sock,(sockaddr*)&address, sizeof(address)) < 0 )
+      THROWERRNO("bind");
+
+    // listen on socket
+    if (listen(all.p->bound_sock, 1) < 0)
+      THROWERRNO("listen");
+
+    // write port file
+    if (all.vm.count("port_file"))
+    {
+      socklen_t address_size = sizeof(address);
+      if (getsockname(all.p->bound_sock, (sockaddr*)&address, &address_size) < 0)
+      {
+        cerr << "getsockname: " << strerror(errno) << endl;
+      }
+      ofstream port_file;
+      port_file.open(all.vm["port_file"].as<string>().c_str());
+      if (!port_file.is_open())
+        THROW("error writing port file: " << all.vm["port_file"].as<string>());
+
+      port_file << ntohs(address.sin_port) << endl;
+      port_file.close();
+    }
+
+    // background process
+    if (!all.active && daemon(1,1))
+      THROWERRNO("daemon");
+
+    // write pid file
+    if (all.vm.count("pid_file"))
+    {
+      ofstream pid_file;
+      pid_file.open(all.vm["pid_file"].as<string>().c_str());
+      if (!pid_file.is_open())
+        THROW("error writing pid file");
+
+      pid_file << getpid() << endl;
+      pid_file.close();
+    }
+
+    if (all.daemon && !all.active)
     {
 #ifdef _WIN32
-      WSAData wsaData;
-      WSAStartup(MAKEWORD(2,2), &wsaData);
-      int lastError = WSAGetLastError();
-#endif
-      all.p->bound_sock = (int)socket(PF_INET, SOCK_STREAM, 0);
-      if (all.p->bound_sock < 0) {
-	stringstream msg;
-	msg << "socket: " << strerror(errno);
-	cerr << msg.str() << endl;
-	THROW(msg.str().c_str());
+      THROW("not supported on windows");
+#else
+      fclose(stdin);
+      // weights will be shared across processes, accessible to children
+      float* shared_weights =
+        (float*)mmap(0,(all.length() << all.reg.stride_shift) * sizeof(float),
+                     PROT_READ|PROT_WRITE, MAP_SHARED|MAP_ANONYMOUS, -1, 0);
+
+      size_t float_count = all.length() << all.reg.stride_shift;
+      weight* dest = shared_weights;
+      memcpy(dest, all.reg.weight_vector, float_count*sizeof(float));
+      free(all.reg.weight_vector);
+      all.reg.weight_vector = dest;
+
+      // learning state to be shared across children
+      shared_data* sd = (shared_data *)mmap(0,sizeof(shared_data),
+                                            PROT_READ|PROT_WRITE, MAP_SHARED|MAP_ANONYMOUS, -1, 0);
+      memcpy(sd, all.sd, sizeof(shared_data));
+      free(all.sd);
+      all.sd = sd;
+
+      // create children
+      size_t num_children = all.num_children;
+      v_array<int> children = v_init<int>();
+      children.resize(num_children);
+      for (size_t i = 0; i < num_children; i++)
+      {
+        // fork() returns pid if parent, 0 if child
+        // store fork value and run child process if child
+        if ((children[i] = fork()) == 0) {
+          all.quiet |= (i > 0);
+          goto child;
+        }
       }
 
-      int on = 1;
-      if (setsockopt(all.p->bound_sock, SOL_SOCKET, SO_REUSEADDR, (char*)&on, sizeof(on)) < 0)
-	cerr << "setsockopt SO_REUSEADDR: " << strerror(errno) << endl;
+      // install signal handler so we can kill children when killed
+      {
+        struct sigaction sa;
+        // specifically don't set SA_RESTART in sa.sa_flags, so that
+        // waitid will be interrupted by SIGTERM with handler installed
+        memset(&sa, 0, sizeof(sa));
+        sa.sa_handler = handle_sigterm;
+        sigaction(SIGTERM, &sa, nullptr);
+      }
 
-      // Enable TCP Keep Alive to prevent socket leaks
-      int enableTKA = 1;
-      if (setsockopt(all.p->bound_sock, SOL_SOCKET, SO_KEEPALIVE, (char*)&enableTKA, sizeof(enableTKA)) < 0)
-        cerr << "setsockopt SO_KEEPALIVE: " << strerror(errno) << endl;
-
-      sockaddr_in address;
-      address.sin_family = AF_INET;
-      address.sin_addr.s_addr = htonl(INADDR_ANY);
-      short unsigned int port = 26542;
-      if (all.vm.count("port"))
-	port = (uint16_t)all.vm["port"].as<size_t>();
-      address.sin_port = htons(port);
-
-      // attempt to bind to socket
-      if ( ::bind(all.p->bound_sock,(sockaddr*)&address, sizeof(address)) < 0 )
-	THROWERRNO("bind");
-      
-      // listen on socket
-      if (listen(all.p->bound_sock, 1) < 0)
-	THROWERRNO("listen");
-	  
-	  // write port file
-	  if (all.vm.count("port_file"))
-	{
-          socklen_t address_size = sizeof(address);
-          if (getsockname(all.p->bound_sock, (sockaddr*)&address, &address_size) < 0)
-            {
-              cerr << "getsockname: " << strerror(errno) << endl;
+      while (true)
+      {
+        // wait for child to change state; if finished, then respawn
+        int status;
+        pid_t pid = wait(&status);
+        if (got_sigterm)
+        {
+          for (size_t i = 0; i < num_children; i++)
+            kill(children[i], SIGTERM);
+          VW::finish(all);
+          exit(0);
+        }
+        if (pid < 0)
+          continue;
+        for (size_t i = 0; i < num_children; i++)
+          if (pid == children[i])
+          {
+            if ((children[i]=fork()) == 0) {
+              all.quiet |= (i > 0);
+              goto child;
             }
-	  ofstream port_file;
-	  port_file.open(all.vm["port_file"].as<string>().c_str());
-	  if (!port_file.is_open())
-	    THROW("error writing port file: " << all.vm["port_file"].as<string>());
-
-	  port_file << ntohs(address.sin_port) << endl;
-	  port_file.close();
-	}
-
-      // background process
-      if (!all.active && daemon(1,1))
-	THROWERRNO("daemon");
-
-      // write pid file
-      if (all.vm.count("pid_file"))
-	{
-	  ofstream pid_file;
-	  pid_file.open(all.vm["pid_file"].as<string>().c_str());
-	  if (!pid_file.is_open())
-	    THROW("error writing pid file");
-
-	  pid_file << getpid() << endl;
-	  pid_file.close();
-	}
-
-      if (all.daemon && !all.active)
-	{
-#ifdef _WIN32
-	  THROW("not supported on windows");
-#else
-	  fclose(stdin);
-	  // weights will be shared across processes, accessible to children
-	  float* shared_weights =
-	    (float*)mmap(0,(all.length() << all.reg.stride_shift) * sizeof(float),
-			 PROT_READ|PROT_WRITE, MAP_SHARED|MAP_ANONYMOUS, -1, 0);
-	  
-	  size_t float_count = all.length() << all.reg.stride_shift;
-	  weight* dest = shared_weights;
-	  memcpy(dest, all.reg.weight_vector, float_count*sizeof(float));
-	  free(all.reg.weight_vector);
-	  all.reg.weight_vector = dest;
-	  
-	  // learning state to be shared across children
-	  shared_data* sd = (shared_data *)mmap(0,sizeof(shared_data),
-			 PROT_READ|PROT_WRITE, MAP_SHARED|MAP_ANONYMOUS, -1, 0);
-	  memcpy(sd, all.sd, sizeof(shared_data));
-	  free(all.sd);
-	  all.sd = sd;
-
-	  // create children
-	  size_t num_children = all.num_children;
-	  v_array<int> children = v_init<int>();
-	  children.resize(num_children);
-	  for (size_t i = 0; i < num_children; i++)
-	    {
-	      // fork() returns pid if parent, 0 if child
-	      // store fork value and run child process if child
-	      if ((children[i] = fork()) == 0) {
-                all.quiet |= (i > 0);
-		goto child;
-              }
-	    }
-
-	  // install signal handler so we can kill children when killed
-	  {
-	    struct sigaction sa;
-	    // specifically don't set SA_RESTART in sa.sa_flags, so that
-	    // waitid will be interrupted by SIGTERM with handler installed
-	    memset(&sa, 0, sizeof(sa));
-	    sa.sa_handler = handle_sigterm;
-	    sigaction(SIGTERM, &sa, nullptr);
-	  }
-
-	  while (true)
-	    {
-	      // wait for child to change state; if finished, then respawn
-	      int status;
-	      pid_t pid = wait(&status);
-	      if (got_sigterm)
-		{
-		  for (size_t i = 0; i < num_children; i++)
-		    kill(children[i], SIGTERM);
-                  VW::finish(all);
-		  exit(0);
-		}
-	      if (pid < 0)
-		continue;
-	      for (size_t i = 0; i < num_children; i++)
-		if (pid == children[i])
-		  {
-		    if ((children[i]=fork()) == 0) {
-                      all.quiet |= (i > 0);
-		      goto child;
-                    }
-		    break;
-		  }
-	    }
+            break;
+          }
+      }
 
 #endif
-	}
+    }
 
 #ifndef _WIN32
-	child:
+child:
 #endif
-      sockaddr_in client_address;
-      socklen_t size = sizeof(client_address);
-      all.p->max_fd = 0;
-      if (!all.quiet)
-	cerr << "calling accept" << endl;
-      int f = (int)accept(all.p->bound_sock,(sockaddr*)&client_address,&size);
-      if (f < 0)
-	THROWERRNO("accept");
-      
-      all.p->label_sock = f;
-      all.print = print_result;
-      
-      all.final_prediction_sink.push_back((size_t) f);
-      
-      all.p->input->files.push_back(f);
-      all.p->max_fd = max(f, all.p->max_fd);
-      if (!all.quiet)
-	cerr << "reading data from port " << port << endl;
-      
-      all.p->max_fd++;
-      if(all.active)
-	all.p->reader = read_features;
-      else {
-	if (isbinary(*(all.p->input))) {
-	  all.p->reader = read_cached_features;
-	  all.print = binary_print_result;
-	} else {
-	  all.p->reader = read_features;
-	}
-	all.p->sorted_cache = true;
-      }
-      all.p->resettable = all.p->write_cache || all.daemon;
-    }
-  else  
-    {
-      if (all.p->input->files.size() > 0)
-	{
-	  if (!quiet)
-	    cerr << "ignoring text input in favor of cache input" << endl;
-	}
-      else
-	{
-	  string temp = all.data_filename;
-	  if (!quiet)
-	    cerr << "Reading datafile = " << temp << endl;
-	  try
-	  {
-	    all.p->input->open_file(temp.c_str(), all.stdin_off, io_buf::READ);
-	  }
-	  catch (exception const& ex)
-	    {
-		  if (temp.size() != 0)
-		  {
-			cerr << "can't open '" << temp << "', sailing on!" << endl;
-	    }
-		  else
-		  {
-			  throw ex;
-		  }
-	  }
+    sockaddr_in client_address;
+    socklen_t size = sizeof(client_address);
+    all.p->max_fd = 0;
+    if (!all.quiet)
+      cerr << "calling accept" << endl;
+    int f = (int)accept(all.p->bound_sock,(sockaddr*)&client_address,&size);
+    if (f < 0)
+      THROWERRNO("accept");
 
-	  all.p->reader = read_features;
-	  all.p->resettable = all.p->write_cache;
-	}
+    all.p->label_sock = f;
+    all.print = print_result;
+
+    all.final_prediction_sink.push_back((size_t) f);
+
+    all.p->input->files.push_back(f);
+    all.p->max_fd = max(f, all.p->max_fd);
+    if (!all.quiet)
+      cerr << "reading data from port " << port << endl;
+
+    all.p->max_fd++;
+    if(all.active)
+      all.p->reader = read_features;
+    else {
+      if (isbinary(*(all.p->input))) {
+        all.p->reader = read_cached_features;
+        all.print = binary_print_result;
+      } else {
+        all.p->reader = read_features;
+      }
+      all.p->sorted_cache = true;
     }
-  
+    all.p->resettable = all.p->write_cache || all.daemon;
+  }
+  else
+  {
+    if (all.p->input->files.size() > 0)
+    {
+      if (!quiet)
+        cerr << "ignoring text input in favor of cache input" << endl;
+    }
+    else
+    {
+      string temp = all.data_filename;
+      if (!quiet)
+        cerr << "Reading datafile = " << temp << endl;
+      try
+      {
+        all.p->input->open_file(temp.c_str(), all.stdin_off, io_buf::READ);
+      }
+      catch (exception const& ex)
+      {
+        if (temp.size() != 0)
+        {
+          cerr << "can't open '" << temp << "', sailing on!" << endl;
+        }
+        else
+        {
+          throw ex;
+        }
+      }
+
+      all.p->reader = read_features;
+      all.p->resettable = all.p->write_cache;
+    }
+  }
+
   if (passes > 1 && !all.p->resettable)
     THROW("need a cache file for multiple passes : try using --cache_file");
-      
+
   all.p->input->count = all.p->input->files.size();
   if (!quiet && !all.daemon)
     cerr << "num sources = " << all.p->input->files.size() << endl;
@@ -620,11 +622,11 @@ void enable_sources(vw& all, bool quiet, size_t passes)
 bool parser_done(parser* p)
 {
   if (p->done)
-    {
-      if (p->used_index != p->begin_parsed_examples)
-	return false;
-      return true;
-    }
+  {
+    if (p->used_index != p->begin_parsed_examples)
+      return false;
+    return true;
+  }
   return false;
 }
 
@@ -637,45 +639,45 @@ void set_done(vw& all)
 }
 
 void addgrams(vw& all, size_t ngram, size_t skip_gram, v_array<feature>& atomics, v_array<audit_data>& audits,
-	      size_t initial_length, v_array<size_t> &gram_mask, size_t skips)
+              size_t initial_length, v_array<size_t> &gram_mask, size_t skips)
 {
   if (ngram == 0 && gram_mask.last() < initial_length)
+  {
+    size_t last = initial_length - gram_mask.last();
+    for(size_t i = 0; i < last; i++)
     {
-      size_t last = initial_length - gram_mask.last();
-      for(size_t i = 0; i < last; i++)
-	{
-	  size_t new_index = atomics[i].weight_index;
-	  for (size_t n = 1; n < gram_mask.size(); n++)
-	    new_index = new_index*quadratic_constant + atomics[i+gram_mask[n]].weight_index;
+      size_t new_index = atomics[i].weight_index;
+      for (size_t n = 1; n < gram_mask.size(); n++)
+        new_index = new_index*quadratic_constant + atomics[i+gram_mask[n]].weight_index;
 
-	  feature f = {1.,(uint32_t)(new_index)};
-	  atomics.push_back(f);
-	  if ((all.audit || all.hash_inv) && audits.size() >= initial_length)
-	    {
-	      string feature_name(audits[i].feature);
-	      for (size_t n = 1; n < gram_mask.size(); n++)
-		{
-		  feature_name += string("^");
-		  feature_name += string(audits[i+gram_mask[n]].feature);
-		}
+      feature f = {1.,(uint32_t)(new_index)};
+      atomics.push_back(f);
+      if ((all.audit || all.hash_inv) && audits.size() >= initial_length)
+      {
+        string feature_name(audits[i].feature);
+        for (size_t n = 1; n < gram_mask.size(); n++)
+        {
+          feature_name += string("^");
+          feature_name += string(audits[i+gram_mask[n]].feature);
+        }
 
-	      string feature_space = string(audits[i].space);
-	      
-	      audit_data a_feature = {nullptr,nullptr,new_index, 1., true};
-	      a_feature.space = (char*)malloc(feature_space.length()+1);
-	      strcpy(a_feature.space, feature_space.c_str());
-	      a_feature.feature = (char*)malloc(feature_name.length()+1);
-	      strcpy(a_feature.feature, feature_name.c_str());
-	      audits.push_back(a_feature);
-	    }
-	}
+        string feature_space = string(audits[i].space);
+
+        audit_data a_feature = {nullptr,nullptr,new_index, 1., true};
+        a_feature.space = (char*)malloc(feature_space.length()+1);
+        strcpy(a_feature.space, feature_space.c_str());
+        a_feature.feature = (char*)malloc(feature_name.length()+1);
+        strcpy(a_feature.feature, feature_name.c_str());
+        audits.push_back(a_feature);
+      }
     }
+  }
   if (ngram > 0)
-    {
-      gram_mask.push_back(gram_mask.last()+1+skips);
-      addgrams(all, ngram-1, skip_gram, atomics, audits, initial_length, gram_mask, 0);
-      gram_mask.pop();
-    }
+  {
+    gram_mask.push_back(gram_mask.last()+1+skips);
+    addgrams(all, ngram-1, skip_gram, atomics, audits, initial_length, gram_mask, 0);
+    gram_mask.pop();
+  }
   if (skip_gram > 0 && ngram > 0)
     addgrams(all, ngram, skip_gram-1, atomics, audits, initial_length, gram_mask, skips+1);
 }
@@ -693,35 +695,35 @@ void addgrams(vw& all, size_t ngram, size_t skip_gram, v_array<feature>& atomics
  */
 void generateGrams(vw& all, example* &ex) {
   for(unsigned char* index = ex->indices.begin; index < ex->indices.end; index++)
+  {
+    size_t length = ex->atomics[*index].size();
+    for (size_t n = 1; n < all.ngram[*index]; n++)
     {
-      size_t length = ex->atomics[*index].size();
-      for (size_t n = 1; n < all.ngram[*index]; n++)
-	{
-	  all.p->gram_mask.erase();
-	  all.p->gram_mask.push_back((size_t)0);
-	  addgrams(all, n, all.skips[*index], ex->atomics[*index], 
-		   ex->audit_features[*index], 
-		   length, all.p->gram_mask, 0);
-	}
+      all.p->gram_mask.erase();
+      all.p->gram_mask.push_back((size_t)0);
+      addgrams(all, n, all.skips[*index], ex->atomics[*index],
+               ex->audit_features[*index],
+               length, all.p->gram_mask, 0);
     }
+  }
 }
 
 example* get_unused_example(vw& all)
 {
   while (true)
+  {
+    mutex_lock(&all.p->examples_lock);
+    if (all.p->examples[all.p->begin_parsed_examples % all.p->ring_size].in_use == false)
     {
-      mutex_lock(&all.p->examples_lock);
-      if (all.p->examples[all.p->begin_parsed_examples % all.p->ring_size].in_use == false)
-	{
-	  example& ret = all.p->examples[all.p->begin_parsed_examples++ % all.p->ring_size];
-	  ret.in_use = true;
-	  mutex_unlock(&all.p->examples_lock);
-	  return &ret;
-	}
-      else 
-	condition_variable_wait(&all.p->example_unused, &all.p->examples_lock);
+      example& ret = all.p->examples[all.p->begin_parsed_examples++ % all.p->ring_size];
+      ret.in_use = true;
       mutex_unlock(&all.p->examples_lock);
+      return &ret;
     }
+    else
+      condition_variable_wait(&all.p->example_unused, &all.p->examples_lock);
+    mutex_unlock(&all.p->examples_lock);
+  }
 }
 
 namespace VW {
@@ -733,11 +735,11 @@ bool parse_atomic_example(vw& all, example* ae, bool do_read = true)
   if(all.p->sort_features && ae->sorted == false)
     unique_sort_features(all.audit, (uint32_t)all.parse_mask, ae);
 
-  if (all.p->write_cache) 
-    {
-      all.p->lp.cache_label(&ae->l,*(all.p->output));
-      cache_features(*(all.p->output), ae, (uint32_t)all.parse_mask);
-    }
+  if (all.p->write_cache)
+  {
+    all.p->lp.cache_label(&ae->l,*(all.p->output));
+    cache_features(*(all.p->output), ae, (uint32_t)all.parse_mask);
+  }
   return true;
 }
 }
@@ -753,23 +755,23 @@ void feature_limit(vw& all, example* ex)
 {
   for(unsigned char* index = ex->indices.begin; index < ex->indices.end; index++)
     if (all.limit[*index] < ex->atomics[*index].size())
-      {
-	v_array<feature>& features = ex->atomics[*index];
-	
-	qsort(features.begin, features.size(), sizeof(feature), order_features);
-	
-	unique_features(features, all.limit[*index]);
-      }
+    {
+      v_array<feature>& features = ex->atomics[*index];
+
+      qsort(features.begin, features.size(), sizeof(feature), order_features);
+
+      unique_features(features, all.limit[*index]);
+    }
 }
 
-namespace VW{
+namespace VW {
 void setup_example(vw& all, example* ae)
 {
   ae->partial_prediction = 0.;
   ae->num_features = 0;
   ae->total_sum_feat_sq = 0;
   ae->loss = 0.;
-  
+
   ae->example_counter = (size_t)(all.p->end_parsed_examples);
   if (!all.p->emptylines_separate_examples)
     all.p->in_pass_counter++;
@@ -778,30 +780,30 @@ void setup_example(vw& all, example* ae)
 
   if (all.p->emptylines_separate_examples && example_is_newline(*ae))
     all.p->in_pass_counter++;
-  
+
   all.sd->t += all.p->lp.get_weight(&ae->l);
   ae->example_t = (float)all.sd->t;
 
-  
+
   if (all.ignore_some)
-    {
-      if (all.audit || all.hash_inv)
-	for (unsigned char* i = ae->indices.begin; i != ae->indices.end; i++)
-	  if (all.ignore[*i])
-	    ae->audit_features[*i].erase();
-      
+  {
+    if (all.audit || all.hash_inv)
       for (unsigned char* i = ae->indices.begin; i != ae->indices.end; i++)
-	if (all.ignore[*i])
-	  {//delete namespace
-	    ae->atomics[*i].erase();
-	    memmove(i,i+1,(ae->indices.end - (i+1))*sizeof(*i));
-	    ae->indices.end--;
-	    i--;
-	  }
-    }
+        if (all.ignore[*i])
+          ae->audit_features[*i].erase();
+
+    for (unsigned char* i = ae->indices.begin; i != ae->indices.end; i++)
+      if (all.ignore[*i])
+      { //delete namespace
+        ae->atomics[*i].erase();
+        memmove(i,i+1,(ae->indices.end - (i+1))*sizeof(*i));
+        ae->indices.end--;
+        i--;
+      }
+  }
 
   if(all.ngram_strings.size() > 0)
-    generateGrams(all, ae);    
+    generateGrams(all, ae);
 
   if (all.add_constant) {
     //add constant feature
@@ -810,7 +812,7 @@ void setup_example(vw& all, example* ae)
     ae->atomics[constant_namespace].push_back(temp);
     ae->total_sum_feat_sq++;
 
-    if (all.audit || all.hash_inv) ae->audit_features[constant_namespace].push_back({nullptr,(char*)"Constant",(uint32_t)constant, 1.,false});
+    if (all.audit || all.hash_inv) ae->audit_features[constant_namespace].push_back( {nullptr,(char*)"Constant",(uint32_t)constant, 1.,false});
   }
 
   if(all.limit_strings.size() > 0)
@@ -818,188 +820,190 @@ void setup_example(vw& all, example* ae)
 
   uint32_t multiplier = all.wpp << all.reg.stride_shift;
   if(multiplier != 1) //make room for per-feature information.
-    {
+  {
+    for (unsigned char* i = ae->indices.begin; i != ae->indices.end; i++)
+      for(feature* j = ae->atomics[*i].begin; j != ae->atomics[*i].end; j++)
+        j->weight_index *= multiplier;
+    if (all.audit || all.hash_inv)
       for (unsigned char* i = ae->indices.begin; i != ae->indices.end; i++)
-	for(feature* j = ae->atomics[*i].begin; j != ae->atomics[*i].end; j++)
-	  j->weight_index *= multiplier;
-      if (all.audit || all.hash_inv)
-	for (unsigned char* i = ae->indices.begin; i != ae->indices.end; i++)
-	  for(audit_data* j = ae->audit_features[*i].begin; j != ae->audit_features[*i].end; j++)
-	    j->weight_index *= multiplier;
-    }
-  
-  for (unsigned char* i = ae->indices.begin; i != ae->indices.end; i++) 
-    {
-      ae->num_features += ae->atomics[*i].end - ae->atomics[*i].begin;
-      ae->total_sum_feat_sq += ae->sum_feat_sq[*i];
-    }
+        for(audit_data* j = ae->audit_features[*i].begin; j != ae->audit_features[*i].end; j++)
+          j->weight_index *= multiplier;
+  }
+
+  for (unsigned char* i = ae->indices.begin; i != ae->indices.end; i++)
+  {
+    ae->num_features += ae->atomics[*i].end - ae->atomics[*i].begin;
+    ae->total_sum_feat_sq += ae->sum_feat_sq[*i];
+  }
 
   size_t new_features_cnt;
   float new_features_sum_feat_sq;
   INTERACTIONS::eval_count_of_generated_ft(all, *ae, new_features_cnt, new_features_sum_feat_sq);
   ae->num_features += new_features_cnt;
   ae->total_sum_feat_sq += new_features_sum_feat_sq;
-  
+
 }
 }
 
-namespace VW{
-  example* new_unused_example(vw& all) { 
-    example* ec = get_unused_example(all);
-    all.p->lp.default_label(&ec->l);
-    all.p->begin_parsed_examples++;
-    ec->example_counter = all.p->begin_parsed_examples;
-    return ec;
-  }
-  example* read_example(vw& all, char* example_line)
+namespace VW {
+example* new_unused_example(vw& all) {
+  example* ec = get_unused_example(all);
+  all.p->lp.default_label(&ec->l);
+  all.p->begin_parsed_examples++;
+  ec->example_counter = all.p->begin_parsed_examples;
+  return ec;
+}
+example* read_example(vw& all, char* example_line)
+{
+  example* ret = get_unused_example(all);
+
+  read_line(all, ret, example_line);
+  parse_atomic_example(all,ret,false);
+  setup_example(all, ret);
+  all.p->end_parsed_examples++;
+
+  return ret;
+}
+
+example* read_example(vw& all, string example_line) {
+  return read_example(all, (char*)example_line.c_str());
+}
+
+void add_constant_feature(vw& vw, example*ec) {
+  uint32_t cns = constant_namespace;
+  ec->indices.push_back(cns);
+  feature temp = {1,(uint32_t) constant};
+  ec->atomics[cns].push_back(temp);
+  ec->total_sum_feat_sq++;
+  ec->num_features++;
+  if (vw.audit || vw.hash_inv) ec->audit_features[constant_namespace].push_back( {nullptr,(char*)"Constant",(uint32_t)constant, 1.,false});
+}
+
+void add_label(example* ec, float label, float weight, float base)
+{
+  ec->l.simple.label = label;
+  ec->l.simple.weight = weight;
+  ec->l.simple.initial = base;
+}
+
+example* import_example(vw& all, string label, primitive_feature_space* features, size_t len)
+{
+  example* ret = get_unused_example(all);
+  all.p->lp.default_label(&ret->l);
+
+  if (label.length() > 0)
+    parse_example_label(all, *ret, label);
+
+  for (size_t i = 0; i < len; i++)
   {
-    example* ret = get_unused_example(all);
-
-    read_line(all, ret, example_line);
-	parse_atomic_example(all,ret,false);
-    setup_example(all, ret);
-    all.p->end_parsed_examples++;
-
-    return ret;
+    uint32_t index = features[i].name;
+    ret->indices.push_back(index);
+    for (size_t j = 0; j < features[i].len; j++)
+    {
+      ret->sum_feat_sq[index] += features[i].fs[j].x * features[i].fs[j].x;
+      ret->atomics[index].push_back(features[i].fs[j]);
+    }
   }
+  VW::parse_atomic_example(all,ret,false);
+  setup_example(all, ret);
+  all.p->end_parsed_examples++;
+  return ret;
+}
 
-  example* read_example(vw& all, string example_line) { return read_example(all, (char*)example_line.c_str()); }
-  
-  void add_constant_feature(vw& vw, example*ec) {
-    uint32_t cns = constant_namespace;
-    ec->indices.push_back(cns);
-    feature temp = {1,(uint32_t) constant};
-    ec->atomics[cns].push_back(temp);
-    ec->total_sum_feat_sq++;
-    ec->num_features++;
-    if (vw.audit || vw.hash_inv) ec->audit_features[constant_namespace].push_back({nullptr,(char*)"Constant",(uint32_t)constant, 1.,false});
-  }
+primitive_feature_space* export_example(vw& all, example* ec, size_t& len)
+{
+  len = ec->indices.size();
+  primitive_feature_space* fs_ptr = new primitive_feature_space[len];
 
-  void add_label(example* ec, float label, float weight, float base)
+  int fs_count = 0;
+  for (unsigned char* i = ec->indices.begin; i != ec->indices.end; i++)
   {
-    ec->l.simple.label = label;
-    ec->l.simple.weight = weight;
-    ec->l.simple.initial = base;
+    fs_ptr[fs_count].name = *i;
+    fs_ptr[fs_count].len = ec->atomics[*i].size();
+    fs_ptr[fs_count].fs = new feature[fs_ptr[fs_count].len];
+
+    int f_count = 0;
+    for (feature *f = ec->atomics[*i].begin; f != ec->atomics[*i].end; f++)
+    {
+      feature t = *f;
+      t.weight_index >>= all.reg.stride_shift;
+      fs_ptr[fs_count].fs[f_count] = t;
+      f_count++;
+    }
+    fs_count++;
   }
+  return fs_ptr;
+}
 
-  example* import_example(vw& all, string label, primitive_feature_space* features, size_t len)
-  {
-    example* ret = get_unused_example(all);
-    all.p->lp.default_label(&ret->l);
+void releaseFeatureSpace(primitive_feature_space* features, size_t len)
+{
+  for (size_t i = 0; i < len; i++)
+    delete features[i].fs;
+  delete (features);
+}
 
-	if (label.length() > 0)
-		parse_example_label(all, *ret, label);
+void parse_example_label(vw& all, example&ec, string label) {
+  v_array<substring> words = v_init<substring>();
+  char* cstr = (char*)label.c_str();
+  substring str = { cstr, cstr+label.length() };
+  words.push_back(str);
+  all.p->lp.parse_label(all.p, all.sd, &ec.l, words);
+  words.erase();
+  words.delete_v();
+}
 
-    for (size_t i = 0; i < len;i++)
+void empty_example(vw& all, example& ec)
+{
+  if (all.audit || all.hash_inv)
+    for (unsigned char* i = ec.indices.begin; i != ec.indices.end; i++)
+    {
+      for (audit_data* temp
+           = ec.audit_features[*i].begin;
+           temp != ec.audit_features[*i].end; temp++)
       {
-	uint32_t index = features[i].name;
-	ret->indices.push_back(index);
-	for (size_t j = 0; j < features[i].len; j++)
-	  {
-	    ret->sum_feat_sq[index] += features[i].fs[j].x * features[i].fs[j].x;
-	    ret->atomics[index].push_back(features[i].fs[j]);
-	  }
+        if (temp->alloced)
+        {
+          free(temp->space);
+          free(temp->feature);
+          temp->alloced=false;
+        }
       }
-    VW::parse_atomic_example(all,ret,false); 
-    setup_example(all, ret);
-	all.p->end_parsed_examples++;
-    return ret;
-  }
+      ec.audit_features[*i].erase();
+    }
 
-  primitive_feature_space* export_example(vw& all, example* ec, size_t& len)
+  for (unsigned char* i = ec.indices.begin; i != ec.indices.end; i++)
   {
-    len = ec->indices.size();
-    primitive_feature_space* fs_ptr = new primitive_feature_space[len]; 
-    
-    int fs_count = 0;
-    for (unsigned char* i = ec->indices.begin; i != ec->indices.end; i++)
-      {
-		fs_ptr[fs_count].name = *i;
-		fs_ptr[fs_count].len = ec->atomics[*i].size();
-		fs_ptr[fs_count].fs = new feature[fs_ptr[fs_count].len];
-	
-		int f_count = 0;
-		for (feature *f = ec->atomics[*i].begin; f != ec->atomics[*i].end; f++)
-		  {
-			feature t = *f;
-			t.weight_index >>= all.reg.stride_shift;
-			fs_ptr[fs_count].fs[f_count] = t;
-			f_count++;
-		  }
-		fs_count++;
-      }
-    return fs_ptr;
-  }
-  
-  void releaseFeatureSpace(primitive_feature_space* features, size_t len)
-  {
-    for (size_t i = 0; i < len;i++)
-      delete features[i].fs;
-    delete (features);
+    ec.atomics[*i].erase();
+    ec.sum_feat_sq[*i]=0;
   }
 
-  void parse_example_label(vw& all, example&ec, string label) {
-    v_array<substring> words = v_init<substring>();
-    char* cstr = (char*)label.c_str();
-    substring str = { cstr, cstr+label.length() };
-    words.push_back(str);
-    all.p->lp.parse_label(all.p, all.sd, &ec.l, words);
-    words.erase();
-    words.delete_v();
-  }
+  ec.indices.erase();
+  ec.tag.erase();
+  ec.sorted = false;
+  ec.end_pass = false;
+}
 
-  void empty_example(vw& all, example& ec)
-  {
-	if (all.audit || all.hash_inv)
-      for (unsigned char* i = ec.indices.begin; i != ec.indices.end; i++) 
-	{
-	  for (audit_data* temp 
-		 = ec.audit_features[*i].begin; 
-	       temp != ec.audit_features[*i].end; temp++)
-	    {
-	      if (temp->alloced)
-		{
-		  free(temp->space);
-		  free(temp->feature);
-		  temp->alloced=false;
-		}
-	    }
-	  ec.audit_features[*i].erase();
-	}
+void finish_example(vw& all, example* ec)
+{
+  // only return examples to the pool that are from the pool and not externally allocated
+  if (!is_ring_example(all, ec))
+    return;
 
-    for (unsigned char* i = ec.indices.begin; i != ec.indices.end; i++) 
-      {
-	ec.atomics[*i].erase();
-	ec.sum_feat_sq[*i]=0;
-      }
-    
-    ec.indices.erase();
-    ec.tag.erase();
-    ec.sorted = false;
-    ec.end_pass = false;
-  }
+  mutex_lock(&all.p->output_lock);
+  all.p->local_example_number++;
+  condition_variable_signal(&all.p->output_done);
+  mutex_unlock(&all.p->output_lock);
 
-  void finish_example(vw& all, example* ec)
-  {
-	// only return examples to the pool that are from the pool and not externally allocated
-	if (!is_ring_example(all, ec))
-      return;
+  empty_example(all, *ec);
 
-    mutex_lock(&all.p->output_lock);
-    all.p->local_example_number++;
-    condition_variable_signal(&all.p->output_done);
-    mutex_unlock(&all.p->output_lock);
-    
-    empty_example(all, *ec);
-    
-    mutex_lock(&all.p->examples_lock);
-    assert(ec->in_use);
-    ec->in_use = false;
-    condition_variable_signal(&all.p->example_unused);
-    if (all.p->done)
-      condition_variable_signal_all(&all.p->example_available);
-    mutex_unlock(&all.p->examples_lock);
-  }
+  mutex_lock(&all.p->examples_lock);
+  assert(ec->in_use);
+  ec->in_use = false;
+  condition_variable_signal(&all.p->example_unused);
+  if (all.p->done)
+    condition_variable_signal_all(&all.p->example_available);
+  mutex_unlock(&all.p->examples_lock);
+}
 }
 
 #ifdef _WIN32
@@ -1008,47 +1012,47 @@ DWORD WINAPI main_parse_loop(LPVOID in)
 void *main_parse_loop(void *in)
 #endif
 {
-	vw* all = (vw*) in;
-	size_t example_number = 0;  // for variable-size batch learning algorithms
+  vw* all = (vw*) in;
+  size_t example_number = 0;  // for variable-size batch learning algorithms
 
 
-	while(!all->p->done)
-	  {
-            example* ae = get_unused_example(*all);
-	    if (!all->do_reset_source && example_number != all->pass_length && all->max_examples > example_number
-		   && VW::parse_atomic_example(*all, ae) )
-	     {
-	       VW::setup_example(*all, ae);
-	       example_number++;
-	     }
-	    else
-	     {
-	       reset_source(*all, all->num_bits);
-	       all->do_reset_source = false;
-	       all->passes_complete++;
-	       end_pass_example(*all, ae);
-	       if (all->passes_complete == all->numpasses && example_number == all->pass_length)
-			 {
-			   all->passes_complete = 0;
-			   all->pass_length = all->pass_length*2+1;
-			 }
-	       if (all->passes_complete >= all->numpasses && all->max_examples >= example_number)
-			 {
-			   mutex_lock(&all->p->examples_lock);
-			   all->p->done = true;
-			   mutex_unlock(&all->p->examples_lock);
-			 }
-	       example_number = 0;
-	     }
-	   mutex_lock(&all->p->examples_lock);
-	   all->p->end_parsed_examples++;
-	   condition_variable_signal_all(&all->p->example_available);
-	   mutex_unlock(&all->p->examples_lock);
-	  }  
-	return 0L;
+  while(!all->p->done)
+  {
+    example* ae = get_unused_example(*all);
+    if (!all->do_reset_source && example_number != all->pass_length && all->max_examples > example_number
+        && VW::parse_atomic_example(*all, ae) )
+    {
+      VW::setup_example(*all, ae);
+      example_number++;
+    }
+    else
+    {
+      reset_source(*all, all->num_bits);
+      all->do_reset_source = false;
+      all->passes_complete++;
+      end_pass_example(*all, ae);
+      if (all->passes_complete == all->numpasses && example_number == all->pass_length)
+      {
+        all->passes_complete = 0;
+        all->pass_length = all->pass_length*2+1;
+      }
+      if (all->passes_complete >= all->numpasses && all->max_examples >= example_number)
+      {
+        mutex_lock(&all->p->examples_lock);
+        all->p->done = true;
+        mutex_unlock(&all->p->examples_lock);
+      }
+      example_number = 0;
+    }
+    mutex_lock(&all->p->examples_lock);
+    all->p->end_parsed_examples++;
+    condition_variable_signal_all(&all->p->example_available);
+    mutex_unlock(&all->p->examples_lock);
+  }
+  return 0L;
 }
 
-namespace VW{
+namespace VW {
 example* get_example(parser* p)
 {
   mutex_lock(&p->examples_lock);
@@ -1058,16 +1062,16 @@ example* get_example(parser* p)
       cout << p->used_index << " " << p->end_parsed_examples << " " << ring_index << endl;
     assert((p->examples+ring_index)->in_use);
     mutex_unlock(&p->examples_lock);
-    
+
     return p->examples + ring_index;
   }
   else {
     if (!p->done)
-      {
-	condition_variable_wait(&p->example_available, &p->examples_lock);
-	mutex_unlock(&p->examples_lock);
-	return get_example(p);
-      }
+    {
+      condition_variable_wait(&p->example_available, &p->examples_lock);
+      mutex_unlock(&p->examples_lock);
+      return get_example(p);
+    }
     else {
       mutex_unlock(&p->examples_lock);
       return nullptr;
@@ -1077,54 +1081,54 @@ example* get_example(parser* p)
 
 float get_topic_prediction(example* ec, size_t i)
 {
-	return ec->topic_predictions[i];
+  return ec->topic_predictions[i];
 }
 
 float get_label(example* ec)
 {
-	return ec->l.simple.label;
+  return ec->l.simple.label;
 }
 
 float get_importance(example* ec)
 {
-	return ec->l.simple.weight;
+  return ec->l.simple.weight;
 }
 
 float get_initial(example* ec)
 {
-	return ec->l.simple.initial;
+  return ec->l.simple.initial;
 }
 
 float get_prediction(example* ec)
 {
-	return ec->pred.scalar;
+  return ec->pred.scalar;
 }
 
 float get_cost_sensitive_prediction(example* ec)
 {
-       return (float)ec->pred.multiclass;
+  return (float)ec->pred.multiclass;
 }
 
 uint32_t* get_multilabel_predictions(example* ec, size_t& len)
 {
-    MULTILABEL::labels labels = ec->pred.multilabels;
-    len = labels.label_v.size();
-    return labels.label_v.begin;
+  MULTILABEL::labels labels = ec->pred.multilabels;
+  len = labels.label_v.size();
+  return labels.label_v.begin;
 }
 
 size_t get_tag_length(example* ec)
 {
-	return ec->tag.size();
+  return ec->tag.size();
 }
 
 const char* get_tag(example* ec)
 {
-	return ec->tag.begin;
+  return ec->tag.begin;
 }
 
 size_t get_feature_number(example* ec)
 {
-	return ec->num_features;
+  return ec->num_features;
 }
 }
 
@@ -1138,15 +1142,15 @@ void initialize_examples(vw& all)
   all.p->examples = calloc_or_die<example>(all.p->ring_size);
 
   for (size_t i = 0; i < all.p->ring_size; i++)
-    {
-      memset(&all.p->examples[i].l, 0, sizeof(polylabel));
-      all.p->examples[i].in_use = false;
-    }
+  {
+    memset(&all.p->examples[i].l, 0, sizeof(polylabel));
+    all.p->examples[i].in_use = false;
+  }
 }
 
 void adjust_used_index(vw& all)
 {
-	all.p->used_index=all.p->begin_parsed_examples;
+  all.p->used_index=all.p->begin_parsed_examples;
 }
 
 void initialize_parser_datastructures(vw& all)
@@ -1163,10 +1167,10 @@ namespace VW {
 void start_parser(vw& all, bool init_structures)
 {
   if (init_structures)
-	initialize_parser_datastructures(all);
-  #ifndef _WIN32
+    initialize_parser_datastructures(all);
+#ifndef _WIN32
   pthread_create(&all.parse_thread, nullptr, main_parse_loop, &all);
-  #else
+#else
   all.parse_thread = ::CreateThread(nullptr, 0, static_cast<LPTHREAD_START_ROUTINE>(main_parse_loop), &all, 0L, nullptr);
 #endif
 }
@@ -1179,21 +1183,21 @@ void free_parser(vw& all)
 
   if(all.ngram_strings.size() > 0)
     all.p->gram_mask.delete_v();
-  
+
   if (all.multilabel_prediction)
-    for (size_t i = 0; i < all.p->ring_size; i++) 
+    for (size_t i = 0; i < all.p->ring_size; i++)
       VW::dealloc_example(all.p->lp.delete_label, all.p->examples[i], MULTILABEL::multilabel.delete_label);
   else
-    for (size_t i = 0; i < all.p->ring_size; i++) 
+    for (size_t i = 0; i < all.p->ring_size; i++)
       VW::dealloc_example(all.p->lp.delete_label, all.p->examples[i]);
   free(all.p->examples);
-  
+
   io_buf* output = all.p->output;
   if (output != nullptr)
-    {
-      output->finalname.delete_v();
-      output->currentname.delete_v();
-    }
+  {
+    output->finalname.delete_v();
+    output->currentname.delete_v();
+  }
 
   all.p->counts.delete_v();
 }
@@ -1207,17 +1211,17 @@ void release_parser_datastructures(vw& all)
 namespace VW {
 void end_parser(vw& all)
 {
-  #ifndef _WIN32
+#ifndef _WIN32
   pthread_join(all.parse_thread, nullptr);
-  #else
+#else
   ::WaitForSingleObject(all.parse_thread, INFINITE);
   ::CloseHandle(all.parse_thread);
-  #endif
+#endif
   release_parser_datastructures(all);
 }
 
 bool is_ring_example(vw& all, example* ae)
 {
-	return all.p->examples <= ae && ae < all.p->examples + all.p->ring_size;
+  return all.p->examples <= ae && ae < all.p->examples + all.p->ring_size;
 }
 }

--- a/vowpalwabbit/parser.h
+++ b/vowpalwabbit/parser.h
@@ -23,14 +23,14 @@ struct parser {
   hash_func_t hasher;
   bool resettable; //Whether or not the input can be reset.
   io_buf* output; //Where to output the cache.
-  bool write_cache; 
+  bool write_cache;
   bool sort_features;
   bool sorted_cache;
 
   size_t ring_size;
   uint64_t begin_parsed_examples; // The index of the beginning parsed example.
   uint64_t end_parsed_examples; // The index of the fully parsed example.
-  uint64_t local_example_number; 
+  uint64_t local_example_number;
   uint32_t in_pass_counter;
   example* examples;
   uint64_t used_index;
@@ -40,7 +40,7 @@ struct parser {
   CV example_unused;
   MUTEX output_lock;
   CV output_done;
-  
+
   bool done;
   v_array<size_t> gram_mask;
 

--- a/vowpalwabbit/print.cc
+++ b/vowpalwabbit/print.cc
@@ -2,12 +2,14 @@
 #include "float.h"
 #include "reductions.h"
 
-struct print{ vw* all; };//regressor, feature loop
+struct print {
+  vw* all;
+};//regressor, feature loop
 
 void print_feature(vw& all, float value, float& weight)
 {
   size_t index = &weight - all.reg.weight_vector;
-  
+
   cout << index;
   if (value != 1.)
     cout << ":" << value;
@@ -18,20 +20,20 @@ void learn(print& p, LEARNER::base_learner&, example& ec)
 {
   label_data& ld = ec.l.simple;
   if (ld.label != FLT_MAX)
+  {
+    cout << ld.label << " ";
+    if (ld.weight != 1 || ld.initial != 0)
     {
-      cout << ld.label << " ";
-      if (ld.weight != 1 || ld.initial != 0)
-	{
-	  cout << ld.weight << " ";
-	  if (ld.initial != 0)
-	    cout << ld.initial << " ";
-	}
+      cout << ld.weight << " ";
+      if (ld.initial != 0)
+        cout << ld.initial << " ";
     }
+  }
   if (ec.tag.size() > 0)
-    {
-      cout << '\'';
-      cout.write(ec.tag.begin, ec.tag.size());
-    }
+  {
+    cout << '\'';
+    cout.write(ec.tag.begin, ec.tag.size());
+  }
   cout << "| ";
   GD::foreach_feature<vw, print_feature>(*(p.all), ec, *p.all);
   cout << endl;
@@ -40,14 +42,14 @@ void learn(print& p, LEARNER::base_learner&, example& ec)
 LEARNER::base_learner* print_setup(vw& all)
 {
   if (missing_option(all, true, "print", "print examples")) return nullptr;
-  
+
   print& p = calloc_or_die<print>();
   p.all = &all;
-  
+
   size_t length = ((size_t)1) << all.num_bits;
   all.reg.weight_mask = (length << all.reg.stride_shift) - 1;
   all.reg.stride_shift = 0;
-  
+
   LEARNER::learner<print>& ret = init_learner(&p, learn, 1);
   return make_base(ret);
 }

--- a/vowpalwabbit/rand48.cc
+++ b/vowpalwabbit/rand48.cc
@@ -22,9 +22,13 @@ float merand48(uint64_t& initial)
 
 uint64_t v = c;
 
-void msrand48(uint64_t initial) { v = initial; }
+void msrand48(uint64_t initial) {
+  v = initial;
+}
 
-float frand48() { return merand48(v); }
+float frand48() {
+  return merand48(v);
+}
 
 float frand48_noadvance()
 {

--- a/vowpalwabbit/scorer.cc
+++ b/vowpalwabbit/scorer.cc
@@ -2,21 +2,23 @@
 #include "reductions.h"
 #include "vw_exception.h"
 
-struct scorer{ vw* all; }; // for set_minmax, loss
+struct scorer {
+  vw* all;
+}; // for set_minmax, loss
 
 template <bool is_learn, float (*link)(float in)>
 void predict_or_learn(scorer& s, LEARNER::base_learner& base, example& ec)
 {
   s.all->set_minmax(s.all->sd, ec.l.simple.label);
-  
+
   if (is_learn && ec.l.simple.label != FLT_MAX && ec.l.simple.weight > 0)
     base.learn(ec);
   else
     base.predict(ec);
-  
+
   if(ec.l.simple.weight > 0 && ec.l.simple.label != FLT_MAX)
     ec.loss = s.all->loss->getLoss(s.all->sd, ec.pred.scalar, ec.l.simple.label) * ec.l.simple.weight;
-  
+
   ec.pred.scalar = link(ec.pred.scalar);
 }
 
@@ -28,57 +30,63 @@ inline void multipredict(scorer&, LEARNER::base_learner& base, example& ec, size
 }
 
 void update(scorer& s, LEARNER::base_learner& base, example& ec) {
-  s.all->set_minmax(s.all->sd, ec.l.simple.label);  
+  s.all->set_minmax(s.all->sd, ec.l.simple.label);
   base.update(ec);
 }
 
 // y = f(x) -> [0, 1]
-inline float logistic(float in) { return 1.f / (1.f + exp(- in)); }
+inline float logistic(float in) {
+  return 1.f / (1.f + exp(- in));
+}
 
 // http://en.wikipedia.org/wiki/Generalized_logistic_curve
 // where the lower & upper asymptotes are -1 & 1 respectively
 // 'glf1' stands for 'Generalized Logistic Function with [-1,1] range'
 //    y = f(x) -> [-1, 1]
-inline float glf1(float in) { return 2.f / (1.f + exp(- in)) - 1.f; }
+inline float glf1(float in) {
+  return 2.f / (1.f + exp(- in)) - 1.f;
+}
 
-inline float id(float in) { return in; }
+inline float id(float in) {
+  return in;
+}
 
 LEARNER::base_learner* scorer_setup(vw& all)
 {
   new_options(all)
-    ("link", po::value<string>()->default_value("identity"), "Specify the link function: identity, logistic or glf1");
+  ("link", po::value<string>()->default_value("identity"), "Specify the link function: identity, logistic or glf1");
   add_options(all);
   po::variables_map& vm = all.vm;
   scorer& s = calloc_or_die<scorer>();
   s.all = &all;
-  
+
   LEARNER::base_learner* base = setup_base(all);
   LEARNER::learner<scorer>* l;
   void (*multipredict_f)(scorer&, LEARNER::base_learner&, example&, size_t, size_t, polyprediction*, bool) = multipredict<id>;
-  
+
   string link = vm["link"].as<string>();
   if (!vm.count("link") || link.compare("identity") == 0)
     l = &init_learner(&s, base, predict_or_learn<true, id>, predict_or_learn<false, id>);
   else if (link.compare("logistic") == 0)
-    {
-      *all.file_options << " --link=logistic ";
-      l = &init_learner(&s, base, predict_or_learn<true, logistic>, 
-			predict_or_learn<false, logistic>);
-      multipredict_f = multipredict<logistic>;
-    }
+  {
+    *all.file_options << " --link=logistic ";
+    l = &init_learner(&s, base, predict_or_learn<true, logistic>,
+                      predict_or_learn<false, logistic>);
+    multipredict_f = multipredict<logistic>;
+  }
   else if (link.compare("glf1") == 0)
-    {
-      *all.file_options << " --link=glf1 ";
-      l = &init_learner(&s, base, predict_or_learn<true, glf1>, 
-			predict_or_learn<false, glf1>);
-      multipredict_f = multipredict<glf1>;
-    }
+  {
+    *all.file_options << " --link=glf1 ";
+    l = &init_learner(&s, base, predict_or_learn<true, glf1>,
+                      predict_or_learn<false, glf1>);
+    multipredict_f = multipredict<glf1>;
+  }
   else
     THROW("Unknown link function: " << link);
 
   l->set_multipredict(multipredict_f);
   l->set_update(update);
   all.scorer = make_base(*l);
-  
+
   return all.scorer;
 }

--- a/vowpalwabbit/search.cc
+++ b/vowpalwabbit/search.cc
@@ -31,2506 +31,2672 @@ namespace MC = MULTICLASS;
 #define MAX(a,b) ((a) > (b) ? (a) : (b))
 
 namespace Search {
-  search_task* all_tasks[] = {
-    &SequenceTask::task,
-    &SequenceSpanTask::task,
-    &ArgmaxTask::task,
-    &SequenceTask_DemoLDF::task,
-    &MulticlassTask::task,
-    &DepParserTask::task,
-    &EntityRelationTask::task,
-    &HookTask::task,
-    &GraphTask::task,
-    nullptr };   // must nullptr terminate!
+search_task* all_tasks[] = {
+  &SequenceTask::task,
+  &SequenceSpanTask::task,
+  &ArgmaxTask::task,
+  &SequenceTask_DemoLDF::task,
+  &MulticlassTask::task,
+  &DepParserTask::task,
+  &EntityRelationTask::task,
+  &HookTask::task,
+  &GraphTask::task,
+  nullptr
+};   // must nullptr terminate!
 
-  search_metatask* all_metatasks[] = {
-    &DebugMT::metatask,
-    &SelectiveBranchingMT::metatask,
-    nullptr };   // must nullptr terminate!
-  
-  const bool PRINT_UPDATE_EVERY_EXAMPLE =0;
-  const bool PRINT_UPDATE_EVERY_PASS =0;
-  const bool PRINT_CLOCK_TIME =0;
+search_metatask* all_metatasks[] = {
+  &DebugMT::metatask,
+  &SelectiveBranchingMT::metatask,
+  nullptr
+};   // must nullptr terminate!
 
-  string   neighbor_feature_space("neighbor");
-  string   condition_feature_space("search_condition");
+const bool PRINT_UPDATE_EVERY_EXAMPLE =0;
+const bool PRINT_UPDATE_EVERY_PASS =0;
+const bool PRINT_CLOCK_TIME =0;
 
-  uint32_t AUTO_CONDITION_FEATURES = 1, AUTO_HAMMING_LOSS = 2, EXAMPLES_DONT_CHANGE = 4, IS_LDF = 8, NO_CACHING = 16;
-  enum SearchState { INITIALIZE, INIT_TEST, INIT_TRAIN, LEARN, GET_TRUTH_STRING };
-  enum RollMethod { POLICY, ORACLE, MIX_PER_STATE, MIX_PER_ROLL, NO_ROLLOUT };
+string   neighbor_feature_space("neighbor");
+string   condition_feature_space("search_condition");
 
-  // a data structure to hold conditioning information
-  struct prediction {
-    ptag    me;     // the id of the current prediction (the one being memoized)
-    size_t  cnt;    // how many variables are we conditioning on?
-    ptag*   tags;   // which variables are they?
-    action* acts;   // and which actions were taken at each?
-    uint32_t hash;  // a hash of the above
-  };
+uint32_t AUTO_CONDITION_FEATURES = 1, AUTO_HAMMING_LOSS = 2, EXAMPLES_DONT_CHANGE = 4, IS_LDF = 8, NO_CACHING = 16;
+enum SearchState { INITIALIZE, INIT_TEST, INIT_TRAIN, LEARN, GET_TRUTH_STRING };
+enum RollMethod { POLICY, ORACLE, MIX_PER_STATE, MIX_PER_ROLL, NO_ROLLOUT };
 
-  // parameters for auto-conditioning
-  struct auto_condition_settings {
-    size_t max_bias_ngram_length;   // add a "bias" feature for each ngram up to and including this length. eg., if it's 1, then you get a single feature for each conditional
-    size_t max_quad_ngram_length;   // add bias *times* input features for each ngram up to and including this length
-    float  feature_value;           // how much weight should the conditional features get?
-  };
+// a data structure to hold conditioning information
+struct prediction {
+  ptag    me;     // the id of the current prediction (the one being memoized)
+  size_t  cnt;    // how many variables are we conditioning on?
+  ptag*   tags;   // which variables are they?
+  action* acts;   // and which actions were taken at each?
+  uint32_t hash;  // a hash of the above
+};
 
-  struct scored_action {
-    action a;  // the action
-    float  s;  // the predicted cost of this action
-    scored_action(action _a, float _s) : a(_a), s(_s) {}
-    scored_action() { a = (action)-1; s = 0.; }
-  };
-  std::ostream& operator << (std::ostream& os, const scored_action& x) { os << x.a << ':' << x.s; return os; }
-  
-  typedef v_array<scored_action> action_prefix;
+// parameters for auto-conditioning
+struct auto_condition_settings {
+  size_t max_bias_ngram_length;   // add a "bias" feature for each ngram up to and including this length. eg., if it's 1, then you get a single feature for each conditional
+  size_t max_quad_ngram_length;   // add bias *times* input features for each ngram up to and including this length
+  float  feature_value;           // how much weight should the conditional features get?
+};
 
-  struct action_cache {
-    float min_cost;
-    action k;
-    bool is_opt;
-    float cost;
-    action_cache(float _min_cost, action _k, bool _is_opt, float _cost) : min_cost(_min_cost), k(_k), is_opt(_is_opt), cost(_cost) {}
-  };
-  std::ostream& operator << (std::ostream& os, const action_cache& x) { os << x.k << ':' << x.cost; if (x.is_opt) os << '*'; return os; }
-
-  struct actionpp { // action++ stores an action and any number of "intermediate" floats
-    action a;
-    v_array<float> pp;
-    actionpp(action _a, v_array<float> _pp) : a(_a), pp(_pp) {}
-    actionpp(action _a) : a(_a) { pp = v_init<float>(); }
-  };
-  
-  struct search_private {
-    vw* all;
-
-    bool auto_condition_features;  // do you want us to automatically add conditioning features?
-    bool auto_hamming_loss;        // if you're just optimizing hamming loss, we can do it for you!
-    bool examples_dont_change;     // set to true if you don't do any internal example munging
-    bool is_ldf;                   // user declared ldf
-    
-    v_array<int32_t> neighbor_features; // ugly encoding of neighbor feature requirements
-    auto_condition_settings acset; // settings for auto-conditioning
-    size_t history_length;         // value of --search_history_length, used by some tasks, default 1
-    
-    size_t A;                      // total number of actions, [1..A]; 0 means ldf
-    size_t num_learners;           // total number of learners;
-    bool cb_learner;               // do contextual bandit learning on action (was "! rollout_all_actions" which was confusing)
-    SearchState state;             // current state of learning
-    size_t learn_learner_id;       // we allow user to use different learners for different states
-    int mix_per_roll_policy;       // for MIX_PER_ROLL, we need to choose a policy to use; this is where it's stored (-2 means "not selected yet")
-    bool no_caching;               // turn off caching
-    size_t rollout_num_steps;      // how many calls of "loss" before we stop really predicting on rollouts and switch to oracle (0 means "infinite")
-    bool (*label_is_test)(polylabel&); // tell me if the label data from an example is test
-    
-    size_t t;                      // current search step
-    size_t T;                      // length of root trajectory
-    v_array<example> learn_ec_copy;// copy of example(s) at learn_t
-    example* learn_ec_ref;         // reference to example at learn_t, when there's no example munging
-    size_t learn_ec_ref_cnt;       // how many are there (for LDF mode only; otherwise 1)
-    v_array<ptag> learn_condition_on;      // a copy of the tags used for conditioning at the training position
-    v_array<actionpp>learn_condition_on_act;// the actions taken
-    v_array<char>   learn_condition_on_names;// the names of the actions
-    v_array<action> learn_allowed_actions; // which actions were allowed at training time?
-    v_array<action> ptag_to_action;// tag to action mapping for conditioning
-    vector<action> test_action_sequence; // if test-mode was run, what was the corresponding action sequence; it's a vector cuz we might expose it to the library
-    action learn_oracle_action;    // store an oracle action for debugging purposes
-    
-    polylabel* allowed_actions_cache;
-    
-    size_t loss_declared_cnt;      // how many times did run declare any loss (implicitly or explicitly)?
-    v_array<scored_action> train_trajectory; // the training trajectory
-    size_t learn_t;                // what time step are we learning on?
-    size_t learn_a_idx;            // what action index are we trying?
-    bool done_with_all_actions;    // set to true when there are no more learn_a_idx to go
-
-    float test_loss;               // loss incurred when run INIT_TEST
-    float learn_loss;              // loss incurred when run LEARN
-    float train_loss;              // loss incurred when run INIT_TRAIN
-    float total_example_t;         // accumulated weight of examples
-    
-    bool last_example_was_newline; // used so we know when a block of examples has passed
-    bool hit_new_pass;             // have we hit a new pass?
-    bool force_oracle;             // insist on using the oracle to make predictions
-    float perturb_oracle;          // with this probability, choose a random action instead of oracle action
-    
-    // if we're printing to stderr we need to remember if we've printed the header yet
-    // (i.e., we do this if we're driving)
-    bool printed_output_header;
-
-    // various strings for different search states
-    bool should_produce_string;
-    stringstream *pred_string;
-    stringstream *truth_string;
-    stringstream *bad_string_stream;
-
-    // parameters controlling interpolation
-    float  beta;                   // interpolation rate
-    float  alpha;                  // parameter used to adapt beta for dagger (see above comment), should be in (0,1)
-
-    RollMethod rollout_method;     // 0=policy, 1=oracle, 2=mix_per_state, 3=mix_per_roll
-    RollMethod rollin_method;
-    float subsample_timesteps;     // train at every time step or just a (random) subset?
-    bool xv;           // train three separate policies -- two for providing examples to the other and a third training on the union (which will be used at test time -- TODO)
-    
-    bool   allow_current_policy;   // should the current policy be used for training? true for dagger
-    bool   adaptive_beta;          // used to implement dagger-like algorithms. if true, beta = 1-(1-alpha)^n after n updates, and policy is mixed with oracle as \pi' = (1-beta)\pi^* + beta \pi
-    size_t passes_per_policy;      // if we're not in dagger-mode, then we need to know how many passes to train a policy
-
-    uint32_t current_policy;       // what policy are we training right now?
-
-    // various statistics for reporting
-    size_t num_features;
-    uint32_t total_number_of_policies;
-    size_t read_example_last_id;
-    size_t passes_since_new_policy;
-    size_t read_example_last_pass;
-    size_t total_examples_generated;
-    size_t total_predictions_made;
-    size_t total_cache_hits;
-
-    vector<example*> ec_seq;  // the collected examples
-    v_hashmap<unsigned char*, scored_action> cache_hash_map;
-    
-    // for foreach_feature temporary storage for conditioning
-    uint32_t dat_new_feature_idx;
-    example* dat_new_feature_ec;
-    stringstream dat_new_feature_audit_ss;
-    size_t dat_new_feature_namespace;
-    string* dat_new_feature_feature_space;
-    float dat_new_feature_value;
-
-    // to reduce memory allocation
-    string rawOutputString;
-    stringstream* rawOutputStringStream;
-    CS::label ldf_test_label;
-    v_array<actionpp> condition_on_actions;
-    v_array<size_t> timesteps;
-    polylabel learn_losses;
-    polylabel gte_label;
-    v_array< pair<float,size_t> > active_uncertainty;
-    
-    LEARNER::base_learner* base_learner;
-    clock_t start_clock_time;
-
-    example*empty_example;
-    CS::label empty_cs_label;
-
-    search_task* task;    // your task!
-    search_metatask* metatask;  // your (optional) metatask
-    BaseTask* metaoverride;
-    size_t meta_t;  // the metatask has it's own notion of time. meta_t+t, during a single run, is the way to think about the "real" decision step but this really only matters for caching purposes
-    v_array< v_array<action_cache>* > memo_foreach_action; // when foreach_action is on, we need to cache TRAIN trajectory actions for LEARN
-  };
-
-  string   audit_feature_space("conditional");
-  uint32_t conditional_constant = 8290743;
-
-  void clear_memo_foreach_action(search_private& priv) {
-    for (size_t i=0; i<priv.memo_foreach_action.size(); i++)
-      if (priv.memo_foreach_action[i]) {
-        priv.memo_foreach_action[i]->delete_v();
-        delete priv.memo_foreach_action[i];
-      }
-    priv.memo_foreach_action.erase();
+struct scored_action {
+  action a;  // the action
+  float  s;  // the predicted cost of this action
+  scored_action(action _a, float _s) : a(_a), s(_s) {}
+  scored_action() {
+    a = (action)-1;
+    s = 0.;
   }
+};
+std::ostream& operator << (std::ostream& os, const scored_action& x) {
+  os << x.a << ':' << x.s;
+  return os;
+}
 
-  inline bool need_memo_foreach_action(search_private& priv) {
-    return
-        (priv.state == INIT_TRAIN) &&
-        (priv.metatask) &&
-        (priv.metaoverride); // &&
-    //        (priv.metaoverride->_foreach_action || priv.metaoverride->_post_prediction);
+typedef v_array<scored_action> action_prefix;
+
+struct action_cache {
+  float min_cost;
+  action k;
+  bool is_opt;
+  float cost;
+  action_cache(float _min_cost, action _k, bool _is_opt, float _cost) : min_cost(_min_cost), k(_k), is_opt(_is_opt), cost(_cost) {}
+};
+std::ostream& operator << (std::ostream& os, const action_cache& x) {
+  os << x.k << ':' << x.cost;
+  if (x.is_opt) os << '*';
+  return os;
+}
+
+struct actionpp { // action++ stores an action and any number of "intermediate" floats
+  action a;
+  v_array<float> pp;
+  actionpp(action _a, v_array<float> _pp) : a(_a), pp(_pp) {}
+  actionpp(action _a) : a(_a) {
+    pp = v_init<float>();
   }
-  
-  int random_policy(search_private& priv, bool allow_current, bool allow_optimal, bool advance_prng=true) {
-    if (priv.beta >= 1) {
-      if (allow_current) return (int)priv.current_policy;
-      if (priv.current_policy > 0) return (((int)priv.current_policy)-1);
-      if (allow_optimal) return -1;
-      std::cerr << "internal error (bug): no valid policies to choose from!  defaulting to current" << std::endl;
-      return (int)priv.current_policy;
+};
+
+struct search_private {
+  vw* all;
+
+  bool auto_condition_features;  // do you want us to automatically add conditioning features?
+  bool auto_hamming_loss;        // if you're just optimizing hamming loss, we can do it for you!
+  bool examples_dont_change;     // set to true if you don't do any internal example munging
+  bool is_ldf;                   // user declared ldf
+
+  v_array<int32_t> neighbor_features; // ugly encoding of neighbor feature requirements
+  auto_condition_settings acset; // settings for auto-conditioning
+  size_t history_length;         // value of --search_history_length, used by some tasks, default 1
+
+  size_t A;                      // total number of actions, [1..A]; 0 means ldf
+  size_t num_learners;           // total number of learners;
+  bool cb_learner;               // do contextual bandit learning on action (was "! rollout_all_actions" which was confusing)
+  SearchState state;             // current state of learning
+  size_t learn_learner_id;       // we allow user to use different learners for different states
+  int mix_per_roll_policy;       // for MIX_PER_ROLL, we need to choose a policy to use; this is where it's stored (-2 means "not selected yet")
+  bool no_caching;               // turn off caching
+  size_t rollout_num_steps;      // how many calls of "loss" before we stop really predicting on rollouts and switch to oracle (0 means "infinite")
+  bool (*label_is_test)(polylabel&); // tell me if the label data from an example is test
+
+  size_t t;                      // current search step
+  size_t T;                      // length of root trajectory
+  v_array<example> learn_ec_copy;// copy of example(s) at learn_t
+  example* learn_ec_ref;         // reference to example at learn_t, when there's no example munging
+  size_t learn_ec_ref_cnt;       // how many are there (for LDF mode only; otherwise 1)
+  v_array<ptag> learn_condition_on;      // a copy of the tags used for conditioning at the training position
+  v_array<actionpp>learn_condition_on_act;// the actions taken
+  v_array<char>   learn_condition_on_names;// the names of the actions
+  v_array<action> learn_allowed_actions; // which actions were allowed at training time?
+  v_array<action> ptag_to_action;// tag to action mapping for conditioning
+  vector<action> test_action_sequence; // if test-mode was run, what was the corresponding action sequence; it's a vector cuz we might expose it to the library
+  action learn_oracle_action;    // store an oracle action for debugging purposes
+
+  polylabel* allowed_actions_cache;
+
+  size_t loss_declared_cnt;      // how many times did run declare any loss (implicitly or explicitly)?
+  v_array<scored_action> train_trajectory; // the training trajectory
+  size_t learn_t;                // what time step are we learning on?
+  size_t learn_a_idx;            // what action index are we trying?
+  bool done_with_all_actions;    // set to true when there are no more learn_a_idx to go
+
+  float test_loss;               // loss incurred when run INIT_TEST
+  float learn_loss;              // loss incurred when run LEARN
+  float train_loss;              // loss incurred when run INIT_TRAIN
+  float total_example_t;         // accumulated weight of examples
+
+  bool last_example_was_newline; // used so we know when a block of examples has passed
+  bool hit_new_pass;             // have we hit a new pass?
+  bool force_oracle;             // insist on using the oracle to make predictions
+  float perturb_oracle;          // with this probability, choose a random action instead of oracle action
+
+  // if we're printing to stderr we need to remember if we've printed the header yet
+  // (i.e., we do this if we're driving)
+  bool printed_output_header;
+
+  // various strings for different search states
+  bool should_produce_string;
+  stringstream *pred_string;
+  stringstream *truth_string;
+  stringstream *bad_string_stream;
+
+  // parameters controlling interpolation
+  float  beta;                   // interpolation rate
+  float  alpha;                  // parameter used to adapt beta for dagger (see above comment), should be in (0,1)
+
+  RollMethod rollout_method;     // 0=policy, 1=oracle, 2=mix_per_state, 3=mix_per_roll
+  RollMethod rollin_method;
+  float subsample_timesteps;     // train at every time step or just a (random) subset?
+  bool xv;           // train three separate policies -- two for providing examples to the other and a third training on the union (which will be used at test time -- TODO)
+
+  bool   allow_current_policy;   // should the current policy be used for training? true for dagger
+  bool   adaptive_beta;          // used to implement dagger-like algorithms. if true, beta = 1-(1-alpha)^n after n updates, and policy is mixed with oracle as \pi' = (1-beta)\pi^* + beta \pi
+  size_t passes_per_policy;      // if we're not in dagger-mode, then we need to know how many passes to train a policy
+
+  uint32_t current_policy;       // what policy are we training right now?
+
+  // various statistics for reporting
+  size_t num_features;
+  uint32_t total_number_of_policies;
+  size_t read_example_last_id;
+  size_t passes_since_new_policy;
+  size_t read_example_last_pass;
+  size_t total_examples_generated;
+  size_t total_predictions_made;
+  size_t total_cache_hits;
+
+  vector<example*> ec_seq;  // the collected examples
+  v_hashmap<unsigned char*, scored_action> cache_hash_map;
+
+  // for foreach_feature temporary storage for conditioning
+  uint32_t dat_new_feature_idx;
+  example* dat_new_feature_ec;
+  stringstream dat_new_feature_audit_ss;
+  size_t dat_new_feature_namespace;
+  string* dat_new_feature_feature_space;
+  float dat_new_feature_value;
+
+  // to reduce memory allocation
+  string rawOutputString;
+  stringstream* rawOutputStringStream;
+  CS::label ldf_test_label;
+  v_array<actionpp> condition_on_actions;
+  v_array<size_t> timesteps;
+  polylabel learn_losses;
+  polylabel gte_label;
+  v_array< pair<float,size_t> > active_uncertainty;
+
+  LEARNER::base_learner* base_learner;
+  clock_t start_clock_time;
+
+  example*empty_example;
+  CS::label empty_cs_label;
+
+  search_task* task;    // your task!
+  search_metatask* metatask;  // your (optional) metatask
+  BaseTask* metaoverride;
+  size_t meta_t;  // the metatask has it's own notion of time. meta_t+t, during a single run, is the way to think about the "real" decision step but this really only matters for caching purposes
+  v_array< v_array<action_cache>* > memo_foreach_action; // when foreach_action is on, we need to cache TRAIN trajectory actions for LEARN
+};
+
+string   audit_feature_space("conditional");
+uint32_t conditional_constant = 8290743;
+
+void clear_memo_foreach_action(search_private& priv) {
+  for (size_t i=0; i<priv.memo_foreach_action.size(); i++)
+    if (priv.memo_foreach_action[i]) {
+      priv.memo_foreach_action[i]->delete_v();
+      delete priv.memo_foreach_action[i];
     }
+  priv.memo_foreach_action.erase();
+}
 
-    int num_valid_policies = (int)priv.current_policy + allow_optimal + allow_current;
-    int pid = -1;
+inline bool need_memo_foreach_action(search_private& priv) {
+  return
+    (priv.state == INIT_TRAIN) &&
+    (priv.metatask) &&
+    (priv.metaoverride); // &&
+  //        (priv.metaoverride->_foreach_action || priv.metaoverride->_post_prediction);
+}
 
-    if (num_valid_policies == 0) {
-      std::cerr << "internal error (bug): no valid policies to choose from!  defaulting to current" << std::endl;
-      return (int)priv.current_policy;
-    } else if (num_valid_policies == 1)
-      pid = 0;
-    else if (num_valid_policies == 2)
-      pid = (advance_prng ? frand48() : frand48_noadvance()) >= priv.beta;
-    else {
-      // SPEEDUP this up in the case that beta is small!
-      float r = (advance_prng ? frand48() : frand48_noadvance());
-      pid = 0;
-
-      if (r > priv.beta) {
-        r -= priv.beta;
-        while ((r > 0) && (pid < num_valid_policies-1)) {
-          pid ++;
-          r -= priv.beta * powf(1.f - priv.beta, (float)pid);
-        }
-      }
-    }
-    // figure out which policy pid refers to
-    if (allow_optimal && (pid == num_valid_policies-1))
-      return -1; // this is the optimal policy
-
-    pid = (int)priv.current_policy - pid;
-    if (!allow_current)
-      pid--;
-
-    return pid;
+int random_policy(search_private& priv, bool allow_current, bool allow_optimal, bool advance_prng=true) {
+  if (priv.beta >= 1) {
+    if (allow_current) return (int)priv.current_policy;
+    if (priv.current_policy > 0) return (((int)priv.current_policy)-1);
+    if (allow_optimal) return -1;
+    std::cerr << "internal error (bug): no valid policies to choose from!  defaulting to current" << std::endl;
+    return (int)priv.current_policy;
   }
 
-  // for two-fold cross validation, we double the number of learners
-  // and send examples to one or the other depending on the xor of
-  // (is_training) and (example_id % 2)
-  int select_learner(search_private& priv, int policy, size_t learner_id, bool is_training, bool is_local) {
-    if (policy<0) return policy;  // optimal policy
-    else {
-      if (priv.xv) {
-        learner_id *= 3;
-        if (! is_local)
-          learner_id += 1 + ( is_training ^ (priv.all->sd->example_number % 2) );
-      }
-      int p = (int) (policy*priv.num_learners+learner_id);
-      return p;
-    }
-  }
+  int num_valid_policies = (int)priv.current_policy + allow_optimal + allow_current;
+  int pid = -1;
 
+  if (num_valid_policies == 0) {
+    std::cerr << "internal error (bug): no valid policies to choose from!  defaulting to current" << std::endl;
+    return (int)priv.current_policy;
+  } else if (num_valid_policies == 1)
+    pid = 0;
+  else if (num_valid_policies == 2)
+    pid = (advance_prng ? frand48() : frand48_noadvance()) >= priv.beta;
+  else {
+    // SPEEDUP this up in the case that beta is small!
+    float r = (advance_prng ? frand48() : frand48_noadvance());
+    pid = 0;
 
-  bool should_print_update(vw& all, bool hit_new_pass=false) {
-    //uncomment to print out final loss after all examples processed
-    //commented for now so that outputs matches make test
-    //if( parser_done(all.p)) return true;
-    
-    if (PRINT_UPDATE_EVERY_EXAMPLE) return true;
-    if (PRINT_UPDATE_EVERY_PASS && hit_new_pass) return true;
-    return (all.sd->weighted_examples >= all.sd->dump_interval) && !all.quiet && !all.bfgs;
-  }
-
-  
-  bool might_print_update(vw& all) {
-    // basically do should_print_update but check me and the next
-    // example because of off-by-ones
-
-    if (PRINT_UPDATE_EVERY_EXAMPLE) return true;
-    if (PRINT_UPDATE_EVERY_PASS) return true;  // SPEEDUP: make this better
-    return (all.sd->weighted_examples + 1. >= all.sd->dump_interval) && !all.quiet && !all.bfgs;
-  }
-
-  bool must_run_test(vw&all, vector<example*>ec, bool is_test_ex) {
-    return
-        (all.final_prediction_sink.size() > 0) ||   // if we have to produce output, we need to run this
-        might_print_update(all) ||                  // if we have to print and update to stderr
-        (all.raw_prediction > 0) ||                 // we need raw predictions
-        ((!all.vw_is_main) && (is_test_ex)) ||      // library needs predictions
-        // or:
-        //   it's not quiet AND
-        //     current_pass == 0
-        //     OR holdout is off
-        //     OR it's a test example
-        ( (! all.quiet || ! all.vw_is_main) &&  // had to disable this because of library mode!
-          (! is_test_ex) &&
-          ( all.holdout_set_off ||                    // no holdout
-            ec[0]->test_only ||
-            (all.current_pass == 0)                   // we need error rates for progressive cost
-            ) )
-        ;
-  }
-
-  void clear_seq(vw&all, search_private& priv) {
-    if (priv.ec_seq.size() > 0)
-      for (size_t i=0; i < priv.ec_seq.size(); i++)
-        VW::finish_example(all, priv.ec_seq[i]);
-    priv.ec_seq.clear();
-  }
-
-  float safediv(float a,float b) { if (b == 0.f) return 0.f; else return (a/b); }
-
-  void to_short_string(string in, size_t max_len, char*out) {
-    for (size_t i=0; i<max_len; i++)
-      out[i] = ((i >= in.length()) || (in[i] == '\n') || (in[i] == '\t')) ? ' ' : in[i];
-
-    if (in.length() > max_len) {
-      out[max_len-2] = '.';
-      out[max_len-1] = '.';
-    }
-    out[max_len] = 0;
-  }
-
-  void number_to_natural(size_t big, char* c) {
-    if      (big > 9999999999) sprintf(c, "%dg", (int)(big / 1000000000));
-    else if (big >    9999999) sprintf(c, "%dm", (int)(big /    1000000));
-    else if (big >       9999) sprintf(c, "%dk", (int)(big /       1000));
-    else                       sprintf(c, "%d",  (int)(big));
-  }
-  
-  void print_update(search_private& priv) {
-    vw& all = *priv.all;
-    if (!priv.printed_output_header && !all.quiet) {
-      const char * header_fmt = "%-10s %-10s %8s%24s %22s %5s %5s  %7s  %7s  %7s  %-8s\n";
-      fprintf(stderr, header_fmt, "average", "since", "instance", "current true",  "current predicted", "cur",  "cur", "predic", "cache", "examples", "");
-      fprintf(stderr, header_fmt, "loss",    "last",  "counter",  "output prefix",  "output prefix",    "pass", "pol", "made",    "hits",  "gener", "beta");
-      std::cerr.precision(5);
-      priv.printed_output_header = true;
-    }
-
-    if (!should_print_update(all, priv.hit_new_pass))
-      return;
-
-    char true_label[21];
-    char pred_label[21];
-    to_short_string(priv.truth_string->str(), 20, true_label);
-    to_short_string(priv.pred_string->str() , 20, pred_label);
-
-    float avg_loss = 0.;
-    float avg_loss_since = 0.;
-    bool use_heldout_loss = (!all.holdout_set_off && all.current_pass >= 1) && (all.sd->weighted_holdout_examples > 0);
-    if (use_heldout_loss) {
-      avg_loss       = safediv((float)all.sd->holdout_sum_loss, (float)all.sd->weighted_holdout_examples);
-      avg_loss_since = safediv((float)all.sd->holdout_sum_loss_since_last_dump, (float)all.sd->weighted_holdout_examples_since_last_dump);
-
-      all.sd->weighted_holdout_examples_since_last_dump = 0;
-      all.sd->holdout_sum_loss_since_last_dump = 0.0;
-    } else {
-      avg_loss       = safediv((float)all.sd->sum_loss, (float)all.sd->weighted_examples);
-      avg_loss_since = safediv((float)all.sd->sum_loss_since_last_dump, (float) (all.sd->weighted_examples - all.sd->old_weighted_examples));
-    }
-
-    char inst_cntr[9];  number_to_natural(all.sd->example_number, inst_cntr);
-    char total_pred[8]; number_to_natural(priv.total_predictions_made, total_pred);
-    char total_cach[8]; number_to_natural(priv.total_cache_hits, total_cach);
-    char total_exge[8]; number_to_natural(priv.total_examples_generated, total_exge);
-    
-    fprintf(stderr, "%-10.6f %-10.6f %8s  [%s] [%s] %5d %5d  %7s  %7s  %7s  %-8f",
-            avg_loss,
-            avg_loss_since,
-            inst_cntr,
-            true_label,
-            pred_label,
-            (int)priv.read_example_last_pass,
-            (int)priv.current_policy,
-            total_pred,
-            total_cach,
-            total_exge,
-            priv.beta);
-
-    if (PRINT_CLOCK_TIME) {
-      size_t num_sec = (size_t)(((float)(clock() - priv.start_clock_time)) / CLOCKS_PER_SEC);
-      fprintf(stderr, " %15lusec", num_sec);
-    }
-
-    if (use_heldout_loss)
-      fprintf(stderr, " h");
-
-    fprintf(stderr, "\n");
-    fflush(stderr);
-    all.sd->update_dump_interval(all.progress_add, all.progress_arg);
-  }
-
-  void add_new_feature(search_private& priv, float val, uint32_t idx) {
-    size_t mask = priv.all->reg.weight_mask;
-    size_t ss   = priv.all->reg.stride_shift;
-    size_t idx2 = ((idx & mask) >> ss) & mask;
-    feature f = { val * priv.dat_new_feature_value,
-                  (uint32_t) (((priv.dat_new_feature_idx + idx2) << ss) ) };
-    priv.dat_new_feature_ec->atomics[priv.dat_new_feature_namespace].push_back(f);
-    priv.dat_new_feature_ec->sum_feat_sq[priv.dat_new_feature_namespace] += f.x * f.x;
-    if (priv.all->audit) {
-      audit_data a = { nullptr, nullptr, f.weight_index, f.x, true };
-      a.space   = calloc_or_die<char>(priv.dat_new_feature_feature_space->length()+1);
-      a.feature = calloc_or_die<char>(priv.dat_new_feature_audit_ss.str().length() + 32);
-      strcpy(a.space, priv.dat_new_feature_feature_space->c_str());
-      int num = sprintf(a.feature, "fid=%lu_", (idx & mask) >> ss);
-      strcpy(a.feature+num, priv.dat_new_feature_audit_ss.str().c_str());
-      priv.dat_new_feature_ec->audit_features[priv.dat_new_feature_namespace].push_back(a);
-    }
-  }
-
-  void del_features_in_top_namespace(search_private& priv, example& ec, size_t ns) {
-    if ((ec.indices.size() == 0) || (ec.indices.last() != ns)) {
-      if (ec.indices.size() == 0)
-	{ THROW("internal error (bug): expecting top namespace to be '" << ns << "' but it was empty"); }
-      else
-	{ THROW("internal error (bug): expecting top namespace to be '" << ns << "' but it was " << (size_t)ec.indices.last()); }
-    }
-    ec.num_features -= ec.atomics[ns].size();
-    ec.total_sum_feat_sq -= ec.sum_feat_sq[ns];
-    ec.sum_feat_sq[ns] = 0;
-    ec.indices.decr();
-    ec.atomics[ns].erase();
-    if (priv.all->audit) {
-      for (size_t i=0; i<ec.audit_features[ns].size(); i++)
-        if (ec.audit_features[ns][i].alloced) {
-          free(ec.audit_features[ns][i].space);
-          free(ec.audit_features[ns][i].feature);
-        }
-      ec.audit_features[ns].erase();
-    }
-  }
-  
-  void add_neighbor_features(search_private& priv) {
-    vw& all = *priv.all;
-    if (priv.neighbor_features.size() == 0) return;
-
-    for (size_t n=0; n<priv.ec_seq.size(); n++) {  // iterate over every example in the sequence
-      example& me = *priv.ec_seq[n];
-      for (size_t n_id=0; n_id < priv.neighbor_features.size(); n_id++) {
-        int32_t offset = priv.neighbor_features[n_id] >> 24;
-        size_t  ns     = priv.neighbor_features[n_id] & 0xFF;
-
-        priv.dat_new_feature_ec = &me;
-        priv.dat_new_feature_value = 1.;
-        priv.dat_new_feature_idx = priv.neighbor_features[n_id] * 13748127;
-        priv.dat_new_feature_namespace = neighbor_namespace;
-        if (priv.all->audit) {
-          priv.dat_new_feature_feature_space = &neighbor_feature_space;
-          priv.dat_new_feature_audit_ss.str("");
-          priv.dat_new_feature_audit_ss << '@' << ((offset > 0) ? '+' : '-') << (char)(abs(offset) + '0');
-          if (ns != ' ') priv.dat_new_feature_audit_ss << (char)ns;
-        }
-
-        //cerr << "n=" << n << " offset=" << offset << endl;
-        if ((offset < 0) && (n < (uint32_t)(-offset))) // add <s> feature
-          add_new_feature(priv, 1., 925871901 << priv.all->reg.stride_shift);
-        else if (n + offset >= priv.ec_seq.size()) // add </s> feature
-          add_new_feature(priv, 1., 3824917 << priv.all->reg.stride_shift);
-        else { // this is actually a neighbor
-          example& other = *priv.ec_seq[n + offset];
-          GD::foreach_feature<search_private,add_new_feature>(all.reg.weight_vector, all.reg.weight_mask, other.atomics[ns].begin, other.atomics[ns].end, priv, me.ft_offset);
-        }
-      }
-
-      size_t sz = me.atomics[neighbor_namespace].size();
-      if ((sz > 0) && (me.sum_feat_sq[neighbor_namespace] > 0.)) {
-        me.indices.push_back(neighbor_namespace);
-        me.total_sum_feat_sq += me.sum_feat_sq[neighbor_namespace];
-        me.num_features += sz;
-      } else {
-        me.atomics[neighbor_namespace].erase();
-        if (priv.all->audit) me.audit_features[neighbor_namespace].erase();
-    }
-    }
-  }
-
-  void del_neighbor_features(search_private& priv) {
-    if (priv.neighbor_features.size() == 0) return;
-    for (size_t n=0; n<priv.ec_seq.size(); n++)
-      del_features_in_top_namespace(priv, *priv.ec_seq[n], neighbor_namespace);
-  }
-
-  void reset_search_structure(search_private& priv) {
-    // NOTE: make sure do NOT reset priv.learn_a_idx
-    priv.t = 0;
-    priv.meta_t = 0;
-    priv.loss_declared_cnt = 0;
-    priv.done_with_all_actions = false;
-    priv.test_loss = 0.;
-    priv.learn_loss = 0.;
-    priv.train_loss = 0.;
-    priv.num_features = 0;
-    priv.should_produce_string = false;
-    priv.mix_per_roll_policy = -2;
-    if (priv.adaptive_beta) {
-      float x = - log1pf(- priv.alpha) * (float)priv.total_examples_generated;
-      static const float log_of_2 = (float)0.6931471805599453;
-      priv.beta = (x <= log_of_2) ? -expm1f(-x) : (1-expf(-x)); // numerical stability
-      //float priv_beta = 1.f - powf(1.f - priv.alpha, (float)priv.total_examples_generated);
-      //assert( fabs(priv_beta - priv.beta) < 1e-2 );
-      if (priv.beta > 1) priv.beta = 1;
-    }
-    priv.ptag_to_action.erase();
-    
-    if (! priv.cb_learner) { // was: if rollout_all_actions
-      uint32_t seed = (uint32_t)(priv.read_example_last_id * 147483 + 4831921) * 2147483647;
-      msrand48(seed);
-    }
-  }
-
-  void search_declare_loss(search_private& priv, float loss) {
-    priv.loss_declared_cnt++;
-    switch (priv.state) {
-      case INIT_TEST:  priv.test_loss  += loss; break;
-      case INIT_TRAIN: priv.train_loss += loss; break;
-      case LEARN:
-        if ((priv.rollout_num_steps == 0) || (priv.loss_declared_cnt <= priv.rollout_num_steps)) {
-          priv.learn_loss += loss;
-          cdbg << "priv.learn_loss += " << loss << " (now = " << priv.learn_loss << ")" << endl;
-        }
-        break;
-      default: break; // get rid of the warning about missing cases (danger!)
-    }
-  }
-
-
-  template<class T> void cdbg_print_array(string str, v_array<T>& A) { cdbg << str << " = ["; for (size_t i=0; i<A.size(); i++) cdbg << " " << A[i]; cdbg << " ]" << endl; }
-  template<class T> void cerr_print_array(string str, v_array<T>& A) { std::cerr << str << " = ["; for (size_t i=0; i<A.size(); i++) std::cerr << " " << A[i]; std::cerr << " ]" << endl; }
-  
-  
-  size_t random(size_t max) { return (size_t)(frand48() * (float)max); }
-  template<class T> bool array_contains(T target, const T*A, size_t n) {
-    if (A == nullptr) return false;
-    for (size_t i=0; i<n; i++)
-      if (A[i] == target) return true;
-    return false;
-  }
-
-  void add_example_conditioning(search_private& priv, example& ec, size_t condition_on_cnt, const char* condition_on_names, actionpp* condition_on_actions) {
-    if (condition_on_cnt == 0) return;
-
-    uint32_t extra_offset=0;
-    if (priv.is_ldf) 
-      if (ec.l.cs.costs.size() > 0)
-        extra_offset = 3849017 * ec.l.cs.costs[0].class_index;
-    
-    size_t I = condition_on_cnt;
-    size_t N = max(priv.acset.max_bias_ngram_length, priv.acset.max_quad_ngram_length);
-    for (size_t i=0; i<I; i++) { // position in conditioning
-      uint32_t fid = 71933 + 8491087 * extra_offset;
-      if (priv.all->audit) {
-        priv.dat_new_feature_audit_ss.str("");
-        priv.dat_new_feature_audit_ss.clear();
-        priv.dat_new_feature_feature_space = &condition_feature_space;
-      }
-
-      for (size_t n=0; n<N; n++) { // length of ngram
-        if (i + n >= I) break; // no more ngrams
-        // we're going to add features for the ngram condition_on_actions[i .. i+N]
-        char name = condition_on_names[i+n];
-        fid = fid * 328901 + 71933 * ((condition_on_actions[i+n].a + 349101) * (name + 38490137));
-
-        priv.dat_new_feature_ec  = &ec;
-        priv.dat_new_feature_idx = fid * quadratic_constant;
-        priv.dat_new_feature_namespace = conditioning_namespace;
-        priv.dat_new_feature_value = priv.acset.feature_value;
-
-        if (priv.all->audit) {
-          if (n > 0) priv.dat_new_feature_audit_ss << ',';
-          if ((33 <= name) && (name <= 126)) priv.dat_new_feature_audit_ss << name;
-          else priv.dat_new_feature_audit_ss << '#' << (int)name;
-          priv.dat_new_feature_audit_ss << '=' << condition_on_actions[i+n].a;
-        }
-        
-        // add the single bias feature
-        if (n < priv.acset.max_bias_ngram_length)
-          add_new_feature(priv, 1., 4398201 << priv.all->reg.stride_shift);
-
-        // add the quadratic features
-        if (n < priv.acset.max_quad_ngram_length)
-          GD::foreach_feature<search_private,uint32_t,add_new_feature>(*priv.all, ec, priv);
-      }
-    }
-
-    for (size_t i=0; i<I; i++)
-      if (condition_on_actions[i].pp.size() > 0) {
-        char name = condition_on_names[i];
-        uint32_t fid = 84913 + 48371803 * (extra_offset + 8392817 * name);
-        for (size_t k=0; k<condition_on_actions[i].pp.size(); k++) {
-          priv.dat_new_feature_ec  = &ec;
-          priv.dat_new_feature_idx = (fid + k) * quadratic_constant;
-          priv.dat_new_feature_namespace = conditioning_namespace;
-          priv.dat_new_feature_value = condition_on_actions[i].pp[k];
-          add_new_feature(priv, condition_on_actions[i].pp[k], 4308927 << priv.all->reg.stride_shift);
-          // TODO: audit
-        }
-      }
-
-    size_t sz = ec.atomics[conditioning_namespace].size();
-    if ((sz > 0) && (ec.sum_feat_sq[conditioning_namespace] > 0.)) {
-      ec.indices.push_back(conditioning_namespace);
-      ec.total_sum_feat_sq += ec.sum_feat_sq[conditioning_namespace];
-      ec.num_features += sz;
-    } else {
-      ec.atomics[conditioning_namespace].erase();
-      if (priv.all->audit) ec.audit_features[conditioning_namespace].erase();
-    }
-  }
-
-  void del_example_conditioning(search_private& priv, example& ec) {
-    if ((ec.indices.size() > 0) && (ec.indices.last() == conditioning_namespace))
-      del_features_in_top_namespace(priv, ec, conditioning_namespace);
-  }
-  
-  inline size_t cs_get_costs_size(bool isCB, polylabel& ld) {
-    return isCB ? ld.cb.costs.size()
-                : ld.cs.costs.size();
-  }
-
-  inline uint32_t cs_get_cost_index(bool isCB, polylabel& ld, size_t k) {
-    return isCB ? ld.cb.costs[k].action
-                : ld.cs.costs[k].class_index;
-  }
-
-  inline float cs_get_cost_partial_prediction(bool isCB, polylabel& ld, size_t k) {
-    return isCB ? ld.cb.costs[k].partial_prediction
-                : ld.cs.costs[k].partial_prediction;
-  }
-
-  inline void cs_set_cost_loss(bool isCB, polylabel& ld, size_t k, float val) {
-    if (isCB) ld.cb.costs[k].cost = val;
-    else      ld.cs.costs[k].x    = val;
-  }
-  
-  inline void cs_costs_erase(bool isCB, polylabel& ld) {
-    if (isCB) ld.cb.costs.erase();
-    else      ld.cs.costs.erase();
-  }
-
-  inline void cs_costs_resize(bool isCB, polylabel& ld, size_t new_size) {
-    if (isCB) ld.cb.costs.resize(new_size);
-    else      ld.cs.costs.resize(new_size);
-  }
-
-  inline void cs_cost_push_back(bool isCB, polylabel& ld, uint32_t index, float value) {
-    if (isCB) { CB::cb_class cost = { value, index, 0., 0. }; ld.cb.costs.push_back(cost); }
-    else      { CS::wclass   cost = { value, index, 0., 0. }; ld.cs.costs.push_back(cost); }
-  }
-  
-  polylabel& allowed_actions_to_ld(search_private& priv, size_t ec_cnt, const action* allowed_actions, size_t allowed_actions_cnt) {
-    bool isCB = priv.cb_learner;
-    polylabel& ld = *priv.allowed_actions_cache;
-    uint32_t num_costs = (uint32_t)cs_get_costs_size(isCB, ld);
-
-    if (priv.is_ldf) {  // LDF version easier
-      if (num_costs > ec_cnt)
-        cs_costs_resize(isCB, ld, ec_cnt);
-      else if (num_costs < ec_cnt)
-        for (action k = num_costs; k < ec_cnt; k++)
-          cs_cost_push_back(isCB, ld, k, FLT_MAX);
-      
-    } else { // non-LDF version
-      if ((allowed_actions == nullptr) || (allowed_actions_cnt == 0)) { // any action is allowed
-        if (num_costs != priv.A) {  // if there are already A-many actions, they must be the right ones, unless the user did something stupid like putting duplicate allowed_actions...
-          cs_costs_erase(isCB, ld);
-          for (action k = 0; k < priv.A; k++)
-            cs_cost_push_back(isCB, ld, k+1, FLT_MAX);  //+1 because MC is 1-based
-        }
-      } else { // we need to peek at allowed_actions
-        cs_costs_erase(isCB, ld);
-        for (size_t i = 0; i < allowed_actions_cnt; i++)
-          cs_cost_push_back(isCB, ld, allowed_actions[i], FLT_MAX);
-      }
-    }
-
-    return ld;
-  }
-
-  void allowed_actions_to_label(search_private& priv, size_t ec_cnt, const action* allowed_actions, size_t allowed_actions_cnt, const action* oracle_actions, size_t oracle_actions_cnt, polylabel& lab) {
-    if (priv.is_ldf) { // LDF version easier
-      cs_costs_erase(priv.cb_learner, lab);
-      for (action k=0; k<ec_cnt; k++)
-        cs_cost_push_back(priv.cb_learner, lab, k, array_contains<action>(k, oracle_actions, oracle_actions_cnt) ? 0.f : 1.f );
-      //cerr << "lab = ["; for (size_t i=0; i<lab.cs.costs.size(); i++) cdbg << ' ' << lab.cs.costs[i].class_index << ':' << lab.cs.costs[i].x; cdbg << " ]" << endl;
-    } else { // non-LDF
-      if ((allowed_actions == NULL) || (allowed_actions_cnt == 0)) { // any action is allowed
-        bool set_to_one = false;
-        if (cs_get_costs_size(priv.cb_learner, lab) != priv.A) {
-          cs_costs_erase(priv.cb_learner, lab);
-          for (action k=0; k<priv.A; k++)
-            cs_cost_push_back(priv.cb_learner, lab, k+1, 1.);
-          set_to_one = true;
-        }
-        //cerr << "lab = ["; for (size_t i=0; i<lab.cs.costs.size(); i++) cdbg << ' ' << lab.cs.costs[i].class_index << ':' << lab.cs.costs[i].x; cdbg << " ]" << endl;
-        if (oracle_actions_cnt <= 1) { // common case to speed up
-          if (! set_to_one)
-            for (action k=0; k<priv.A; k++)
-              cs_set_cost_loss(priv.cb_learner, lab, k, 1.);
-          if (oracle_actions_cnt == 1)
-            cs_set_cost_loss(priv.cb_learner, lab, oracle_actions[0]-1, 0.);
-        } else {
-          for (action k=0; k<priv.A; k++)
-            cs_set_cost_loss(priv.cb_learner, lab, k, array_contains<action>(k+1, oracle_actions, oracle_actions_cnt) ? 0.f : 1.f);
-        }
-      } else { // only some actions are allowed
-        cs_costs_erase(priv.cb_learner, lab);
-        float w = 1.; // array_contains<action>(3, oracle_actions, oracle_actions_cnt) ? 5.f : 1.f;
-        for (size_t i=0; i<allowed_actions_cnt; i++) {
-          action k = allowed_actions[i];
-          cs_cost_push_back(priv.cb_learner, lab, k, (array_contains<action>(k, oracle_actions, oracle_actions_cnt)) ? 0.f : w); // 1.f );
-        }
+    if (r > priv.beta) {
+      r -= priv.beta;
+      while ((r > 0) && (pid < num_valid_policies-1)) {
+        pid ++;
+        r -= priv.beta * powf(1.f - priv.beta, (float)pid);
       }
     }
   }
-  
-  template<class T>
-  void ensure_size(v_array<T>& A, size_t sz) {
-    if ((size_t)(A.end_array - A.begin) < sz) 
-      A.resize(sz*2+1, true);
-    A.end = A.begin + sz;
+  // figure out which policy pid refers to
+  if (allow_optimal && (pid == num_valid_policies-1))
+    return -1; // this is the optimal policy
+
+  pid = (int)priv.current_policy - pid;
+  if (!allow_current)
+    pid--;
+
+  return pid;
+}
+
+// for two-fold cross validation, we double the number of learners
+// and send examples to one or the other depending on the xor of
+// (is_training) and (example_id % 2)
+int select_learner(search_private& priv, int policy, size_t learner_id, bool is_training, bool is_local) {
+  if (policy<0) return policy;  // optimal policy
+  else {
+    if (priv.xv) {
+      learner_id *= 3;
+      if (! is_local)
+        learner_id += 1 + ( is_training ^ (priv.all->sd->example_number % 2) );
+    }
+    int p = (int) (policy*priv.num_learners+learner_id);
+    return p;
+  }
+}
+
+
+bool should_print_update(vw& all, bool hit_new_pass=false) {
+  //uncomment to print out final loss after all examples processed
+  //commented for now so that outputs matches make test
+  //if( parser_done(all.p)) return true;
+
+  if (PRINT_UPDATE_EVERY_EXAMPLE) return true;
+  if (PRINT_UPDATE_EVERY_PASS && hit_new_pass) return true;
+  return (all.sd->weighted_examples >= all.sd->dump_interval) && !all.quiet && !all.bfgs;
+}
+
+
+bool might_print_update(vw& all) {
+  // basically do should_print_update but check me and the next
+  // example because of off-by-ones
+
+  if (PRINT_UPDATE_EVERY_EXAMPLE) return true;
+  if (PRINT_UPDATE_EVERY_PASS) return true;  // SPEEDUP: make this better
+  return (all.sd->weighted_examples + 1. >= all.sd->dump_interval) && !all.quiet && !all.bfgs;
+}
+
+bool must_run_test(vw&all, vector<example*>ec, bool is_test_ex) {
+  return
+    (all.final_prediction_sink.size() > 0) ||   // if we have to produce output, we need to run this
+    might_print_update(all) ||                  // if we have to print and update to stderr
+    (all.raw_prediction > 0) ||                 // we need raw predictions
+    ((!all.vw_is_main) && (is_test_ex)) ||      // library needs predictions
+    // or:
+    //   it's not quiet AND
+    //     current_pass == 0
+    //     OR holdout is off
+    //     OR it's a test example
+    ( (! all.quiet || ! all.vw_is_main) &&  // had to disable this because of library mode!
+      (! is_test_ex) &&
+      ( all.holdout_set_off ||                    // no holdout
+        ec[0]->test_only ||
+        (all.current_pass == 0)                   // we need error rates for progressive cost
+      ) )
+    ;
+}
+
+void clear_seq(vw&all, search_private& priv) {
+  if (priv.ec_seq.size() > 0)
+    for (size_t i=0; i < priv.ec_seq.size(); i++)
+      VW::finish_example(all, priv.ec_seq[i]);
+  priv.ec_seq.clear();
+}
+
+float safediv(float a,float b) {
+  if (b == 0.f) return 0.f;
+  else return (a/b);
+}
+
+void to_short_string(string in, size_t max_len, char*out) {
+  for (size_t i=0; i<max_len; i++)
+    out[i] = ((i >= in.length()) || (in[i] == '\n') || (in[i] == '\t')) ? ' ' : in[i];
+
+  if (in.length() > max_len) {
+    out[max_len-2] = '.';
+    out[max_len-1] = '.';
+  }
+  out[max_len] = 0;
+}
+
+void number_to_natural(size_t big, char* c) {
+  if      (big > 9999999999) sprintf(c, "%dg", (int)(big / 1000000000));
+  else if (big >    9999999) sprintf(c, "%dm", (int)(big /    1000000));
+  else if (big >       9999) sprintf(c, "%dk", (int)(big /       1000));
+  else                       sprintf(c, "%d",  (int)(big));
+}
+
+void print_update(search_private& priv) {
+  vw& all = *priv.all;
+  if (!priv.printed_output_header && !all.quiet) {
+    const char * header_fmt = "%-10s %-10s %8s%24s %22s %5s %5s  %7s  %7s  %7s  %-8s\n";
+    fprintf(stderr, header_fmt, "average", "since", "instance", "current true",  "current predicted", "cur",  "cur", "predic", "cache", "examples", "");
+    fprintf(stderr, header_fmt, "loss",    "last",  "counter",  "output prefix",  "output prefix",    "pass", "pol", "made",    "hits",  "gener", "beta");
+    std::cerr.precision(5);
+    priv.printed_output_header = true;
   }
 
-  template<class T> void push_at(v_array<T>& v, T item, size_t pos) {
-    if (v.size() > pos)
-      v.begin[pos] = item;
-    else {
-      if (v.end_array > v.begin + pos) {
-        // there's enough memory, just not enough filler
-        v.begin[pos] = item;
-        v.end = v.begin + pos + 1;
-      } else {
-        // there's not enough memory
-        v.resize(2 * pos + 3, true);
-        v.begin[pos] = item;
-        v.end = v.begin + pos + 1;
-      }
-    }
+  if (!should_print_update(all, priv.hit_new_pass))
+    return;
+
+  char true_label[21];
+  char pred_label[21];
+  to_short_string(priv.truth_string->str(), 20, true_label);
+  to_short_string(priv.pred_string->str() , 20, pred_label);
+
+  float avg_loss = 0.;
+  float avg_loss_since = 0.;
+  bool use_heldout_loss = (!all.holdout_set_off && all.current_pass >= 1) && (all.sd->weighted_holdout_examples > 0);
+  if (use_heldout_loss) {
+    avg_loss       = safediv((float)all.sd->holdout_sum_loss, (float)all.sd->weighted_holdout_examples);
+    avg_loss_since = safediv((float)all.sd->holdout_sum_loss_since_last_dump, (float)all.sd->weighted_holdout_examples_since_last_dump);
+
+    all.sd->weighted_holdout_examples_since_last_dump = 0;
+    all.sd->holdout_sum_loss_since_last_dump = 0.0;
+  } else {
+    avg_loss       = safediv((float)all.sd->sum_loss, (float)all.sd->weighted_examples);
+    avg_loss_since = safediv((float)all.sd->sum_loss_since_last_dump, (float) (all.sd->weighted_examples - all.sd->old_weighted_examples));
   }
 
-  action choose_oracle_action(search_private& priv, size_t ec_cnt, const action* oracle_actions, size_t oracle_actions_cnt, const action* allowed_actions, size_t allowed_actions_cnt) {
-    if ((priv.perturb_oracle > 0.) && (priv.state == INIT_TRAIN) && (frand48() < priv.perturb_oracle))
-      oracle_actions_cnt = 0;
-    action a = ( oracle_actions_cnt > 0) ?  oracle_actions[random(oracle_actions_cnt )] :
-               (allowed_actions_cnt > 0) ? allowed_actions[random(allowed_actions_cnt)] :
-               priv.is_ldf ? (action)random(ec_cnt) :
-               (action)(1 + random(priv.A));
-    cdbg << "choose_oracle_action from oracle_actions = ["; for (size_t i=0; i<oracle_actions_cnt; i++) cdbg << " " << oracle_actions[i]; cdbg << " ], ret=" << a << endl;
-    if (need_memo_foreach_action(priv) && (priv.state == INIT_TRAIN)) {
-      v_array<action_cache>* this_cache = new v_array<action_cache>();
-      *this_cache = v_init<action_cache>();
-      // TODO we don't really need to construct this polylabel
-      polylabel l = allowed_actions_to_ld(priv, 1, allowed_actions, allowed_actions_cnt);
-      size_t K = cs_get_costs_size(priv.cb_learner, l);
-      for (size_t k = 0; k < K; k++) {
-        action cl = cs_get_cost_index(priv.cb_learner, l, k);
-        float cost = array_contains(cl, oracle_actions, oracle_actions_cnt) ? 0.f : 1.f;
-        this_cache->push_back( action_cache(0., cl, cl==a, cost) );
-      }
-      size_t pos = priv.meta_t + priv.t;
-      assert( priv.memo_foreach_action.size() == pos - 1 );
-      priv.memo_foreach_action.push_back(this_cache);
-      cdbg << "memo_foreach_action[" << pos-1 << "] = " << this_cache << " from oracle" << endl;
-    }
-    return a;
+  char inst_cntr[9];
+  number_to_natural(all.sd->example_number, inst_cntr);
+  char total_pred[8];
+  number_to_natural(priv.total_predictions_made, total_pred);
+  char total_cach[8];
+  number_to_natural(priv.total_cache_hits, total_cach);
+  char total_exge[8];
+  number_to_natural(priv.total_examples_generated, total_exge);
+
+  fprintf(stderr, "%-10.6f %-10.6f %8s  [%s] [%s] %5d %5d  %7s  %7s  %7s  %-8f",
+          avg_loss,
+          avg_loss_since,
+          inst_cntr,
+          true_label,
+          pred_label,
+          (int)priv.read_example_last_pass,
+          (int)priv.current_policy,
+          total_pred,
+          total_cach,
+          total_exge,
+          priv.beta);
+
+  if (PRINT_CLOCK_TIME) {
+    size_t num_sec = (size_t)(((float)(clock() - priv.start_clock_time)) / CLOCKS_PER_SEC);
+    fprintf(stderr, " %15lusec", num_sec);
   }
-  
-  action single_prediction_notLDF(search_private& priv, example& ec, int policy, const action* allowed_actions, size_t allowed_actions_cnt, float& a_cost, action override_action) {  // if override_action != -1, then we return it as the action and a_cost is set to the appropriate cost for that action
-    vw& all = *priv.all;
-    polylabel old_label = ec.l;
-    bool need_partial_predictions = need_memo_foreach_action(priv) || (priv.metaoverride && priv.metaoverride->_foreach_action) || (override_action != (action)-1);
-    if ((allowed_actions_cnt > 0) || need_partial_predictions)
-      ec.l = allowed_actions_to_ld(priv, 1, allowed_actions, allowed_actions_cnt);
+
+  if (use_heldout_loss)
+    fprintf(stderr, " h");
+
+  fprintf(stderr, "\n");
+  fflush(stderr);
+  all.sd->update_dump_interval(all.progress_add, all.progress_arg);
+}
+
+void add_new_feature(search_private& priv, float val, uint32_t idx) {
+  size_t mask = priv.all->reg.weight_mask;
+  size_t ss   = priv.all->reg.stride_shift;
+  size_t idx2 = ((idx & mask) >> ss) & mask;
+  feature f = { val * priv.dat_new_feature_value,
+                (uint32_t) (((priv.dat_new_feature_idx + idx2) << ss) )
+              };
+  priv.dat_new_feature_ec->atomics[priv.dat_new_feature_namespace].push_back(f);
+  priv.dat_new_feature_ec->sum_feat_sq[priv.dat_new_feature_namespace] += f.x * f.x;
+  if (priv.all->audit) {
+    audit_data a = { nullptr, nullptr, f.weight_index, f.x, true };
+    a.space   = calloc_or_die<char>(priv.dat_new_feature_feature_space->length()+1);
+    a.feature = calloc_or_die<char>(priv.dat_new_feature_audit_ss.str().length() + 32);
+    strcpy(a.space, priv.dat_new_feature_feature_space->c_str());
+    int num = sprintf(a.feature, "fid=%lu_", (idx & mask) >> ss);
+    strcpy(a.feature+num, priv.dat_new_feature_audit_ss.str().c_str());
+    priv.dat_new_feature_ec->audit_features[priv.dat_new_feature_namespace].push_back(a);
+  }
+}
+
+void del_features_in_top_namespace(search_private& priv, example& ec, size_t ns) {
+  if ((ec.indices.size() == 0) || (ec.indices.last() != ns)) {
+    if (ec.indices.size() == 0)
+    {
+      THROW("internal error (bug): expecting top namespace to be '" << ns << "' but it was empty");
+    }
     else
-      ec.l.cs = priv.empty_cs_label;
-
-    cdbg << "allowed_actions_cnt=" << allowed_actions_cnt << ", ec.l = ["; for (size_t i=0; i<ec.l.cs.costs.size(); i++) cdbg << ' ' << ec.l.cs.costs[i].class_index << ':' << ec.l.cs.costs[i].x; cdbg << " ]" << endl;
-    
-    priv.base_learner->predict(ec, policy);
-    uint32_t act = ec.pred.multiclass;
-    cdbg << "a=" << act << " from"; for (size_t ii=0; ii<allowed_actions_cnt; ii++) cdbg << ' ' << allowed_actions[ii]; cdbg << endl;
-    a_cost = ec.partial_prediction;
-    cdbg << "a_cost = " << a_cost << endl;
-
-    if (override_action != (action)-1)
-      act = override_action;
-
-    if (need_partial_predictions) {
-      size_t K = cs_get_costs_size(priv.cb_learner, ec.l);
-      float min_cost = FLT_MAX;
-      for (size_t k = 0; k < K; k++) {
-        float cost = cs_get_cost_partial_prediction(priv.cb_learner, ec.l, k);
-        if (cost < min_cost) min_cost = cost;
+    {
+      THROW("internal error (bug): expecting top namespace to be '" << ns << "' but it was " << (size_t)ec.indices.last());
+    }
+  }
+  ec.num_features -= ec.atomics[ns].size();
+  ec.total_sum_feat_sq -= ec.sum_feat_sq[ns];
+  ec.sum_feat_sq[ns] = 0;
+  ec.indices.decr();
+  ec.atomics[ns].erase();
+  if (priv.all->audit) {
+    for (size_t i=0; i<ec.audit_features[ns].size(); i++)
+      if (ec.audit_features[ns][i].alloced) {
+        free(ec.audit_features[ns][i].space);
+        free(ec.audit_features[ns][i].feature);
       }
-      v_array<action_cache>* this_cache = nullptr;
-      if (need_memo_foreach_action(priv) && (override_action == (action)-1)) {
-        this_cache = new v_array<action_cache>();
-        *this_cache = v_init<action_cache>();
+    ec.audit_features[ns].erase();
+  }
+}
+
+void add_neighbor_features(search_private& priv) {
+  vw& all = *priv.all;
+  if (priv.neighbor_features.size() == 0) return;
+
+  for (size_t n=0; n<priv.ec_seq.size(); n++) {  // iterate over every example in the sequence
+    example& me = *priv.ec_seq[n];
+    for (size_t n_id=0; n_id < priv.neighbor_features.size(); n_id++) {
+      int32_t offset = priv.neighbor_features[n_id] >> 24;
+      size_t  ns     = priv.neighbor_features[n_id] & 0xFF;
+
+      priv.dat_new_feature_ec = &me;
+      priv.dat_new_feature_value = 1.;
+      priv.dat_new_feature_idx = priv.neighbor_features[n_id] * 13748127;
+      priv.dat_new_feature_namespace = neighbor_namespace;
+      if (priv.all->audit) {
+        priv.dat_new_feature_feature_space = &neighbor_feature_space;
+        priv.dat_new_feature_audit_ss.str("");
+        priv.dat_new_feature_audit_ss << '@' << ((offset > 0) ? '+' : '-') << (char)(abs(offset) + '0');
+        if (ns != ' ') priv.dat_new_feature_audit_ss << (char)ns;
       }
-      for (size_t k = 0; k < K; k++) {
-        action cl = cs_get_cost_index(priv.cb_learner, ec.l, k);
-        float cost = cs_get_cost_partial_prediction(priv.cb_learner, ec.l, k);
-        if (priv.metaoverride && priv.metaoverride->_foreach_action)
-          priv.metaoverride->_foreach_action(*priv.metaoverride->sch, priv.t-1, min_cost, cl, cl==act, cost);
-        if (override_action == cl)
-          a_cost = cost;
-        if (this_cache)
-          this_cache->push_back( action_cache(min_cost, cl, cl==act, cost) );
-      }
-      if (this_cache) {
-        size_t pos = priv.meta_t + priv.t;
-        assert( priv.memo_foreach_action.size() == pos - 1 );
-        priv.memo_foreach_action.push_back(this_cache);
-        cdbg << "memo_foreach_action[" << pos-1 << "] = " << this_cache << endl;
+
+      //cerr << "n=" << n << " offset=" << offset << endl;
+      if ((offset < 0) && (n < (uint32_t)(-offset))) // add <s> feature
+        add_new_feature(priv, 1., 925871901 << priv.all->reg.stride_shift);
+      else if (n + offset >= priv.ec_seq.size()) // add </s> feature
+        add_new_feature(priv, 1., 3824917 << priv.all->reg.stride_shift);
+      else { // this is actually a neighbor
+        example& other = *priv.ec_seq[n + offset];
+        GD::foreach_feature<search_private,add_new_feature>(all.reg.weight_vector, all.reg.weight_mask, other.atomics[ns].begin, other.atomics[ns].end, priv, me.ft_offset);
       }
     }
-    
-    if ((priv.state == INIT_TRAIN) && (priv.subsample_timesteps <= -1)) { // active learning
-      size_t K = cs_get_costs_size(priv.cb_learner, ec.l);
-      float min_cost = FLT_MAX, min_cost2 = FLT_MAX;
-      for (size_t k = 0; k < K; k++) {
-        float cost = cs_get_cost_partial_prediction(priv.cb_learner, ec.l, k);
-        if (cost < min_cost) { min_cost2 = min_cost; min_cost = cost; }
-        else if (cost < min_cost2) { min_cost2 = cost; }
-      }
-      if (min_cost2 < FLT_MAX)
-        priv.active_uncertainty.push_back( make_pair(min_cost2 - min_cost, priv.t+priv.meta_t) );
-    }
-    
-    // generate raw predictions if necessary
-    if ((priv.state == INIT_TEST) && (all.raw_prediction > 0)) {
-      priv.rawOutputStringStream->str("");
-      for (size_t k = 0; k < cs_get_costs_size(priv.cb_learner, ec.l); k++) {
-        if (k > 0) (*priv.rawOutputStringStream) << ' ';
-        (*priv.rawOutputStringStream) << cs_get_cost_index(priv.cb_learner, ec.l, k) << ':' << cs_get_cost_partial_prediction(priv.cb_learner, ec.l, k);
-      }
-      all.print_text(all.raw_prediction, priv.rawOutputStringStream->str(), ec.tag);
-    }
-    
-    ec.l = old_label;
 
-    priv.total_predictions_made++;
-    priv.num_features += ec.num_features;
+    size_t sz = me.atomics[neighbor_namespace].size();
+    if ((sz > 0) && (me.sum_feat_sq[neighbor_namespace] > 0.)) {
+      me.indices.push_back(neighbor_namespace);
+      me.total_sum_feat_sq += me.sum_feat_sq[neighbor_namespace];
+      me.num_features += sz;
+    } else {
+      me.atomics[neighbor_namespace].erase();
+      if (priv.all->audit) me.audit_features[neighbor_namespace].erase();
+    }
+  }
+}
 
-    return act;
+void del_neighbor_features(search_private& priv) {
+  if (priv.neighbor_features.size() == 0) return;
+  for (size_t n=0; n<priv.ec_seq.size(); n++)
+    del_features_in_top_namespace(priv, *priv.ec_seq[n], neighbor_namespace);
+}
+
+void reset_search_structure(search_private& priv) {
+  // NOTE: make sure do NOT reset priv.learn_a_idx
+  priv.t = 0;
+  priv.meta_t = 0;
+  priv.loss_declared_cnt = 0;
+  priv.done_with_all_actions = false;
+  priv.test_loss = 0.;
+  priv.learn_loss = 0.;
+  priv.train_loss = 0.;
+  priv.num_features = 0;
+  priv.should_produce_string = false;
+  priv.mix_per_roll_policy = -2;
+  if (priv.adaptive_beta) {
+    float x = - log1pf(- priv.alpha) * (float)priv.total_examples_generated;
+    static const float log_of_2 = (float)0.6931471805599453;
+    priv.beta = (x <= log_of_2) ? -expm1f(-x) : (1-expf(-x)); // numerical stability
+    //float priv_beta = 1.f - powf(1.f - priv.alpha, (float)priv.total_examples_generated);
+    //assert( fabs(priv_beta - priv.beta) < 1e-2 );
+    if (priv.beta > 1) priv.beta = 1;
+  }
+  priv.ptag_to_action.erase();
+
+  if (! priv.cb_learner) { // was: if rollout_all_actions
+    uint32_t seed = (uint32_t)(priv.read_example_last_id * 147483 + 4831921) * 2147483647;
+    msrand48(seed);
+  }
+}
+
+void search_declare_loss(search_private& priv, float loss) {
+  priv.loss_declared_cnt++;
+  switch (priv.state) {
+  case INIT_TEST:
+    priv.test_loss  += loss;
+    break;
+  case INIT_TRAIN:
+    priv.train_loss += loss;
+    break;
+  case LEARN:
+    if ((priv.rollout_num_steps == 0) || (priv.loss_declared_cnt <= priv.rollout_num_steps)) {
+      priv.learn_loss += loss;
+      cdbg << "priv.learn_loss += " << loss << " (now = " << priv.learn_loss << ")" << endl;
+    }
+    break;
+  default:
+    break; // get rid of the warning about missing cases (danger!)
+  }
+}
+
+
+template<class T> void cdbg_print_array(string str, v_array<T>& A) {
+  cdbg << str << " = [";
+  for (size_t i=0; i<A.size(); i++) cdbg << " " << A[i];
+  cdbg << " ]" << endl;
+}
+template<class T> void cerr_print_array(string str, v_array<T>& A) {
+  std::cerr << str << " = [";
+  for (size_t i=0; i<A.size(); i++) std::cerr << " " << A[i];
+  std::cerr << " ]" << endl;
+}
+
+
+size_t random(size_t max) {
+  return (size_t)(frand48() * (float)max);
+}
+template<class T> bool array_contains(T target, const T*A, size_t n) {
+  if (A == nullptr) return false;
+  for (size_t i=0; i<n; i++)
+    if (A[i] == target) return true;
+  return false;
+}
+
+void add_example_conditioning(search_private& priv, example& ec, size_t condition_on_cnt, const char* condition_on_names, actionpp* condition_on_actions) {
+  if (condition_on_cnt == 0) return;
+
+  uint32_t extra_offset=0;
+  if (priv.is_ldf)
+    if (ec.l.cs.costs.size() > 0)
+      extra_offset = 3849017 * ec.l.cs.costs[0].class_index;
+
+  size_t I = condition_on_cnt;
+  size_t N = max(priv.acset.max_bias_ngram_length, priv.acset.max_quad_ngram_length);
+  for (size_t i=0; i<I; i++) { // position in conditioning
+    uint32_t fid = 71933 + 8491087 * extra_offset;
+    if (priv.all->audit) {
+      priv.dat_new_feature_audit_ss.str("");
+      priv.dat_new_feature_audit_ss.clear();
+      priv.dat_new_feature_feature_space = &condition_feature_space;
+    }
+
+    for (size_t n=0; n<N; n++) { // length of ngram
+      if (i + n >= I) break; // no more ngrams
+      // we're going to add features for the ngram condition_on_actions[i .. i+N]
+      char name = condition_on_names[i+n];
+      fid = fid * 328901 + 71933 * ((condition_on_actions[i+n].a + 349101) * (name + 38490137));
+
+      priv.dat_new_feature_ec  = &ec;
+      priv.dat_new_feature_idx = fid * quadratic_constant;
+      priv.dat_new_feature_namespace = conditioning_namespace;
+      priv.dat_new_feature_value = priv.acset.feature_value;
+
+      if (priv.all->audit) {
+        if (n > 0) priv.dat_new_feature_audit_ss << ',';
+        if ((33 <= name) && (name <= 126)) priv.dat_new_feature_audit_ss << name;
+        else priv.dat_new_feature_audit_ss << '#' << (int)name;
+        priv.dat_new_feature_audit_ss << '=' << condition_on_actions[i+n].a;
+      }
+
+      // add the single bias feature
+      if (n < priv.acset.max_bias_ngram_length)
+        add_new_feature(priv, 1., 4398201 << priv.all->reg.stride_shift);
+
+      // add the quadratic features
+      if (n < priv.acset.max_quad_ngram_length)
+        GD::foreach_feature<search_private,uint32_t,add_new_feature>(*priv.all, ec, priv);
+    }
   }
 
-  action single_prediction_LDF(search_private& priv, example* ecs, size_t ec_cnt, int policy, float& a_cost, action override_action) {  // if override_action != -1, then we return it as the action and a_cost is set to the appropriate cost for that action
-    bool need_partial_predictions = need_memo_foreach_action(priv) || (priv.metaoverride && priv.metaoverride->_foreach_action) || (override_action != (action)-1);
+  for (size_t i=0; i<I; i++)
+    if (condition_on_actions[i].pp.size() > 0) {
+      char name = condition_on_names[i];
+      uint32_t fid = 84913 + 48371803 * (extra_offset + 8392817 * name);
+      for (size_t k=0; k<condition_on_actions[i].pp.size(); k++) {
+        priv.dat_new_feature_ec  = &ec;
+        priv.dat_new_feature_idx = (fid + k) * quadratic_constant;
+        priv.dat_new_feature_namespace = conditioning_namespace;
+        priv.dat_new_feature_value = condition_on_actions[i].pp[k];
+        add_new_feature(priv, condition_on_actions[i].pp[k], 4308927 << priv.all->reg.stride_shift);
+        // TODO: audit
+      }
+    }
 
-    CS::cs_label.default_label(&priv.ldf_test_label);
-    CS::wclass wc = { 0., 1, 0., 0. };
-    priv.ldf_test_label.costs.push_back(wc);
-    
-    // keep track of best (aka chosen) action
-    float  best_prediction = 0.;
-    action best_action = 0;
-    
-    size_t start_K = (priv.is_ldf && COST_SENSITIVE::ec_is_example_header(ecs[0])) ? 1 : 0;
+  size_t sz = ec.atomics[conditioning_namespace].size();
+  if ((sz > 0) && (ec.sum_feat_sq[conditioning_namespace] > 0.)) {
+    ec.indices.push_back(conditioning_namespace);
+    ec.total_sum_feat_sq += ec.sum_feat_sq[conditioning_namespace];
+    ec.num_features += sz;
+  } else {
+    ec.atomics[conditioning_namespace].erase();
+    if (priv.all->audit) ec.audit_features[conditioning_namespace].erase();
+  }
+}
 
+void del_example_conditioning(search_private& priv, example& ec) {
+  if ((ec.indices.size() > 0) && (ec.indices.last() == conditioning_namespace))
+    del_features_in_top_namespace(priv, ec, conditioning_namespace);
+}
+
+inline size_t cs_get_costs_size(bool isCB, polylabel& ld) {
+  return isCB ? ld.cb.costs.size()
+         : ld.cs.costs.size();
+}
+
+inline uint32_t cs_get_cost_index(bool isCB, polylabel& ld, size_t k) {
+  return isCB ? ld.cb.costs[k].action
+         : ld.cs.costs[k].class_index;
+}
+
+inline float cs_get_cost_partial_prediction(bool isCB, polylabel& ld, size_t k) {
+  return isCB ? ld.cb.costs[k].partial_prediction
+         : ld.cs.costs[k].partial_prediction;
+}
+
+inline void cs_set_cost_loss(bool isCB, polylabel& ld, size_t k, float val) {
+  if (isCB) ld.cb.costs[k].cost = val;
+  else      ld.cs.costs[k].x    = val;
+}
+
+inline void cs_costs_erase(bool isCB, polylabel& ld) {
+  if (isCB) ld.cb.costs.erase();
+  else      ld.cs.costs.erase();
+}
+
+inline void cs_costs_resize(bool isCB, polylabel& ld, size_t new_size) {
+  if (isCB) ld.cb.costs.resize(new_size);
+  else      ld.cs.costs.resize(new_size);
+}
+
+inline void cs_cost_push_back(bool isCB, polylabel& ld, uint32_t index, float value) {
+  if (isCB) {
+    CB::cb_class cost = { value, index, 0., 0. };
+    ld.cb.costs.push_back(cost);
+  }
+  else      {
+    CS::wclass   cost = { value, index, 0., 0. };
+    ld.cs.costs.push_back(cost);
+  }
+}
+
+polylabel& allowed_actions_to_ld(search_private& priv, size_t ec_cnt, const action* allowed_actions, size_t allowed_actions_cnt) {
+  bool isCB = priv.cb_learner;
+  polylabel& ld = *priv.allowed_actions_cache;
+  uint32_t num_costs = (uint32_t)cs_get_costs_size(isCB, ld);
+
+  if (priv.is_ldf) {  // LDF version easier
+    if (num_costs > ec_cnt)
+      cs_costs_resize(isCB, ld, ec_cnt);
+    else if (num_costs < ec_cnt)
+      for (action k = num_costs; k < ec_cnt; k++)
+        cs_cost_push_back(isCB, ld, k, FLT_MAX);
+
+  } else { // non-LDF version
+    if ((allowed_actions == nullptr) || (allowed_actions_cnt == 0)) { // any action is allowed
+      if (num_costs != priv.A) {  // if there are already A-many actions, they must be the right ones, unless the user did something stupid like putting duplicate allowed_actions...
+        cs_costs_erase(isCB, ld);
+        for (action k = 0; k < priv.A; k++)
+          cs_cost_push_back(isCB, ld, k+1, FLT_MAX);  //+1 because MC is 1-based
+      }
+    } else { // we need to peek at allowed_actions
+      cs_costs_erase(isCB, ld);
+      for (size_t i = 0; i < allowed_actions_cnt; i++)
+        cs_cost_push_back(isCB, ld, allowed_actions[i], FLT_MAX);
+    }
+  }
+
+  return ld;
+}
+
+void allowed_actions_to_label(search_private& priv, size_t ec_cnt, const action* allowed_actions, size_t allowed_actions_cnt, const action* oracle_actions, size_t oracle_actions_cnt, polylabel& lab) {
+  if (priv.is_ldf) { // LDF version easier
+    cs_costs_erase(priv.cb_learner, lab);
+    for (action k=0; k<ec_cnt; k++)
+      cs_cost_push_back(priv.cb_learner, lab, k, array_contains<action>(k, oracle_actions, oracle_actions_cnt) ? 0.f : 1.f );
+    //cerr << "lab = ["; for (size_t i=0; i<lab.cs.costs.size(); i++) cdbg << ' ' << lab.cs.costs[i].class_index << ':' << lab.cs.costs[i].x; cdbg << " ]" << endl;
+  } else { // non-LDF
+    if ((allowed_actions == NULL) || (allowed_actions_cnt == 0)) { // any action is allowed
+      bool set_to_one = false;
+      if (cs_get_costs_size(priv.cb_learner, lab) != priv.A) {
+        cs_costs_erase(priv.cb_learner, lab);
+        for (action k=0; k<priv.A; k++)
+          cs_cost_push_back(priv.cb_learner, lab, k+1, 1.);
+        set_to_one = true;
+      }
+      //cerr << "lab = ["; for (size_t i=0; i<lab.cs.costs.size(); i++) cdbg << ' ' << lab.cs.costs[i].class_index << ':' << lab.cs.costs[i].x; cdbg << " ]" << endl;
+      if (oracle_actions_cnt <= 1) { // common case to speed up
+        if (! set_to_one)
+          for (action k=0; k<priv.A; k++)
+            cs_set_cost_loss(priv.cb_learner, lab, k, 1.);
+        if (oracle_actions_cnt == 1)
+          cs_set_cost_loss(priv.cb_learner, lab, oracle_actions[0]-1, 0.);
+      } else {
+        for (action k=0; k<priv.A; k++)
+          cs_set_cost_loss(priv.cb_learner, lab, k, array_contains<action>(k+1, oracle_actions, oracle_actions_cnt) ? 0.f : 1.f);
+      }
+    } else { // only some actions are allowed
+      cs_costs_erase(priv.cb_learner, lab);
+      float w = 1.; // array_contains<action>(3, oracle_actions, oracle_actions_cnt) ? 5.f : 1.f;
+      for (size_t i=0; i<allowed_actions_cnt; i++) {
+        action k = allowed_actions[i];
+        cs_cost_push_back(priv.cb_learner, lab, k, (array_contains<action>(k, oracle_actions, oracle_actions_cnt)) ? 0.f : w); // 1.f );
+      }
+    }
+  }
+}
+
+template<class T>
+void ensure_size(v_array<T>& A, size_t sz) {
+  if ((size_t)(A.end_array - A.begin) < sz)
+    A.resize(sz*2+1, true);
+  A.end = A.begin + sz;
+}
+
+template<class T> void push_at(v_array<T>& v, T item, size_t pos) {
+  if (v.size() > pos)
+    v.begin[pos] = item;
+  else {
+    if (v.end_array > v.begin + pos) {
+      // there's enough memory, just not enough filler
+      v.begin[pos] = item;
+      v.end = v.begin + pos + 1;
+    } else {
+      // there's not enough memory
+      v.resize(2 * pos + 3, true);
+      v.begin[pos] = item;
+      v.end = v.begin + pos + 1;
+    }
+  }
+}
+
+action choose_oracle_action(search_private& priv, size_t ec_cnt, const action* oracle_actions, size_t oracle_actions_cnt, const action* allowed_actions, size_t allowed_actions_cnt) {
+  if ((priv.perturb_oracle > 0.) && (priv.state == INIT_TRAIN) && (frand48() < priv.perturb_oracle))
+    oracle_actions_cnt = 0;
+  action a = ( oracle_actions_cnt > 0) ?  oracle_actions[random(oracle_actions_cnt )] :
+             (allowed_actions_cnt > 0) ? allowed_actions[random(allowed_actions_cnt)] :
+             priv.is_ldf ? (action)random(ec_cnt) :
+             (action)(1 + random(priv.A));
+  cdbg << "choose_oracle_action from oracle_actions = [";
+  for (size_t i=0; i<oracle_actions_cnt; i++) cdbg << " " << oracle_actions[i];
+  cdbg << " ], ret=" << a << endl;
+  if (need_memo_foreach_action(priv) && (priv.state == INIT_TRAIN)) {
+    v_array<action_cache>* this_cache = new v_array<action_cache>();
+    *this_cache = v_init<action_cache>();
+    // TODO we don't really need to construct this polylabel
+    polylabel l = allowed_actions_to_ld(priv, 1, allowed_actions, allowed_actions_cnt);
+    size_t K = cs_get_costs_size(priv.cb_learner, l);
+    for (size_t k = 0; k < K; k++) {
+      action cl = cs_get_cost_index(priv.cb_learner, l, k);
+      float cost = array_contains(cl, oracle_actions, oracle_actions_cnt) ? 0.f : 1.f;
+      this_cache->push_back( action_cache(0., cl, cl==a, cost) );
+    }
+    size_t pos = priv.meta_t + priv.t;
+    assert( priv.memo_foreach_action.size() == pos - 1 );
+    priv.memo_foreach_action.push_back(this_cache);
+    cdbg << "memo_foreach_action[" << pos-1 << "] = " << this_cache << " from oracle" << endl;
+  }
+  return a;
+}
+
+action single_prediction_notLDF(search_private& priv, example& ec, int policy, const action* allowed_actions, size_t allowed_actions_cnt, float& a_cost, action override_action) {  // if override_action != -1, then we return it as the action and a_cost is set to the appropriate cost for that action
+  vw& all = *priv.all;
+  polylabel old_label = ec.l;
+  bool need_partial_predictions = need_memo_foreach_action(priv) || (priv.metaoverride && priv.metaoverride->_foreach_action) || (override_action != (action)-1);
+  if ((allowed_actions_cnt > 0) || need_partial_predictions)
+    ec.l = allowed_actions_to_ld(priv, 1, allowed_actions, allowed_actions_cnt);
+  else
+    ec.l.cs = priv.empty_cs_label;
+
+  cdbg << "allowed_actions_cnt=" << allowed_actions_cnt << ", ec.l = [";
+  for (size_t i=0; i<ec.l.cs.costs.size(); i++) cdbg << ' ' << ec.l.cs.costs[i].class_index << ':' << ec.l.cs.costs[i].x;
+  cdbg << " ]" << endl;
+
+  priv.base_learner->predict(ec, policy);
+  uint32_t act = ec.pred.multiclass;
+  cdbg << "a=" << act << " from";
+  for (size_t ii=0; ii<allowed_actions_cnt; ii++) cdbg << ' ' << allowed_actions[ii];
+  cdbg << endl;
+  a_cost = ec.partial_prediction;
+  cdbg << "a_cost = " << a_cost << endl;
+
+  if (override_action != (action)-1)
+    act = override_action;
+
+  if (need_partial_predictions) {
+    size_t K = cs_get_costs_size(priv.cb_learner, ec.l);
+    float min_cost = FLT_MAX;
+    for (size_t k = 0; k < K; k++) {
+      float cost = cs_get_cost_partial_prediction(priv.cb_learner, ec.l, k);
+      if (cost < min_cost) min_cost = cost;
+    }
     v_array<action_cache>* this_cache = nullptr;
-    if (need_partial_predictions) {
+    if (need_memo_foreach_action(priv) && (override_action == (action)-1)) {
       this_cache = new v_array<action_cache>();
       *this_cache = v_init<action_cache>();
     }
-    
-    for (action a= (uint32_t)start_K; a<ec_cnt; a++) {
-      cdbg << "== single_prediction_LDF a=" << a << "==" << endl;
-      if (start_K > 0)
-        LabelDict::add_example_namespaces_from_example(ecs[a], ecs[0], priv.all->audit);
-        
-      polylabel old_label = ecs[a].l;
-      ecs[a].l.cs = priv.ldf_test_label;
-      priv.base_learner->predict(ecs[a], policy);
-
-      priv.empty_example->in_use = true;
-      priv.base_learner->predict(*priv.empty_example);
-
-      cdbg << "partial_prediction[" << a << "] = " << ecs[a].partial_prediction << endl;
-
-      if (override_action != (action)-1) {
-        if (a == override_action)
-          a_cost = ecs[a].partial_prediction;
-      } else if ((a == start_K) || (ecs[a].partial_prediction < best_prediction)) {
-        best_prediction = ecs[a].partial_prediction;
-        best_action     = a;
-        a_cost          = best_prediction;
-      }
+    for (size_t k = 0; k < K; k++) {
+      action cl = cs_get_cost_index(priv.cb_learner, ec.l, k);
+      float cost = cs_get_cost_partial_prediction(priv.cb_learner, ec.l, k);
+      if (priv.metaoverride && priv.metaoverride->_foreach_action)
+        priv.metaoverride->_foreach_action(*priv.metaoverride->sch, priv.t-1, min_cost, cl, cl==act, cost);
+      if (override_action == cl)
+        a_cost = cost;
       if (this_cache)
-        this_cache->push_back( action_cache(0., a, false, ecs[a].partial_prediction) );
-      
-      priv.num_features += ecs[a].num_features;
-      ecs[a].l = old_label;
-      if (start_K > 0)
-        LabelDict::del_example_namespaces_from_example(ecs[a], ecs[0], priv.all->audit);
+        this_cache->push_back( action_cache(min_cost, cl, cl==act, cost) );
     }
-    if (override_action != (action)-1)
-      best_action = override_action;
-    else
-      a_cost = best_prediction;
-    
     if (this_cache) {
-      for (size_t i=0; i<this_cache->size(); i++) {
-        action_cache& ac = this_cache->get(i);
-        ac.min_cost = a_cost;
-        ac.is_opt = (ac.k == best_action);
-        if (priv.metaoverride && priv.metaoverride->_foreach_action)
-          priv.metaoverride->_foreach_action(*priv.metaoverride->sch, priv.t-1, ac.min_cost, ac.k, ac.is_opt, ac.cost);
+      size_t pos = priv.meta_t + priv.t;
+      assert( priv.memo_foreach_action.size() == pos - 1 );
+      priv.memo_foreach_action.push_back(this_cache);
+      cdbg << "memo_foreach_action[" << pos-1 << "] = " << this_cache << endl;
+    }
+  }
+
+  if ((priv.state == INIT_TRAIN) && (priv.subsample_timesteps <= -1)) { // active learning
+    size_t K = cs_get_costs_size(priv.cb_learner, ec.l);
+    float min_cost = FLT_MAX, min_cost2 = FLT_MAX;
+    for (size_t k = 0; k < K; k++) {
+      float cost = cs_get_cost_partial_prediction(priv.cb_learner, ec.l, k);
+      if (cost < min_cost) {
+        min_cost2 = min_cost;
+        min_cost = cost;
       }
-      if (need_memo_foreach_action(priv) && (override_action == (action)-1))
-        priv.memo_foreach_action.push_back(this_cache);
-      else {
-        this_cache->delete_v();
-        delete this_cache;
+      else if (cost < min_cost2) {
+        min_cost2 = cost;
       }
     }
-
-    // TODO: generate raw predictions if necessary
-    
-    priv.total_predictions_made++;
-    return best_action;
+    if (min_cost2 < FLT_MAX)
+      priv.active_uncertainty.push_back( make_pair(min_cost2 - min_cost, priv.t+priv.meta_t) );
   }
 
-  int choose_policy(search_private& priv, bool advance_prng=true) {
-    RollMethod method = (priv.state == INIT_TEST ) ? POLICY :
-                        (priv.state == LEARN     ) ? priv.rollout_method :
-                        (priv.state == INIT_TRAIN) ? priv.rollin_method :
-                        NO_ROLLOUT;   // this should never happen
-    switch (method) {
-      case POLICY:
-        return random_policy(priv, priv.allow_current_policy || (priv.state == INIT_TEST), false, advance_prng);
+  // generate raw predictions if necessary
+  if ((priv.state == INIT_TEST) && (all.raw_prediction > 0)) {
+    priv.rawOutputStringStream->str("");
+    for (size_t k = 0; k < cs_get_costs_size(priv.cb_learner, ec.l); k++) {
+      if (k > 0) (*priv.rawOutputStringStream) << ' ';
+      (*priv.rawOutputStringStream) << cs_get_cost_index(priv.cb_learner, ec.l, k) << ':' << cs_get_cost_partial_prediction(priv.cb_learner, ec.l, k);
+    }
+    all.print_text(all.raw_prediction, priv.rawOutputStringStream->str(), ec.tag);
+  }
 
-      case ORACLE:
-        return -1;
+  ec.l = old_label;
 
-      case MIX_PER_STATE:
-        return random_policy(priv, priv.allow_current_policy, true, advance_prng);
+  priv.total_predictions_made++;
+  priv.num_features += ec.num_features;
 
-      case MIX_PER_ROLL:
-        if (priv.mix_per_roll_policy == -2) // then we have to choose one!
-          priv.mix_per_roll_policy = random_policy(priv, priv.allow_current_policy, true, advance_prng);
-        return priv.mix_per_roll_policy;
+  return act;
+}
 
-    case NO_ROLLOUT:
-    default:
-      THROW("internal error (bug): trying to rollin or rollout with NO_ROLLOUT");
+action single_prediction_LDF(search_private& priv, example* ecs, size_t ec_cnt, int policy, float& a_cost, action override_action) {  // if override_action != -1, then we return it as the action and a_cost is set to the appropriate cost for that action
+  bool need_partial_predictions = need_memo_foreach_action(priv) || (priv.metaoverride && priv.metaoverride->_foreach_action) || (override_action != (action)-1);
+
+  CS::cs_label.default_label(&priv.ldf_test_label);
+  CS::wclass wc = { 0., 1, 0., 0. };
+  priv.ldf_test_label.costs.push_back(wc);
+
+  // keep track of best (aka chosen) action
+  float  best_prediction = 0.;
+  action best_action = 0;
+
+  size_t start_K = (priv.is_ldf && COST_SENSITIVE::ec_is_example_header(ecs[0])) ? 1 : 0;
+
+  v_array<action_cache>* this_cache = nullptr;
+  if (need_partial_predictions) {
+    this_cache = new v_array<action_cache>();
+    *this_cache = v_init<action_cache>();
+  }
+
+  for (action a= (uint32_t)start_K; a<ec_cnt; a++) {
+    cdbg << "== single_prediction_LDF a=" << a << "==" << endl;
+    if (start_K > 0)
+      LabelDict::add_example_namespaces_from_example(ecs[a], ecs[0], priv.all->audit);
+
+    polylabel old_label = ecs[a].l;
+    ecs[a].l.cs = priv.ldf_test_label;
+    priv.base_learner->predict(ecs[a], policy);
+
+    priv.empty_example->in_use = true;
+    priv.base_learner->predict(*priv.empty_example);
+
+    cdbg << "partial_prediction[" << a << "] = " << ecs[a].partial_prediction << endl;
+
+    if (override_action != (action)-1) {
+      if (a == override_action)
+        a_cost = ecs[a].partial_prediction;
+    } else if ((a == start_K) || (ecs[a].partial_prediction < best_prediction)) {
+      best_prediction = ecs[a].partial_prediction;
+      best_action     = a;
+      a_cost          = best_prediction;
+    }
+    if (this_cache)
+      this_cache->push_back( action_cache(0., a, false, ecs[a].partial_prediction) );
+
+    priv.num_features += ecs[a].num_features;
+    ecs[a].l = old_label;
+    if (start_K > 0)
+      LabelDict::del_example_namespaces_from_example(ecs[a], ecs[0], priv.all->audit);
+  }
+  if (override_action != (action)-1)
+    best_action = override_action;
+  else
+    a_cost = best_prediction;
+
+  if (this_cache) {
+    for (size_t i=0; i<this_cache->size(); i++) {
+      action_cache& ac = this_cache->get(i);
+      ac.min_cost = a_cost;
+      ac.is_opt = (ac.k == best_action);
+      if (priv.metaoverride && priv.metaoverride->_foreach_action)
+        priv.metaoverride->_foreach_action(*priv.metaoverride->sch, priv.t-1, ac.min_cost, ac.k, ac.is_opt, ac.cost);
+    }
+    if (need_memo_foreach_action(priv) && (override_action == (action)-1))
+      priv.memo_foreach_action.push_back(this_cache);
+    else {
+      this_cache->delete_v();
+      delete this_cache;
     }
   }
-  
-  void record_action(search_private& priv, ptag mytag, action a) {
-    if (mytag == 0) return;
-    push_at(priv.ptag_to_action, a, mytag);
+
+  // TODO: generate raw predictions if necessary
+
+  priv.total_predictions_made++;
+  return best_action;
+}
+
+int choose_policy(search_private& priv, bool advance_prng=true) {
+  RollMethod method = (priv.state == INIT_TEST ) ? POLICY :
+                      (priv.state == LEARN     ) ? priv.rollout_method :
+                      (priv.state == INIT_TRAIN) ? priv.rollin_method :
+                      NO_ROLLOUT;   // this should never happen
+  switch (method) {
+  case POLICY:
+    return random_policy(priv, priv.allow_current_policy || (priv.state == INIT_TEST), false, advance_prng);
+
+  case ORACLE:
+    return -1;
+
+  case MIX_PER_STATE:
+    return random_policy(priv, priv.allow_current_policy, true, advance_prng);
+
+  case MIX_PER_ROLL:
+    if (priv.mix_per_roll_policy == -2) // then we have to choose one!
+      priv.mix_per_roll_policy = random_policy(priv, priv.allow_current_policy, true, advance_prng);
+    return priv.mix_per_roll_policy;
+
+  case NO_ROLLOUT:
+  default:
+    THROW("internal error (bug): trying to rollin or rollout with NO_ROLLOUT");
   }
+}
 
-  bool cached_item_equivalent(unsigned char*& A, unsigned char*& B) {
-    size_t sz_A = *A;
-    size_t sz_B = *B;
-    if (sz_A != sz_B) return false;
-    return memcmp(A, B, sz_A) == 0;
+void record_action(search_private& priv, ptag mytag, action a) {
+  if (mytag == 0) return;
+  push_at(priv.ptag_to_action, a, mytag);
+}
+
+bool cached_item_equivalent(unsigned char*& A, unsigned char*& B) {
+  size_t sz_A = *A;
+  size_t sz_B = *B;
+  if (sz_A != sz_B) return false;
+  return memcmp(A, B, sz_A) == 0;
+}
+
+void free_key(unsigned char* mem, scored_action) {
+  free(mem);
+}
+void clear_cache_hash_map(search_private& priv) {
+  priv.cache_hash_map.iter(free_key);
+  priv.cache_hash_map.clear();
+}
+
+// returns true if found and do_store is false. if do_store is true, always returns true.
+bool cached_action_store_or_find(search_private& priv, ptag mytag, const ptag* condition_on, const char* condition_on_names, actionpp* condition_on_actions, size_t condition_on_cnt, int policy, size_t learner_id, action &a, bool do_store, float& a_cost) {
+  if (priv.no_caching) return do_store;
+  if (mytag == 0) return do_store; // don't attempt to cache when tag is zero
+
+  size_t sz  = sizeof(size_t) + sizeof(ptag) + sizeof(int) + sizeof(size_t) + sizeof(size_t) + condition_on_cnt * (sizeof(ptag) + sizeof(action) + sizeof(uint32_t) + sizeof(char));
+  for (size_t i=0; i<condition_on_cnt; i++)
+    sz += sizeof(float) * condition_on_actions[i].pp.size();
+  if (sz % 4 != 0) sz = 4 * (sz / 4 + 1); // make sure sz aligns to 4 so that uniform_hash does the right thing
+
+  unsigned char* item = calloc_or_die<unsigned char>(sz);
+  unsigned char* here = item;
+  *here = (unsigned char)sz;
+  here += sizeof(size_t);
+  *here = mytag;
+  here += sizeof(ptag);
+  *here = policy;
+  here += sizeof(int);
+  *here = (unsigned char)learner_id;
+  here += sizeof(size_t);
+  *here = (unsigned char)condition_on_cnt;
+  here += sizeof(size_t);
+  for (size_t i=0; i<condition_on_cnt; i++) {
+    uint32_t nf = condition_on_actions[i].pp.size();
+    *here = condition_on[i];
+    here += sizeof(ptag);
+    *here = condition_on_actions[i].a;
+    here += sizeof(action);
+    *here = nf;
+    here += sizeof(uint32_t);
+    for (uint32_t j=0; j<nf; j++) {
+      *here = condition_on_actions[i].pp[j];
+      here += sizeof(float);
+    }
+    *here = condition_on_names[i];
+    here += sizeof(char);  // SPEEDUP: should we align this at 4?
   }
+  uint32_t hash = uniform_hash(item, sz, 3419);
 
-  void free_key(unsigned char* mem, scored_action) { free(mem); }
-  void clear_cache_hash_map(search_private& priv) {
-    priv.cache_hash_map.iter(free_key);
-    priv.cache_hash_map.clear();
+  if (do_store) {
+    priv.cache_hash_map.put(item, hash, scored_action(a, a_cost));
+    return true;
+  } else { // its a find
+    scored_action sa = priv.cache_hash_map.get(item, hash);
+    a = sa.a;
+    a_cost = sa.s;
+    free(item);
+    return a != (action)-1;
   }
-  
-  // returns true if found and do_store is false. if do_store is true, always returns true.
-  bool cached_action_store_or_find(search_private& priv, ptag mytag, const ptag* condition_on, const char* condition_on_names, actionpp* condition_on_actions, size_t condition_on_cnt, int policy, size_t learner_id, action &a, bool do_store, float& a_cost) {
-    if (priv.no_caching) return do_store;
-    if (mytag == 0) return do_store; // don't attempt to cache when tag is zero
+}
 
-    size_t sz  = sizeof(size_t) + sizeof(ptag) + sizeof(int) + sizeof(size_t) + sizeof(size_t) + condition_on_cnt * (sizeof(ptag) + sizeof(action) + sizeof(uint32_t) + sizeof(char));
-    for (size_t i=0; i<condition_on_cnt; i++)
-      sz += sizeof(float) * condition_on_actions[i].pp.size();
-    if (sz % 4 != 0) sz = 4 * (sz / 4 + 1); // make sure sz aligns to 4 so that uniform_hash does the right thing
+void generate_training_example(search_private& priv, polylabel& losses, float weight, bool add_conditioning=true, float min_loss=FLT_MAX) {  // min_loss = FLT_MAX means "please compute it for me as the actual min"; any other value means to use this
+  // should we really subtract out min-loss?
+  //float min_loss = FLT_MAX;
+  if (priv.cb_learner) {
+    if (min_loss == FLT_MAX)
+      for (size_t i=0; i<losses.cb.costs.size(); i++) min_loss = MIN(min_loss, losses.cb.costs[i].cost);
+    for (size_t i=0; i<losses.cb.costs.size(); i++) losses.cb.costs[i].cost = losses.cb.costs[i].cost - min_loss;
+  } else {
+    if (min_loss == FLT_MAX)
+      for (size_t i=0; i<losses.cs.costs.size(); i++) min_loss = MIN(min_loss, losses.cs.costs[i].x);
+    for (size_t i=0; i<losses.cs.costs.size(); i++) losses.cs.costs[i].x = (losses.cs.costs[i].x - min_loss) * weight;
+    //for (size_t i=0; i<losses.cs.costs.size(); i++) cerr << '\t' << losses.cs.costs[i].x; cerr << endl;
+  }
+  //cdbg << "losses = ["; for (size_t i=0; i<losses.cs.costs.size(); i++) cdbg << ' ' << losses.cs.costs[i].class_index << ':' << losses.cs.costs[i].x; cdbg << " ], min_loss=" << min_loss << endl;
 
-    unsigned char* item = calloc_or_die<unsigned char>(sz);
-    unsigned char* here = item;
-    *here = (unsigned char)sz; here += sizeof(size_t);
-    *here = mytag;             here += sizeof(ptag);
-    *here = policy;            here += sizeof(int);
-    *here = (unsigned char)learner_id;        here += sizeof(size_t);
-    *here = (unsigned char)condition_on_cnt;  here += sizeof(size_t);
-    for (size_t i=0; i<condition_on_cnt; i++) {
-      uint32_t nf = condition_on_actions[i].pp.size();
-      *here = condition_on[i];           here += sizeof(ptag);
-      *here = condition_on_actions[i].a; here += sizeof(action);
-      *here = nf;                        here += sizeof(uint32_t);
-      for (uint32_t j=0; j<nf; j++) {
-        *here = condition_on_actions[i].pp[j]; here += sizeof(float);
+  priv.total_example_t += 1.;   // TODO: should be max-min
+
+  if (!priv.is_ldf) {   // not LDF
+    // since we're not LDF, it should be the case that ec_ref_cnt == 1
+    // and learn_ec_ref[0] is a pointer to a single example
+    assert(priv.learn_ec_ref_cnt == 1);
+    assert(priv.learn_ec_ref != nullptr);
+
+    //polylabel labels = allowed_actions_to_ld(priv, priv.learn_ec_ref_cnt, priv.learn_allowed_actions.begin, priv.learn_allowed_actions.size());
+    //cdbg_print_array("learn_allowed_actions", priv.learn_allowed_actions);
+
+    example& ec = priv.learn_ec_ref[0];
+    float old_example_t = ec.example_t;
+    ec.example_t = priv.total_example_t;
+    polylabel old_label = ec.l;
+    ec.l = losses; // labels;
+    if (add_conditioning) add_example_conditioning(priv, ec, priv.learn_condition_on.size(), priv.learn_condition_on_names.begin, priv.learn_condition_on_act.begin);
+    //cerr << "losses = ["; for (size_t i=0; i<losses.cs.costs.size(); i++) cerr << ' ' << losses.cs.costs[i].class_index << ':' << losses.cs.costs[i].x; cerr << " ]" << endl;
+    for (size_t is_local=0; is_local<=priv.xv; is_local++) {
+      int learner = select_learner(priv, priv.current_policy, priv.learn_learner_id, true, is_local);
+      ec.in_use = true;
+      priv.base_learner->learn(ec, learner);
+    }
+    if (add_conditioning) del_example_conditioning(priv, ec);
+    ec.l = old_label;
+    ec.example_t = old_example_t;
+    priv.total_examples_generated++;
+  } else {              // is  LDF
+    assert(cs_get_costs_size(priv.cb_learner, losses) == priv.learn_ec_ref_cnt);
+    size_t start_K = (priv.is_ldf && COST_SENSITIVE::ec_is_example_header(priv.learn_ec_ref[0])) ? 1 : 0;
+
+    // TODO: weight
+    if (add_conditioning)
+      for (action a= (uint32_t)start_K; a<priv.learn_ec_ref_cnt; a++) {
+        example& ec = priv.learn_ec_ref[a];
+        add_example_conditioning(priv, ec, priv.learn_condition_on.size(), priv.learn_condition_on_names.begin, priv.learn_condition_on_act.begin);
       }
-      *here = condition_on_names[i];     here += sizeof(char);  // SPEEDUP: should we align this at 4?
-    }
-    uint32_t hash = uniform_hash(item, sz, 3419);
 
-    if (do_store) {
-      priv.cache_hash_map.put(item, hash, scored_action(a, a_cost));
-      return true;
-    } else { // its a find
-      scored_action sa = priv.cache_hash_map.get(item, hash);
-      a = sa.a;
-      a_cost = sa.s;
-      free(item);
-      return a != (action)-1;
-    }
-  }
+    for (size_t is_local=0; is_local<=priv.xv; is_local++) {
+      int learner = select_learner(priv, priv.current_policy, priv.learn_learner_id, true, is_local);
 
-  void generate_training_example(search_private& priv, polylabel& losses, float weight, bool add_conditioning=true, float min_loss=FLT_MAX) {  // min_loss = FLT_MAX means "please compute it for me as the actual min"; any other value means to use this
-    // should we really subtract out min-loss?
-    //float min_loss = FLT_MAX;
-    if (priv.cb_learner) {
-      if (min_loss == FLT_MAX)
-        for (size_t i=0; i<losses.cb.costs.size(); i++) min_loss = MIN(min_loss, losses.cb.costs[i].cost);
-      for (size_t i=0; i<losses.cb.costs.size(); i++) losses.cb.costs[i].cost = losses.cb.costs[i].cost - min_loss;
-    } else {
-      if (min_loss == FLT_MAX)
-        for (size_t i=0; i<losses.cs.costs.size(); i++) min_loss = MIN(min_loss, losses.cs.costs[i].x);
-      for (size_t i=0; i<losses.cs.costs.size(); i++) losses.cs.costs[i].x = (losses.cs.costs[i].x - min_loss) * weight;
-      //for (size_t i=0; i<losses.cs.costs.size(); i++) cerr << '\t' << losses.cs.costs[i].x; cerr << endl;
-    }
-    //cdbg << "losses = ["; for (size_t i=0; i<losses.cs.costs.size(); i++) cdbg << ' ' << losses.cs.costs[i].class_index << ':' << losses.cs.costs[i].x; cdbg << " ], min_loss=" << min_loss << endl;
+      for (action a= (uint32_t)start_K; a<priv.learn_ec_ref_cnt; a++) {
+        example& ec = priv.learn_ec_ref[a];
+        float old_example_t = ec.example_t;
+        ec.example_t = priv.total_example_t;
 
-    priv.total_example_t += 1.;   // TODO: should be max-min
-    
-    if (!priv.is_ldf) {   // not LDF
-      // since we're not LDF, it should be the case that ec_ref_cnt == 1
-      // and learn_ec_ref[0] is a pointer to a single example
-      assert(priv.learn_ec_ref_cnt == 1);
-      assert(priv.learn_ec_ref != nullptr);
-
-      //polylabel labels = allowed_actions_to_ld(priv, priv.learn_ec_ref_cnt, priv.learn_allowed_actions.begin, priv.learn_allowed_actions.size());
-      //cdbg_print_array("learn_allowed_actions", priv.learn_allowed_actions);
-
-      example& ec = priv.learn_ec_ref[0];
-      float old_example_t = ec.example_t;
-      ec.example_t = priv.total_example_t;
-      polylabel old_label = ec.l;
-      ec.l = losses; // labels;
-      if (add_conditioning) add_example_conditioning(priv, ec, priv.learn_condition_on.size(), priv.learn_condition_on_names.begin, priv.learn_condition_on_act.begin);
-      //cerr << "losses = ["; for (size_t i=0; i<losses.cs.costs.size(); i++) cerr << ' ' << losses.cs.costs[i].class_index << ':' << losses.cs.costs[i].x; cerr << " ]" << endl;
-      for (size_t is_local=0; is_local<=priv.xv; is_local++) {
-        int learner = select_learner(priv, priv.current_policy, priv.learn_learner_id, true, is_local);
+        CS::label& lab = ec.l.cs;
+        if (lab.costs.size() == 0) {
+          CS::wclass wc = { 0., a - (uint32_t)start_K, 0., 0. };
+          lab.costs.push_back(wc);
+        }
+        lab.costs[0].x = losses.cs.costs[a-start_K].x;
+        //cerr << "cost[" << a << "] = " << losses[a] << " - " << min_loss << " = " << lab.costs[0].x << endl;
         ec.in_use = true;
         priv.base_learner->learn(ec, learner);
-      }
-      if (add_conditioning) del_example_conditioning(priv, ec);
-      ec.l = old_label;
-      ec.example_t = old_example_t;
-      priv.total_examples_generated++;
-    } else {              // is  LDF
-      assert(cs_get_costs_size(priv.cb_learner, losses) == priv.learn_ec_ref_cnt);
-      size_t start_K = (priv.is_ldf && COST_SENSITIVE::ec_is_example_header(priv.learn_ec_ref[0])) ? 1 : 0;
 
-      // TODO: weight
-      if (add_conditioning)
-        for (action a= (uint32_t)start_K; a<priv.learn_ec_ref_cnt; a++) {
-          example& ec = priv.learn_ec_ref[a];
-          add_example_conditioning(priv, ec, priv.learn_condition_on.size(), priv.learn_condition_on_names.begin, priv.learn_condition_on_act.begin);
-        }
-
-      for (size_t is_local=0; is_local<=priv.xv; is_local++) {
-        int learner = select_learner(priv, priv.current_policy, priv.learn_learner_id, true, is_local);
-
-        for (action a= (uint32_t)start_K; a<priv.learn_ec_ref_cnt; a++) {
-          example& ec = priv.learn_ec_ref[a];
-          float old_example_t = ec.example_t;
-          ec.example_t = priv.total_example_t;
-          
-          CS::label& lab = ec.l.cs;
-          if (lab.costs.size() == 0) {
-            CS::wclass wc = { 0., a - (uint32_t)start_K, 0., 0. };
-            lab.costs.push_back(wc);
-          }
-          lab.costs[0].x = losses.cs.costs[a-start_K].x;
-          //cerr << "cost[" << a << "] = " << losses[a] << " - " << min_loss << " = " << lab.costs[0].x << endl;
-          ec.in_use = true;
-          priv.base_learner->learn(ec, learner);
-
-          cdbg << "generate_training_example called learn on action a=" << a << ", costs.size=" << lab.costs.size() << " ec=" << &ec << endl;
-          ec.example_t = old_example_t;
-          priv.total_examples_generated++;
-        }
-
-        priv.base_learner->learn(*priv.empty_example, learner);
-        cdbg << "generate_training_example called learn on empty_example" << endl;
+        cdbg << "generate_training_example called learn on action a=" << a << ", costs.size=" << lab.costs.size() << " ec=" << &ec << endl;
+        ec.example_t = old_example_t;
+        priv.total_examples_generated++;
       }
 
-      if (add_conditioning) 
-        for (action a= (uint32_t)start_K; a<priv.learn_ec_ref_cnt; a++) {
-          example& ec = priv.learn_ec_ref[a];
-          del_example_conditioning(priv, ec);
-        }
+      priv.base_learner->learn(*priv.empty_example, learner);
+      cdbg << "generate_training_example called learn on empty_example" << endl;
     }
+
+    if (add_conditioning)
+      for (action a= (uint32_t)start_K; a<priv.learn_ec_ref_cnt; a++) {
+        example& ec = priv.learn_ec_ref[a];
+        del_example_conditioning(priv, ec);
+      }
+  }
+}
+
+bool search_predictNeedsExample(search_private& priv) {
+  // this is basically copied from the logic of search_predict()
+  switch (priv.state) {
+  case INITIALIZE:
+    return false;
+  case GET_TRUTH_STRING:
+    return false;
+  case INIT_TEST:
+    return true;
+  case INIT_TRAIN:
+    // TODO: do we need to do something here for metatasks?
+    //if (priv.beam && (priv.t < priv.beam_actions.size()))
+    //  return false;
+    if (priv.rollout_method == NO_ROLLOUT) return true;
+    break;
+  case LEARN:
+    if (priv.t+priv.meta_t < priv.learn_t) return false;  // TODO: in meta search mode with foreach feature we'll need it even here
+    if (priv.t+priv.meta_t == priv.learn_t) return true;  // SPEEDUP: we really only need it on the last learn_a, but this is hard to know...
+    // t > priv.learn_t
+    if ((priv.rollout_num_steps > 0) && (priv.loss_declared_cnt >= priv.rollout_num_steps)) return false; // skipping
+    break;
   }
 
-  bool search_predictNeedsExample(search_private& priv) {
-    // this is basically copied from the logic of search_predict()
-    switch (priv.state) {
-      case INITIALIZE: return false;
-      case GET_TRUTH_STRING: return false;
-      case INIT_TEST:
-        return true;
-      case INIT_TRAIN:
-        // TODO: do we need to do something here for metatasks?
-        //if (priv.beam && (priv.t < priv.beam_actions.size()))
-        //  return false;
-        if (priv.rollout_method == NO_ROLLOUT) return true;
-        break;
-      case LEARN:
-        if (priv.t+priv.meta_t < priv.learn_t) return false;  // TODO: in meta search mode with foreach feature we'll need it even here
-        if (priv.t+priv.meta_t == priv.learn_t) return true;  // SPEEDUP: we really only need it on the last learn_a, but this is hard to know...
-        // t > priv.learn_t
-        if ((priv.rollout_num_steps > 0) && (priv.loss_declared_cnt >= priv.rollout_num_steps)) return false; // skipping
-        break;
-    }
+  int pol = choose_policy(priv, false); // choose a policy but don't advance prng
+  return (pol != -1);
+}
 
-    int pol = choose_policy(priv, false); // choose a policy but don't advance prng
-    return (pol != -1);
+void foreach_action_from_cache(search_private& priv, size_t t, action override_a=(action)-1) {
+  cdbg << "foreach_action_from_cache: t=" << t << ", memo_foreach_action.size()=" << priv.memo_foreach_action.size() << ", override_a=" << override_a << endl;
+  assert(t < priv.memo_foreach_action.size());
+  v_array<action_cache>* cached = priv.memo_foreach_action[t];
+  if (!cached) return; // the only way this can happen is if the metatask overrode this action
+  cdbg << "memo_foreach_action size = " << cached->size() << endl;
+  for (size_t id=0; id<cached->size(); id++) {
+    action_cache& ac = cached->get(id);
+    priv.metaoverride->_foreach_action(*priv.metaoverride->sch,
+                                       t-priv.meta_t,
+                                       ac.min_cost,
+                                       ac.k,
+                                       (override_a == (action)-1) ? ac.is_opt : (ac.k == override_a),
+                                       ac.cost);
+  }
+}
+
+// note: ec_cnt should be 1 if we are not LDF
+action search_predict(search_private& priv, example* ecs, size_t ec_cnt, ptag mytag, const action* oracle_actions, size_t oracle_actions_cnt, const ptag* condition_on, const char* condition_on_names, const action* allowed_actions, size_t allowed_actions_cnt, size_t learner_id, float& a_cost, float weight) {
+  size_t condition_on_cnt = condition_on_names ? strlen(condition_on_names) : 0;
+  size_t t = priv.t + priv.meta_t;
+  priv.t++;
+
+  // make sure parameters come in pairs correctly
+  assert((oracle_actions  == nullptr) == (oracle_actions_cnt  == 0));
+  assert((condition_on    == nullptr) == (condition_on_names  == nullptr));
+  assert((allowed_actions == nullptr) == (allowed_actions_cnt == 0));
+
+  // if we're just after the string, choose an oracle action
+  if ((priv.state == GET_TRUTH_STRING) || priv.force_oracle) {
+    action a = choose_oracle_action(priv, ec_cnt, oracle_actions, oracle_actions_cnt, allowed_actions, allowed_actions_cnt);
+    //if (priv.metaoverride && priv.metaoverride->_post_prediction)
+    //  priv.metaoverride->_post_prediction(*priv.metaoverride->sch, t-priv.meta_t, a, 0.);
+    a_cost = 0.;
+    return a;
   }
 
-  void foreach_action_from_cache(search_private& priv, size_t t, action override_a=(action)-1) {
-    cdbg << "foreach_action_from_cache: t=" << t << ", memo_foreach_action.size()=" << priv.memo_foreach_action.size() << ", override_a=" << override_a << endl;
-    assert(t < priv.memo_foreach_action.size());
-    v_array<action_cache>* cached = priv.memo_foreach_action[t];
-    if (!cached) return; // the only way this can happen is if the metatask overrode this action
-    cdbg << "memo_foreach_action size = " << cached->size() << endl;
-    for (size_t id=0; id<cached->size(); id++) {
-      action_cache& ac = cached->get(id);
-      priv.metaoverride->_foreach_action(*priv.metaoverride->sch,
-                                         t-priv.meta_t,
-                                         ac.min_cost,
-                                         ac.k,
-                                         (override_a == (action)-1) ? ac.is_opt : (ac.k == override_a),
-                                         ac.cost);
-    }
+  // if we're in LEARN mode and before learn_t, return the train action
+  if ((priv.state == LEARN) && (t < priv.learn_t)) {
+    assert(t < priv.train_trajectory.size());
+    action a = priv.train_trajectory[t].a;
+    a_cost   = priv.train_trajectory[t].s;
+    cdbg << "LEARN " << t << " < priv.learn_t ==> a=" << a << ", a_cost=" << a_cost << endl;
+    if (priv.metaoverride && priv.metaoverride->_foreach_action)
+      foreach_action_from_cache(priv, t);
+    if (priv.metaoverride && priv.metaoverride->_post_prediction)
+      priv.metaoverride->_post_prediction(*priv.metaoverride->sch, t-priv.meta_t, a, a_cost);
+    return a;
   }
-  
-  // note: ec_cnt should be 1 if we are not LDF
-  action search_predict(search_private& priv, example* ecs, size_t ec_cnt, ptag mytag, const action* oracle_actions, size_t oracle_actions_cnt, const ptag* condition_on, const char* condition_on_names, const action* allowed_actions, size_t allowed_actions_cnt, size_t learner_id, float& a_cost, float weight) {
-    size_t condition_on_cnt = condition_on_names ? strlen(condition_on_names) : 0;
-    size_t t = priv.t + priv.meta_t;
-    priv.t++;
 
-    // make sure parameters come in pairs correctly
-    assert((oracle_actions  == nullptr) == (oracle_actions_cnt  == 0));
-    assert((condition_on    == nullptr) == (condition_on_names  == nullptr));
-    assert((allowed_actions == nullptr) == (allowed_actions_cnt == 0));
-    
-    // if we're just after the string, choose an oracle action
-    if ((priv.state == GET_TRUTH_STRING) || priv.force_oracle) {
-      action a = choose_oracle_action(priv, ec_cnt, oracle_actions, oracle_actions_cnt, allowed_actions, allowed_actions_cnt);
-      //if (priv.metaoverride && priv.metaoverride->_post_prediction)
-      //  priv.metaoverride->_post_prediction(*priv.metaoverride->sch, t-priv.meta_t, a, 0.);
-      a_cost = 0.;
-      return a;
-    }
+  // for LDF, # of valid actions is ec_cnt; otherwise it's either allowed_actions_cnt or A
+  size_t valid_action_cnt = priv.is_ldf ? ec_cnt :
+                            (allowed_actions_cnt > 0) ? allowed_actions_cnt : priv.A;
 
-    // if we're in LEARN mode and before learn_t, return the train action
-    if ((priv.state == LEARN) && (t < priv.learn_t)) {
-      assert(t < priv.train_trajectory.size());
-      action a = priv.train_trajectory[t].a;
-      a_cost   = priv.train_trajectory[t].s;
-      cdbg << "LEARN " << t << " < priv.learn_t ==> a=" << a << ", a_cost=" << a_cost << endl;
-      if (priv.metaoverride && priv.metaoverride->_foreach_action)
-        foreach_action_from_cache(priv, t);
-      if (priv.metaoverride && priv.metaoverride->_post_prediction)
-        priv.metaoverride->_post_prediction(*priv.metaoverride->sch, t-priv.meta_t, a, a_cost);
-      return a;
-    }
-    
-    // for LDF, # of valid actions is ec_cnt; otherwise it's either allowed_actions_cnt or A
-    size_t valid_action_cnt = priv.is_ldf ? ec_cnt :
-                              (allowed_actions_cnt > 0) ? allowed_actions_cnt : priv.A;
+  // if we're in LEARN mode and _at_ learn_t, then:
+  //   - choose the next action
+  //   - decide if we're done
+  //   - if we are, then copy/mark the example ref
+  if ((priv.state == LEARN) && (t == priv.learn_t)) {
+    action a = (action)priv.learn_a_idx;
+    priv.loss_declared_cnt = 0;
 
-    // if we're in LEARN mode and _at_ learn_t, then:
-    //   - choose the next action
-    //   - decide if we're done
-    //   - if we are, then copy/mark the example ref
-    if ((priv.state == LEARN) && (t == priv.learn_t)) {
-      action a = (action)priv.learn_a_idx;
-      priv.loss_declared_cnt = 0;
-      
-      cdbg << "LEARN " << t << " = priv.learn_t ==> a=" << a << endl;
-      
-      priv.learn_a_idx++;
+    cdbg << "LEARN " << t << " = priv.learn_t ==> a=" << a << endl;
 
-      // check to see if we're done with available actions
-      if (priv.learn_a_idx >= valid_action_cnt) {
-        priv.done_with_all_actions = true;
-        priv.learn_learner_id = learner_id;
+    priv.learn_a_idx++;
 
-        // set reference or copy example(s)
-        if (oracle_actions_cnt > 0) priv.learn_oracle_action = oracle_actions[0];
-        priv.learn_ec_ref_cnt = ec_cnt;
-        if (priv.examples_dont_change)
-          priv.learn_ec_ref = ecs;
-        else {
-          size_t label_size = priv.is_ldf ? sizeof(CS::label) : sizeof(MC::label_t);
-          void (*label_copy_fn)(void*,void*) = priv.is_ldf ? CS::cs_label.copy_label : nullptr;
-          
-          ensure_size(priv.learn_ec_copy, ec_cnt);
-          for (size_t i=0; i<ec_cnt; i++) 
-            VW::copy_example_data(priv.all->audit, priv.learn_ec_copy.begin+i, ecs+i, label_size, label_copy_fn);
+    // check to see if we're done with available actions
+    if (priv.learn_a_idx >= valid_action_cnt) {
+      priv.done_with_all_actions = true;
+      priv.learn_learner_id = learner_id;
 
-          priv.learn_ec_ref = priv.learn_ec_copy.begin;
-        }
+      // set reference or copy example(s)
+      if (oracle_actions_cnt > 0) priv.learn_oracle_action = oracle_actions[0];
+      priv.learn_ec_ref_cnt = ec_cnt;
+      if (priv.examples_dont_change)
+        priv.learn_ec_ref = ecs;
+      else {
+        size_t label_size = priv.is_ldf ? sizeof(CS::label) : sizeof(MC::label_t);
+        void (*label_copy_fn)(void*,void*) = priv.is_ldf ? CS::cs_label.copy_label : nullptr;
 
-        // copy conditioning stuff and allowed actions
-        if (priv.auto_condition_features) {
-          ensure_size(priv.learn_condition_on,     condition_on_cnt);
-          ensure_size(priv.learn_condition_on_act, condition_on_cnt);
+        ensure_size(priv.learn_ec_copy, ec_cnt);
+        for (size_t i=0; i<ec_cnt; i++)
+          VW::copy_example_data(priv.all->audit, priv.learn_ec_copy.begin+i, ecs+i, label_size, label_copy_fn);
 
-          priv.learn_condition_on.end = priv.learn_condition_on.begin + condition_on_cnt;   // allow .size() to be used in lieu of _cnt
-
-          memcpy(priv.learn_condition_on.begin, condition_on, condition_on_cnt * sizeof(ptag));
-          
-          for (size_t i=0; i<condition_on_cnt; i++)
-            push_at(priv.learn_condition_on_act
-                    , actionpp(((1 <= condition_on[i]) && (condition_on[i] < priv.ptag_to_action.size())) ? priv.ptag_to_action[condition_on[i]] : 0)
-                    , i);  // TODO pp
-
-          if (condition_on_names == nullptr) {
-            ensure_size(priv.learn_condition_on_names, 1);
-            priv.learn_condition_on_names[0] = 0;
-          } else {
-            ensure_size(priv.learn_condition_on_names, strlen(condition_on_names)+1);
-            strcpy(priv.learn_condition_on_names.begin, condition_on_names);
-          }
-        }
-
-        if (allowed_actions && (allowed_actions_cnt > 0)) {
-          ensure_size(priv.learn_allowed_actions, allowed_actions_cnt);
-          memcpy(priv.learn_allowed_actions.begin, allowed_actions, allowed_actions_cnt*sizeof(action));
-          cdbg_print_array("in LEARN, learn_allowed_actions", priv.learn_allowed_actions);
-        }
+        priv.learn_ec_ref = priv.learn_ec_copy.begin;
       }
 
-      assert((allowed_actions_cnt == 0) || (a < allowed_actions_cnt));
+      // copy conditioning stuff and allowed actions
+      if (priv.auto_condition_features) {
+        ensure_size(priv.learn_condition_on,     condition_on_cnt);
+        ensure_size(priv.learn_condition_on_act, condition_on_cnt);
 
-      a_cost = 0.;
-      action a_name = (allowed_actions && (allowed_actions_cnt > 0)) ? allowed_actions[a] : priv.is_ldf ? a : (a+1);
-      if (priv.metaoverride && priv.metaoverride->_foreach_action) {
-        foreach_action_from_cache(priv,t,a_name);
-        if (priv.memo_foreach_action[t]) {
-          cdbg << "@ memo_foreach_action: t=" << t << ", a=" << a << ", cost=" << priv.memo_foreach_action[t]->get(a).cost << endl;
-          a_cost = priv.memo_foreach_action[t]->get(a).cost;
-        }
-      }
+        priv.learn_condition_on.end = priv.learn_condition_on.begin + condition_on_cnt;   // allow .size() to be used in lieu of _cnt
 
-      a = a_name;
-      
-      if (priv.metaoverride && priv.metaoverride->_post_prediction)
-        priv.metaoverride->_post_prediction(*priv.metaoverride->sch, t-priv.meta_t, a, a_cost);
-      return a;
-    }
+        memcpy(priv.learn_condition_on.begin, condition_on, condition_on_cnt * sizeof(ptag));
 
-    if ((priv.state == LEARN) && (t > priv.learn_t) && (priv.rollout_num_steps > 0) && (priv.loss_declared_cnt >= priv.rollout_num_steps)) {
-      cdbg << "... skipping" << endl;
-      action a = priv.is_ldf ? 0 : ((allowed_actions && (allowed_actions_cnt > 0)) ? allowed_actions[0] : 1);
-      if (priv.metaoverride && priv.metaoverride->_post_prediction)
-        priv.metaoverride->_post_prediction(*priv.metaoverride->sch, t-priv.meta_t, a, 0.);
-      if (priv.metaoverride && priv.metaoverride->_foreach_action)
-        foreach_action_from_cache(priv, t);
-      a_cost = 0.;
-      return a;
-    }
-
-    
-    if ((priv.state == INIT_TRAIN) ||
-        (priv.state == INIT_TEST) ||
-        ((priv.state == LEARN) && (t > priv.learn_t))) {
-      // we actually need to run the policy
-      
-      int policy = choose_policy(priv);
-      action a = 0;
-
-      cdbg << "executing policy " << policy << endl;
-      
-      bool gte_here = (priv.state == INIT_TRAIN) && (priv.rollout_method == NO_ROLLOUT) && (oracle_actions_cnt > 0);
-      a_cost = 0.;
-      bool skip = false;
-      
-      if (priv.metaoverride && priv.metaoverride->_maybe_override_prediction && (priv.state != LEARN)) { // if LEARN and t>learn_t,then we cannot allow overrides!
-        skip = priv.metaoverride->_maybe_override_prediction(*priv.metaoverride->sch, t-priv.meta_t, a, a_cost);
-        cdbg << "maybe_override_prediction --> " << skip << ", a=" << a << ", a_cost=" << a_cost << endl;
-        if (skip && need_memo_foreach_action(priv))
-          priv.memo_foreach_action.push_back(nullptr);
-      }
-      
-      if ((!skip) && (policy == -1)) 
-        a = choose_oracle_action(priv, ec_cnt, oracle_actions, oracle_actions_cnt, allowed_actions, allowed_actions_cnt);   // TODO: we probably want to actually get costs for oracle actions???
-
-      bool need_fea = (policy == -1) && priv.metaoverride && priv.metaoverride->_foreach_action;
-      
-      if ((policy >= 0) || gte_here || need_fea) { // the last case is we need to do foreach action
-        int learner = select_learner(priv, policy, learner_id, false, priv.state != INIT_TEST);
-
-        ensure_size(priv.condition_on_actions, condition_on_cnt);
         for (size_t i=0; i<condition_on_cnt; i++)
-          priv.condition_on_actions[i].a = ((1 <= condition_on[i]) && (condition_on[i] < priv.ptag_to_action.size())) ? priv.ptag_to_action[condition_on[i]] : 0;
-        // TODO: store floats
+          push_at(priv.learn_condition_on_act
+                  , actionpp(((1 <= condition_on[i]) && (condition_on[i] < priv.ptag_to_action.size())) ? priv.ptag_to_action[condition_on[i]] : 0)
+                  , i);  // TODO pp
 
-        bool not_test = priv.all->training && !ecs[0].test_only;
-
-        if ((!skip) && (!need_fea) && not_test && cached_action_store_or_find(priv, mytag, condition_on, condition_on_names, priv.condition_on_actions.begin, condition_on_cnt, policy, learner_id, a, false, a_cost))
-          // if this succeeded, 'a' has the right action
-          priv.total_cache_hits++;
-        else { // we need to predict, and then cache, and maybe run foreach_action
-          size_t start_K = (priv.is_ldf && COST_SENSITIVE::ec_is_example_header(ecs[0])) ? 1 : 0;
-          if (priv.auto_condition_features)
-            for (size_t n=start_K; n<ec_cnt; n++)
-              add_example_conditioning(priv, ecs[n], condition_on_cnt, condition_on_names, priv.condition_on_actions.begin);
-
-          if (((!skip) && (policy >= 0)) || need_fea)   // only make a prediction if we're going to use the output
-            a = priv.is_ldf ? single_prediction_LDF(priv, ecs, ec_cnt, learner, a_cost, need_fea ? a : (action)-1)
-                            : single_prediction_notLDF(priv, *ecs, learner, allowed_actions, allowed_actions_cnt, a_cost, need_fea ? a : (action)-1);
-
-          if (need_fea) {
-            // TODO this
-
-          }
-          
-          if (gte_here) {
-            cdbg << "INIT_TRAIN, NO_ROLLOUT, at least one oracle_actions" << endl;
-            // we can generate a training example _NOW_ because we're not doing rollouts
-            //allowed_actions_to_losses(priv, ec_cnt, allowed_actions, allowed_actions_cnt, oracle_actions, oracle_actions_cnt, losses);
-            allowed_actions_to_label(priv, ec_cnt, allowed_actions, allowed_actions_cnt, oracle_actions, oracle_actions_cnt, priv.gte_label);
-            //cerr << "priv.gte_label = ["; for (size_t i=0; i<priv.gte_label.cs.costs.size(); i++) cerr << ' ' << priv.gte_label.cs.costs[i].class_index << ':' << priv.gte_label.cs.costs[i].x; cerr << " ]" << endl;
-            
-            priv.learn_ec_ref = ecs;
-            priv.learn_ec_ref_cnt = ec_cnt;
-            if (allowed_actions) {
-              ensure_size(priv.learn_allowed_actions, allowed_actions_cnt); // TODO: do we really need this?
-              memcpy(priv.learn_allowed_actions.begin, allowed_actions, allowed_actions_cnt * sizeof(action));
-            }
-            size_t old_learner_id = priv.learn_learner_id;
-            priv.learn_learner_id = learner_id;
-            generate_training_example(priv, priv.gte_label, 1., false);  // this is false because the conditioning has already been added!
-            priv.learn_learner_id = old_learner_id;
-          }
-          
-          if (priv.auto_condition_features)
-            for (size_t n=start_K; n<ec_cnt; n++)
-              del_example_conditioning(priv, ecs[n]);
-
-          if (not_test && (!skip))
-            cached_action_store_or_find(priv, mytag, condition_on, condition_on_names, priv.condition_on_actions.begin, condition_on_cnt, policy, learner_id, a, true, a_cost);
+        if (condition_on_names == nullptr) {
+          ensure_size(priv.learn_condition_on_names, 1);
+          priv.learn_condition_on_names[0] = 0;
+        } else {
+          ensure_size(priv.learn_condition_on_names, strlen(condition_on_names)+1);
+          strcpy(priv.learn_condition_on_names.begin, condition_on_names);
         }
       }
 
-      if (priv.state == INIT_TRAIN)
-        priv.train_trajectory.push_back( scored_action(a, a_cost) ); // note the action for future reference
-      
-      if (priv.metaoverride && priv.metaoverride->_post_prediction)
-        priv.metaoverride->_post_prediction(*priv.metaoverride->sch, t-priv.meta_t, a, a_cost);
-      
-      return a;
+      if (allowed_actions && (allowed_actions_cnt > 0)) {
+        ensure_size(priv.learn_allowed_actions, allowed_actions_cnt);
+        memcpy(priv.learn_allowed_actions.begin, allowed_actions, allowed_actions_cnt*sizeof(action));
+        cdbg_print_array("in LEARN, learn_allowed_actions", priv.learn_allowed_actions);
+      }
     }
 
-    THROW("error: predict called in unknown state");
+    assert((allowed_actions_cnt == 0) || (a < allowed_actions_cnt));
+
+    a_cost = 0.;
+    action a_name = (allowed_actions && (allowed_actions_cnt > 0)) ? allowed_actions[a] : priv.is_ldf ? a : (a+1);
+    if (priv.metaoverride && priv.metaoverride->_foreach_action) {
+      foreach_action_from_cache(priv,t,a_name);
+      if (priv.memo_foreach_action[t]) {
+        cdbg << "@ memo_foreach_action: t=" << t << ", a=" << a << ", cost=" << priv.memo_foreach_action[t]->get(a).cost << endl;
+        a_cost = priv.memo_foreach_action[t]->get(a).cost;
+      }
+    }
+
+    a = a_name;
+
+    if (priv.metaoverride && priv.metaoverride->_post_prediction)
+      priv.metaoverride->_post_prediction(*priv.metaoverride->sch, t-priv.meta_t, a, a_cost);
+    return a;
   }
-  
-  inline bool cmp_size_t(const size_t a, const size_t b) { return a < b; }
-  inline bool cmp_size_t_pair(const pair<size_t,size_t>& a, const pair<size_t,size_t>& b) { return ((a.first == b.first) && (a.second < b.second)) || (a.first < b.first); }
-  void get_training_timesteps(search_private& priv, v_array<size_t>& timesteps) {
-    timesteps.erase();
 
-    // if there's active learning, we need to 
-    if (priv.subsample_timesteps <= -1) {
-      for (size_t i=0; i<priv.active_uncertainty.size(); i++)
-        if (frand48() > priv.active_uncertainty[i].first)
-          timesteps.push_back(priv.active_uncertainty[i].second - 1);
-          /*
-        float k = (float)priv.total_examples_generated;
-        priv.ec_seq[t]->revert_weight = priv.all->loss->getRevertingWeight(priv.all->sd, priv.ec_seq[t].pred.scalar, priv.all->eta / powf(k, priv.all->power_t));
-        float importance = query_decision(active_str, *priv.ec_seq[t], k);
-        if (importance > 0.)
-          timesteps.push_back(pair<size_t,size_t>(0,t));
-          */
+  if ((priv.state == LEARN) && (t > priv.learn_t) && (priv.rollout_num_steps > 0) && (priv.loss_declared_cnt >= priv.rollout_num_steps)) {
+    cdbg << "... skipping" << endl;
+    action a = priv.is_ldf ? 0 : ((allowed_actions && (allowed_actions_cnt > 0)) ? allowed_actions[0] : 1);
+    if (priv.metaoverride && priv.metaoverride->_post_prediction)
+      priv.metaoverride->_post_prediction(*priv.metaoverride->sch, t-priv.meta_t, a, 0.);
+    if (priv.metaoverride && priv.metaoverride->_foreach_action)
+      foreach_action_from_cache(priv, t);
+    a_cost = 0.;
+    return a;
+  }
+
+
+  if ((priv.state == INIT_TRAIN) ||
+      (priv.state == INIT_TEST) ||
+      ((priv.state == LEARN) && (t > priv.learn_t))) {
+    // we actually need to run the policy
+
+    int policy = choose_policy(priv);
+    action a = 0;
+
+    cdbg << "executing policy " << policy << endl;
+
+    bool gte_here = (priv.state == INIT_TRAIN) && (priv.rollout_method == NO_ROLLOUT) && (oracle_actions_cnt > 0);
+    a_cost = 0.;
+    bool skip = false;
+
+    if (priv.metaoverride && priv.metaoverride->_maybe_override_prediction && (priv.state != LEARN)) { // if LEARN and t>learn_t,then we cannot allow overrides!
+      skip = priv.metaoverride->_maybe_override_prediction(*priv.metaoverride->sch, t-priv.meta_t, a, a_cost);
+      cdbg << "maybe_override_prediction --> " << skip << ", a=" << a << ", a_cost=" << a_cost << endl;
+      if (skip && need_memo_foreach_action(priv))
+        priv.memo_foreach_action.push_back(nullptr);
     }
-    // if there's no subsampling to do, just return [0,T)
-    else
-    if (priv.subsample_timesteps <= 0)
-      for (size_t t=0; t<priv.T; t++)
+
+    if ((!skip) && (policy == -1))
+      a = choose_oracle_action(priv, ec_cnt, oracle_actions, oracle_actions_cnt, allowed_actions, allowed_actions_cnt);   // TODO: we probably want to actually get costs for oracle actions???
+
+    bool need_fea = (policy == -1) && priv.metaoverride && priv.metaoverride->_foreach_action;
+
+    if ((policy >= 0) || gte_here || need_fea) { // the last case is we need to do foreach action
+      int learner = select_learner(priv, policy, learner_id, false, priv.state != INIT_TEST);
+
+      ensure_size(priv.condition_on_actions, condition_on_cnt);
+      for (size_t i=0; i<condition_on_cnt; i++)
+        priv.condition_on_actions[i].a = ((1 <= condition_on[i]) && (condition_on[i] < priv.ptag_to_action.size())) ? priv.ptag_to_action[condition_on[i]] : 0;
+      // TODO: store floats
+
+      bool not_test = priv.all->training && !ecs[0].test_only;
+
+      if ((!skip) && (!need_fea) && not_test && cached_action_store_or_find(priv, mytag, condition_on, condition_on_names, priv.condition_on_actions.begin, condition_on_cnt, policy, learner_id, a, false, a_cost))
+        // if this succeeded, 'a' has the right action
+        priv.total_cache_hits++;
+      else { // we need to predict, and then cache, and maybe run foreach_action
+        size_t start_K = (priv.is_ldf && COST_SENSITIVE::ec_is_example_header(ecs[0])) ? 1 : 0;
+        if (priv.auto_condition_features)
+          for (size_t n=start_K; n<ec_cnt; n++)
+            add_example_conditioning(priv, ecs[n], condition_on_cnt, condition_on_names, priv.condition_on_actions.begin);
+
+        if (((!skip) && (policy >= 0)) || need_fea)   // only make a prediction if we're going to use the output
+          a = priv.is_ldf ? single_prediction_LDF(priv, ecs, ec_cnt, learner, a_cost, need_fea ? a : (action)-1)
+                : single_prediction_notLDF(priv, *ecs, learner, allowed_actions, allowed_actions_cnt, a_cost, need_fea ? a : (action)-1);
+
+        if (need_fea) {
+          // TODO this
+
+        }
+
+        if (gte_here) {
+          cdbg << "INIT_TRAIN, NO_ROLLOUT, at least one oracle_actions" << endl;
+          // we can generate a training example _NOW_ because we're not doing rollouts
+          //allowed_actions_to_losses(priv, ec_cnt, allowed_actions, allowed_actions_cnt, oracle_actions, oracle_actions_cnt, losses);
+          allowed_actions_to_label(priv, ec_cnt, allowed_actions, allowed_actions_cnt, oracle_actions, oracle_actions_cnt, priv.gte_label);
+          //cerr << "priv.gte_label = ["; for (size_t i=0; i<priv.gte_label.cs.costs.size(); i++) cerr << ' ' << priv.gte_label.cs.costs[i].class_index << ':' << priv.gte_label.cs.costs[i].x; cerr << " ]" << endl;
+
+          priv.learn_ec_ref = ecs;
+          priv.learn_ec_ref_cnt = ec_cnt;
+          if (allowed_actions) {
+            ensure_size(priv.learn_allowed_actions, allowed_actions_cnt); // TODO: do we really need this?
+            memcpy(priv.learn_allowed_actions.begin, allowed_actions, allowed_actions_cnt * sizeof(action));
+          }
+          size_t old_learner_id = priv.learn_learner_id;
+          priv.learn_learner_id = learner_id;
+          generate_training_example(priv, priv.gte_label, 1., false);  // this is false because the conditioning has already been added!
+          priv.learn_learner_id = old_learner_id;
+        }
+
+        if (priv.auto_condition_features)
+          for (size_t n=start_K; n<ec_cnt; n++)
+            del_example_conditioning(priv, ecs[n]);
+
+        if (not_test && (!skip))
+          cached_action_store_or_find(priv, mytag, condition_on, condition_on_names, priv.condition_on_actions.begin, condition_on_cnt, policy, learner_id, a, true, a_cost);
+      }
+    }
+
+    if (priv.state == INIT_TRAIN)
+      priv.train_trajectory.push_back( scored_action(a, a_cost) ); // note the action for future reference
+
+    if (priv.metaoverride && priv.metaoverride->_post_prediction)
+      priv.metaoverride->_post_prediction(*priv.metaoverride->sch, t-priv.meta_t, a, a_cost);
+
+    return a;
+  }
+
+  THROW("error: predict called in unknown state");
+}
+
+inline bool cmp_size_t(const size_t a, const size_t b) {
+  return a < b;
+}
+inline bool cmp_size_t_pair(const pair<size_t,size_t>& a, const pair<size_t,size_t>& b) {
+  return ((a.first == b.first) && (a.second < b.second)) || (a.first < b.first);
+}
+void get_training_timesteps(search_private& priv, v_array<size_t>& timesteps) {
+  timesteps.erase();
+
+  // if there's active learning, we need to
+  if (priv.subsample_timesteps <= -1) {
+    for (size_t i=0; i<priv.active_uncertainty.size(); i++)
+      if (frand48() > priv.active_uncertainty[i].first)
+        timesteps.push_back(priv.active_uncertainty[i].second - 1);
+    /*
+    float k = (float)priv.total_examples_generated;
+    priv.ec_seq[t]->revert_weight = priv.all->loss->getRevertingWeight(priv.all->sd, priv.ec_seq[t].pred.scalar, priv.all->eta / powf(k, priv.all->power_t));
+    float importance = query_decision(active_str, *priv.ec_seq[t], k);
+    if (importance > 0.)
+    timesteps.push_back(pair<size_t,size_t>(0,t));
+    */
+  }
+  // if there's no subsampling to do, just return [0,T)
+  else if (priv.subsample_timesteps <= 0)
+    for (size_t t=0; t<priv.T; t++)
+      timesteps.push_back(t);
+
+  // if subsample in (0,1) then pick steps with that probability, but ensuring there's at least one!
+  else if (priv.subsample_timesteps < 1) {
+    for (size_t t=0; t<priv.T; t++)
+      if (frand48() <= priv.subsample_timesteps)
         timesteps.push_back(t);
 
-    // if subsample in (0,1) then pick steps with that probability, but ensuring there's at least one!
-    else if (priv.subsample_timesteps < 1) {
-      for (size_t t=0; t<priv.T; t++)
-        if (frand48() <= priv.subsample_timesteps)
-          timesteps.push_back(t);
+    if (timesteps.size() == 0) // ensure at least one
+      timesteps.push_back((size_t)(frand48() * priv.T));
+  }
 
-      if (timesteps.size() == 0) // ensure at least one
-        timesteps.push_back((size_t)(frand48() * priv.T));
+  // finally, if subsample >= 1, then pick (int) that many uniformly at random without replacement; could use an LFSR but why? :P
+  else {
+    while ((timesteps.size() < (size_t)priv.subsample_timesteps) &&
+           (timesteps.size() < priv.T)) {
+      size_t t = (size_t)(frand48() * (float)priv.T);
+      if (! v_array_contains(timesteps, t))
+        timesteps.push_back(t);
     }
-
-    // finally, if subsample >= 1, then pick (int) that many uniformly at random without replacement; could use an LFSR but why? :P
-    else {
-      while ((timesteps.size() < (size_t)priv.subsample_timesteps) &&
-             (timesteps.size() < priv.T)) {
-        size_t t = (size_t)(frand48() * (float)priv.T);
-        if (! v_array_contains(timesteps, t))
-          timesteps.push_back(t);
-      }
-      std::sort(timesteps.begin, timesteps.end, cmp_size_t);
-    }
+    std::sort(timesteps.begin, timesteps.end, cmp_size_t);
   }
-  
-  struct final_item {
-    v_array<scored_action> * prefix;
-    string str;
-    float total_cost;
-    final_item(v_array<scored_action>*p,string s,float ic) : prefix(p), str(s), total_cost(ic) {}
-  };
+}
 
-  
-  void free_action_prefix(action_prefix* px) {
-    px->delete_v();
-    delete px;
+struct final_item {
+  v_array<scored_action> * prefix;
+  string str;
+  float total_cost;
+  final_item(v_array<scored_action>*p,string s,float ic) : prefix(p), str(s), total_cost(ic) {}
+};
+
+
+void free_action_prefix(action_prefix* px) {
+  px->delete_v();
+  delete px;
+}
+
+void free_final_item(final_item* p) {
+  p->prefix->delete_v();
+  delete p->prefix;
+  delete p;
+}
+
+void BaseTask::Run() {
+  search_private& priv = *sch->priv;
+  // make sure output is correct
+  bool old_should_produce_string = priv.should_produce_string;
+  if (! _final_run && ! _with_output_string) priv.should_produce_string = false;
+  // if this isn't a final run, it shouldn't count for loss
+  float old_test_loss = priv.test_loss;
+  //float old_learn_loss = priv.learn_loss;
+  priv.learn_loss *= 0.5;
+  float old_train_loss = priv.train_loss;
+
+  if (priv.should_produce_string)
+    priv.pred_string->str("");
+
+  priv.t = 0;
+  priv.metaoverride = this;
+  priv.task->run(*sch, ec);
+  priv.metaoverride = nullptr;
+  priv.meta_t += priv.t;
+
+  // restore
+  if (_with_output_string && old_should_produce_string)
+    _with_output_string(*sch, *priv.pred_string);
+
+  priv.should_produce_string = old_should_produce_string;
+  if (! _final_run) {
+    priv.test_loss = old_test_loss;
+    //priv.learn_loss = old_learn_loss;
+    priv.train_loss = old_train_loss;
   }
+}
 
-  void free_final_item(final_item* p) {
-    p->prefix->delete_v();
-    delete p->prefix;
-    delete p;
-  }
-  
-  void BaseTask::Run() {
-    search_private& priv = *sch->priv;
-    // make sure output is correct
-    bool old_should_produce_string = priv.should_produce_string;
-    if (! _final_run && ! _with_output_string) priv.should_produce_string = false;
-    // if this isn't a final run, it shouldn't count for loss
-    float old_test_loss = priv.test_loss;
-    //float old_learn_loss = priv.learn_loss;
-    priv.learn_loss *= 0.5;
-    float old_train_loss = priv.train_loss;
+void run_task(search& sch, vector<example*>& ec) {
+  search_private& priv = *sch.priv;
+  if (priv.metatask && (priv.state != GET_TRUTH_STRING))
+    priv.metatask->run(sch, ec);
+  else
+    priv.task->run(sch, ec);
+}
 
-    if (priv.should_produce_string)
-      priv.pred_string->str("");
-    
-    priv.t = 0;
-    priv.metaoverride = this;
-    priv.task->run(*sch, ec);
-    priv.metaoverride = nullptr;
-    priv.meta_t += priv.t;
+template <bool is_learn>
+void train_single_example(search& sch, bool is_test_ex, bool is_holdout_ex) {
+  search_private& priv = *sch.priv;
+  vw&all = *priv.all;
+  bool ran_test = false;  // we must keep track so that even if we skip test, we still update # of examples seen
 
-    // restore
-    if (_with_output_string && old_should_produce_string)
-      _with_output_string(*sch, *priv.pred_string);
-          
-    priv.should_produce_string = old_should_produce_string;
-    if (! _final_run) {
-      priv.test_loss = old_test_loss;
-      //priv.learn_loss = old_learn_loss;
-      priv.train_loss = old_train_loss;
-    }
-  }
-  
-  void run_task(search& sch, vector<example*>& ec) {
-    search_private& priv = *sch.priv;
-    if (priv.metatask && (priv.state != GET_TRUTH_STRING))
-      priv.metatask->run(sch, ec);
-    else
-      priv.task->run(sch, ec);
-  }
-  
-  template <bool is_learn>
-  void train_single_example(search& sch, bool is_test_ex, bool is_holdout_ex) {
-    search_private& priv = *sch.priv;
-    vw&all = *priv.all;
-    bool ran_test = false;  // we must keep track so that even if we skip test, we still update # of examples seen
+  //if (! priv.no_caching)
+  clear_cache_hash_map(priv);
 
-    //if (! priv.no_caching)
-      clear_cache_hash_map(priv);
+  cdbg << "is_test_ex=" << is_test_ex << " vw_is_main=" << all.vw_is_main << endl;
+  cdbg << "must_run_test = " << must_run_test(all, priv.ec_seq, is_test_ex) << endl;
+  // do an initial test pass to compute output (and loss)
+  if (must_run_test(all, priv.ec_seq, is_test_ex)) {
+    cdbg << "======================================== INIT TEST (" << priv.current_policy << "," << priv.read_example_last_pass << ") ========================================" << endl;
 
-    cdbg << "is_test_ex=" << is_test_ex << " vw_is_main=" << all.vw_is_main << endl;
-    cdbg << "must_run_test = " << must_run_test(all, priv.ec_seq, is_test_ex) << endl;
-    // do an initial test pass to compute output (and loss)
-    if (must_run_test(all, priv.ec_seq, is_test_ex)) {
-      cdbg << "======================================== INIT TEST (" << priv.current_policy << "," << priv.read_example_last_pass << ") ========================================" << endl;
+    ran_test = true;
 
-      ran_test = true;
-      
-      // do the prediction
-      reset_search_structure(priv);
-      priv.state = INIT_TEST;
-      priv.should_produce_string = might_print_update(all) || (all.final_prediction_sink.size() > 0) || (all.raw_prediction > 0);
-      priv.pred_string->str("");
-      priv.test_action_sequence.clear();
-      run_task(sch, priv.ec_seq);
-
-      // accumulate loss
-      if (! is_test_ex) 
-        all.sd->update(priv.ec_seq[0]->test_only, priv.test_loss, 1.f, priv.num_features);
-      
-      // generate output
-      for (int* sink = all.final_prediction_sink.begin; sink != all.final_prediction_sink.end; ++sink)
-        all.print_text((int)*sink, priv.pred_string->str(), priv.ec_seq[0]->tag);
-
-      if (all.raw_prediction > 0)
-        all.print_text(all.raw_prediction, "", priv.ec_seq[0]->tag);
-    }
-
-    // if we're not training, then we're done!
-    if ((!is_learn) || is_test_ex || is_holdout_ex || priv.ec_seq[0]->test_only || (!priv.all->training))
-      return;
-
-    // SPEEDUP: if the oracle was never called, we can skip this!
-    
-    // do a pass over the data allowing oracle
-    cdbg << "======================================== INIT TRAIN (" << priv.current_policy << "," << priv.read_example_last_pass << ") ========================================" << endl;
-    //cerr << "training" << endl;
-
-    clear_cache_hash_map(priv);
+    // do the prediction
     reset_search_structure(priv);
-    clear_memo_foreach_action(priv);
-    priv.state = INIT_TRAIN;
-    priv.active_uncertainty.erase();
-    priv.train_trajectory.erase();  // this is where we'll store the training sequence
+    priv.state = INIT_TEST;
+    priv.should_produce_string = might_print_update(all) || (all.final_prediction_sink.size() > 0) || (all.raw_prediction > 0);
+    priv.pred_string->str("");
+    priv.test_action_sequence.clear();
     run_task(sch, priv.ec_seq);
 
-    if (!ran_test) {  // was  && !priv.ec_seq[0]->test_only) { but we know it's not test_only
-      all.sd->weighted_examples += 1.f;
-      all.sd->total_features += priv.num_features;
-      all.sd->sum_loss += priv.test_loss;
-      all.sd->sum_loss_since_last_dump += priv.test_loss;
-      all.sd->example_number++;
-    }
-    
-    // if there's nothing to train on, we're done!
-    if ((priv.loss_declared_cnt == 0) || (priv.t+priv.meta_t == 0) || (priv.rollout_method == NO_ROLLOUT)) {// TODO: make sure NO_ROLLOUT works with beam!
-      return;
-    }
-    
-    // otherwise, we have some learn'in to do!      
-    cdbg << "======================================== LEARN (" << priv.current_policy << "," << priv.read_example_last_pass << ") ========================================" << endl;
-    priv.T = priv.metatask ? priv.meta_t : priv.t;
-    get_training_timesteps(priv, priv.timesteps);
-    cdbg << "train_trajectory.size() = " << priv.train_trajectory.size() << ":\t";
-    cdbg_print_array<scored_action>("", priv.train_trajectory);
-    //cdbg << "memo_foreach_action = " << priv.memo_foreach_action << endl;
-    for (size_t i=0; i<priv.memo_foreach_action.size(); i++) {
-      cdbg << "memo_foreach_action[" << i << "] = ";
-      if (priv.memo_foreach_action[i]) cdbg << *priv.memo_foreach_action[i];
-      else cdbg << "null";
-      cdbg << endl;
-    }
+    // accumulate loss
+    if (! is_test_ex)
+      all.sd->update(priv.ec_seq[0]->test_only, priv.test_loss, 1.f, priv.num_features);
 
-    if (priv.cb_learner) priv.learn_losses.cb.costs.erase();
-    else                 priv.learn_losses.cs.costs.erase();
+    // generate output
+    for (int* sink = all.final_prediction_sink.begin; sink != all.final_prediction_sink.end; ++sink)
+      all.print_text((int)*sink, priv.pred_string->str(), priv.ec_seq[0]->tag);
 
-    for (size_t tid=0; tid<priv.timesteps.size(); tid++) {
-      cdbg << "timestep = " << priv.timesteps[tid] << " [" << tid << "/" << priv.timesteps.size() << "]" << endl;
-
-      if (priv.metatask && !priv.memo_foreach_action[tid]) {
-        cdbg << "skipping because it looks like this was overridden by metatask" << endl;
-        continue;
-      }
-
-      priv.learn_a_idx = 0;
-      priv.done_with_all_actions = false;
-      // for each action, roll out to get a loss
-      while (! priv.done_with_all_actions) {
-        reset_search_structure(priv);
-        priv.state = LEARN;
-        priv.learn_t = priv.timesteps[tid];
-        cdbg << "-------------------------------------------------------------------------------------" << endl;
-        cdbg << "learn_t = " << priv.learn_t << ", learn_a_idx = " << priv.learn_a_idx << endl;
-        run_task(sch, priv.ec_seq);
-        //cerr_print_array("in GENER, learn_allowed_actions", priv.learn_allowed_actions);
-        float this_loss = priv.learn_loss;
-        cs_cost_push_back(priv.cb_learner, priv.learn_losses, priv.is_ldf ? (priv.learn_a_idx - 1) : priv.learn_a_idx, this_loss);
-        //                          (priv.learn_allowed_actions.size() > 0) ? priv.learn_allowed_actions[priv.learn_a_idx-1] : priv.is_ldf ? (priv.learn_a_idx-1) : (priv.learn_a_idx),
-        //                           priv.learn_loss);
-      }
-      // now we can make a training example
-      if (priv.learn_allowed_actions.size() > 0) {
-        for (size_t i=0; i<priv.learn_allowed_actions.size(); i++) {
-          priv.learn_losses.cs.costs[i].class_index = priv.learn_allowed_actions[i];
-        }
-      }
-      //float min_loss = 0.;
-      //if (priv.metatask)
-      //  for (size_t aid=0; aid<priv.memo_foreach_action[tid]->size(); aid++)
-      //    min_loss = MIN(min_loss, priv.memo_foreach_action[tid]->get(aid).cost);
-      generate_training_example(priv, priv.learn_losses, 1., true); // , min_loss);  // TODO: weight
-      if (! priv.examples_dont_change)
-        for (size_t n=0; n<priv.learn_ec_copy.size(); n++) {
-          if (sch.priv->is_ldf) CS::cs_label.delete_label(&priv.learn_ec_copy[n].l.cs);
-          else                  MC::mc_label.delete_label(&priv.learn_ec_copy[n].l.multi);
-        }
-      if (priv.cb_learner) priv.learn_losses.cb.costs.erase();
-      else                 priv.learn_losses.cs.costs.erase();
-    }
+    if (all.raw_prediction > 0)
+      all.print_text(all.raw_prediction, "", priv.ec_seq[0]->tag);
   }
 
+  // if we're not training, then we're done!
+  if ((!is_learn) || is_test_ex || is_holdout_ex || priv.ec_seq[0]->test_only || (!priv.all->training))
+    return;
 
-  template <bool is_learn>
-  void do_actual_learning(vw&all, search& sch) {
-    search_private& priv = *sch.priv;
+  // SPEEDUP: if the oracle was never called, we can skip this!
 
-    if (priv.ec_seq.size() == 0)
-      return;  // nothing to do :)
+  // do a pass over the data allowing oracle
+  cdbg << "======================================== INIT TRAIN (" << priv.current_policy << "," << priv.read_example_last_pass << ") ========================================" << endl;
+  //cerr << "training" << endl;
 
-    bool is_test_ex = false;
-    bool is_holdout_ex = false;
-    for (size_t i=0; i<priv.ec_seq.size(); i++) {
-      is_test_ex |= priv.label_is_test(priv.ec_seq[i]->l);
-      is_holdout_ex |= priv.ec_seq[i]->test_only;
-      if (is_test_ex && is_holdout_ex) break;
-    }
+  clear_cache_hash_map(priv);
+  reset_search_structure(priv);
+  clear_memo_foreach_action(priv);
+  priv.state = INIT_TRAIN;
+  priv.active_uncertainty.erase();
+  priv.train_trajectory.erase();  // this is where we'll store the training sequence
+  run_task(sch, priv.ec_seq);
 
-    if (priv.task->run_setup) priv.task->run_setup(sch, priv.ec_seq);
-
-    // if we're going to have to print to the screen, generate the "truth" string
-    cdbg << "======================================== GET TRUTH STRING (" << priv.current_policy << "," << priv.read_example_last_pass << ") ========================================" << endl;
-    if (might_print_update(all)) {
-      if (is_test_ex)
-        priv.truth_string->str("**test**");
-      else {
-        reset_search_structure(*sch.priv);
-        priv.state = GET_TRUTH_STRING;
-        priv.should_produce_string = true;
-        priv.truth_string->str("");
-        run_task(sch, priv.ec_seq);
-      }
-    }
-
-    add_neighbor_features(priv);
-    train_single_example<is_learn>(sch, is_test_ex, is_holdout_ex);
-    del_neighbor_features(priv);
-
-    if (priv.task->run_takedown) priv.task->run_takedown(sch, priv.ec_seq);
+  if (!ran_test) {  // was  && !priv.ec_seq[0]->test_only) { but we know it's not test_only
+    all.sd->weighted_examples += 1.f;
+    all.sd->total_features += priv.num_features;
+    all.sd->sum_loss += priv.test_loss;
+    all.sd->sum_loss_since_last_dump += priv.test_loss;
+    all.sd->example_number++;
   }
 
-  template <bool is_learn>
-  void search_predict_or_learn(search& sch, base_learner& base, example& ec) {
-    search_private& priv = *sch.priv;
-    vw* all = priv.all;
-    priv.base_learner = &base;
-    bool is_real_example = true;
+  // if there's nothing to train on, we're done!
+  if ((priv.loss_declared_cnt == 0) || (priv.t+priv.meta_t == 0) || (priv.rollout_method == NO_ROLLOUT)) {// TODO: make sure NO_ROLLOUT works with beam!
+    return;
+  }
 
-    if (example_is_newline(ec) || priv.ec_seq.size() >= all->p->ring_size - 2) {
-      if (priv.ec_seq.size() >= all->p->ring_size - 2) // -2 to give some wiggle room
-        std::cerr << "warning: length of sequence at " << ec.example_counter << " exceeds ring size; breaking apart" << std::endl;
+  // otherwise, we have some learn'in to do!
+  cdbg << "======================================== LEARN (" << priv.current_policy << "," << priv.read_example_last_pass << ") ========================================" << endl;
+  priv.T = priv.metatask ? priv.meta_t : priv.t;
+  get_training_timesteps(priv, priv.timesteps);
+  cdbg << "train_trajectory.size() = " << priv.train_trajectory.size() << ":\t";
+  cdbg_print_array<scored_action>("", priv.train_trajectory);
+  //cdbg << "memo_foreach_action = " << priv.memo_foreach_action << endl;
+  for (size_t i=0; i<priv.memo_foreach_action.size(); i++) {
+    cdbg << "memo_foreach_action[" << i << "] = ";
+    if (priv.memo_foreach_action[i]) cdbg << *priv.memo_foreach_action[i];
+    else cdbg << "null";
+    cdbg << endl;
+  }
 
-      do_actual_learning<is_learn>(*all, sch);
+  if (priv.cb_learner) priv.learn_losses.cb.costs.erase();
+  else                 priv.learn_losses.cs.costs.erase();
 
-      priv.hit_new_pass = false;
-      priv.last_example_was_newline = true;
-      is_real_example = false;
-    } else {
-      if (priv.last_example_was_newline)
-        priv.ec_seq.clear();
-      priv.ec_seq.push_back(&ec);
-      priv.last_example_was_newline = false;
+  for (size_t tid=0; tid<priv.timesteps.size(); tid++) {
+    cdbg << "timestep = " << priv.timesteps[tid] << " [" << tid << "/" << priv.timesteps.size() << "]" << endl;
+
+    if (priv.metatask && !priv.memo_foreach_action[tid]) {
+      cdbg << "skipping because it looks like this was overridden by metatask" << endl;
+      continue;
     }
 
-    if (is_real_example)
-      priv.read_example_last_id = ec.example_counter;
-  }
-
-  void end_pass(search& sch) {
-    search_private& priv = *sch.priv;
-    vw* all = priv.all;
-    priv.hit_new_pass = true;
-    priv.read_example_last_pass++;
-    priv.passes_since_new_policy++;
-
-    if (priv.passes_since_new_policy >= priv.passes_per_policy) {
-      priv.passes_since_new_policy = 0;
-      if(all->training)
-        priv.current_policy++;
-      if (priv.current_policy > priv.total_number_of_policies) {
-        std::cerr << "internal error (bug): too many policies; not advancing" << std::endl;
-        priv.current_policy = priv.total_number_of_policies;
-      }
-      //reset search_trained_nb_policies in options_from_file so it is saved to regressor file later
-      std::stringstream ss;
-      ss << priv.current_policy;
-      VW::cmd_string_replace_value(all->file_options,"--search_trained_nb_policies", ss.str());
-    }
-  }
-
-  void finish_example(vw& all, search& sch, example& ec) {
-    if (ec.end_pass || example_is_newline(ec) || sch.priv->ec_seq.size() >= all.p->ring_size - 2) {
-      print_update(*sch.priv);
-      VW::finish_example(all, &ec);
-      clear_seq(all, *sch.priv);
-    }
-  }
-
-  void end_examples(search& sch) {
-    search_private& priv = *sch.priv;
-    vw* all    = priv.all;
-
-    do_actual_learning<true>(*all, sch);
-
-    if( all->training ) {
-      std::stringstream ss1;
-      std::stringstream ss2;
-      ss1 << ((priv.passes_since_new_policy == 0) ? priv.current_policy : (priv.current_policy+1));
-      //use cmd_string_replace_value in case we already loaded a predictor which had a value stored for --search_trained_nb_policies
-      VW::cmd_string_replace_value(all->file_options,"--search_trained_nb_policies", ss1.str());
-      ss2 << priv.total_number_of_policies;
-      //use cmd_string_replace_value in case we already loaded a predictor which had a value stored for --search_total_nb_policies
-      VW::cmd_string_replace_value(all->file_options,"--search_total_nb_policies", ss2.str());
-    }
-  }
-
-  bool mc_label_is_test(polylabel& lab) {
-    return MC::label_is_test(&lab.multi);
-  }
-
-  void search_initialize(vw* all, search& sch) {
-    search_private& priv = *sch.priv;
-    priv.all = all;
-
-    priv.auto_condition_features = false;
-    priv.auto_hamming_loss = false;
-    priv.examples_dont_change = false;
-    priv.is_ldf = false;
-
-    priv.label_is_test = mc_label_is_test;
-
-    priv.active_uncertainty = v_init< pair<float,size_t> >();
-    priv.xv = false;
-    priv.A = 1;
-    priv.num_learners = 1;
-    priv.cb_learner = false;
-    priv.state = INITIALIZE;
-    priv.learn_learner_id = 0;
-    priv.mix_per_roll_policy = -2;
-
-    priv.t = 0;
-    priv.T = 0;
-    priv.learn_ec_ref = nullptr;
-    priv.learn_ec_ref_cnt = 0;
-    //priv.allowed_actions_cache = nullptr;
-
-    priv.loss_declared_cnt = 0;
-    priv.learn_t = 0;
     priv.learn_a_idx = 0;
     priv.done_with_all_actions = false;
+    // for each action, roll out to get a loss
+    while (! priv.done_with_all_actions) {
+      reset_search_structure(priv);
+      priv.state = LEARN;
+      priv.learn_t = priv.timesteps[tid];
+      cdbg << "-------------------------------------------------------------------------------------" << endl;
+      cdbg << "learn_t = " << priv.learn_t << ", learn_a_idx = " << priv.learn_a_idx << endl;
+      run_task(sch, priv.ec_seq);
+      //cerr_print_array("in GENER, learn_allowed_actions", priv.learn_allowed_actions);
+      float this_loss = priv.learn_loss;
+      cs_cost_push_back(priv.cb_learner, priv.learn_losses, priv.is_ldf ? (priv.learn_a_idx - 1) : priv.learn_a_idx, this_loss);
+      //                          (priv.learn_allowed_actions.size() > 0) ? priv.learn_allowed_actions[priv.learn_a_idx-1] : priv.is_ldf ? (priv.learn_a_idx-1) : (priv.learn_a_idx),
+      //                           priv.learn_loss);
+    }
+    // now we can make a training example
+    if (priv.learn_allowed_actions.size() > 0) {
+      for (size_t i=0; i<priv.learn_allowed_actions.size(); i++) {
+        priv.learn_losses.cs.costs[i].class_index = priv.learn_allowed_actions[i];
+      }
+    }
+    //float min_loss = 0.;
+    //if (priv.metatask)
+    //  for (size_t aid=0; aid<priv.memo_foreach_action[tid]->size(); aid++)
+    //    min_loss = MIN(min_loss, priv.memo_foreach_action[tid]->get(aid).cost);
+    generate_training_example(priv, priv.learn_losses, 1., true); // , min_loss);  // TODO: weight
+    if (! priv.examples_dont_change)
+      for (size_t n=0; n<priv.learn_ec_copy.size(); n++) {
+        if (sch.priv->is_ldf) CS::cs_label.delete_label(&priv.learn_ec_copy[n].l.cs);
+        else                  MC::mc_label.delete_label(&priv.learn_ec_copy[n].l.multi);
+      }
+    if (priv.cb_learner) priv.learn_losses.cb.costs.erase();
+    else                 priv.learn_losses.cs.costs.erase();
+  }
+}
 
-    priv.test_loss = 0.;
-    priv.learn_loss = 0.;
-    priv.train_loss = 0.;
-    
-    priv.force_oracle = false;
-    priv.perturb_oracle = 0.;
-    
-    priv.last_example_was_newline = false;
+
+template <bool is_learn>
+void do_actual_learning(vw&all, search& sch) {
+  search_private& priv = *sch.priv;
+
+  if (priv.ec_seq.size() == 0)
+    return;  // nothing to do :)
+
+  bool is_test_ex = false;
+  bool is_holdout_ex = false;
+  for (size_t i=0; i<priv.ec_seq.size(); i++) {
+    is_test_ex |= priv.label_is_test(priv.ec_seq[i]->l);
+    is_holdout_ex |= priv.ec_seq[i]->test_only;
+    if (is_test_ex && is_holdout_ex) break;
+  }
+
+  if (priv.task->run_setup) priv.task->run_setup(sch, priv.ec_seq);
+
+  // if we're going to have to print to the screen, generate the "truth" string
+  cdbg << "======================================== GET TRUTH STRING (" << priv.current_policy << "," << priv.read_example_last_pass << ") ========================================" << endl;
+  if (might_print_update(all)) {
+    if (is_test_ex)
+      priv.truth_string->str("**test**");
+    else {
+      reset_search_structure(*sch.priv);
+      priv.state = GET_TRUTH_STRING;
+      priv.should_produce_string = true;
+      priv.truth_string->str("");
+      run_task(sch, priv.ec_seq);
+    }
+  }
+
+  add_neighbor_features(priv);
+  train_single_example<is_learn>(sch, is_test_ex, is_holdout_ex);
+  del_neighbor_features(priv);
+
+  if (priv.task->run_takedown) priv.task->run_takedown(sch, priv.ec_seq);
+}
+
+template <bool is_learn>
+void search_predict_or_learn(search& sch, base_learner& base, example& ec) {
+  search_private& priv = *sch.priv;
+  vw* all = priv.all;
+  priv.base_learner = &base;
+  bool is_real_example = true;
+
+  if (example_is_newline(ec) || priv.ec_seq.size() >= all->p->ring_size - 2) {
+    if (priv.ec_seq.size() >= all->p->ring_size - 2) // -2 to give some wiggle room
+      std::cerr << "warning: length of sequence at " << ec.example_counter << " exceeds ring size; breaking apart" << std::endl;
+
+    do_actual_learning<is_learn>(*all, sch);
+
     priv.hit_new_pass = false;
+    priv.last_example_was_newline = true;
+    is_real_example = false;
+  } else {
+    if (priv.last_example_was_newline)
+      priv.ec_seq.clear();
+    priv.ec_seq.push_back(&ec);
+    priv.last_example_was_newline = false;
+  }
 
-    priv.printed_output_header = false;
+  if (is_real_example)
+    priv.read_example_last_id = ec.example_counter;
+}
 
-    priv.should_produce_string = false;
-    priv.pred_string  = new stringstream();
-    priv.truth_string = new stringstream();
-    priv.bad_string_stream = new stringstream();
-    priv.bad_string_stream->clear(priv.bad_string_stream->badbit);
+void end_pass(search& sch) {
+  search_private& priv = *sch.priv;
+  vw* all = priv.all;
+  priv.hit_new_pass = true;
+  priv.read_example_last_pass++;
+  priv.passes_since_new_policy++;
 
-    priv.beta = 0.5;
-    priv.alpha = 1e-10f;
+  if (priv.passes_since_new_policy >= priv.passes_per_policy) {
+    priv.passes_since_new_policy = 0;
+    if(all->training)
+      priv.current_policy++;
+    if (priv.current_policy > priv.total_number_of_policies) {
+      std::cerr << "internal error (bug): too many policies; not advancing" << std::endl;
+      priv.current_policy = priv.total_number_of_policies;
+    }
+    //reset search_trained_nb_policies in options_from_file so it is saved to regressor file later
+    std::stringstream ss;
+    ss << priv.current_policy;
+    VW::cmd_string_replace_value(all->file_options,"--search_trained_nb_policies", ss.str());
+  }
+}
 
-    priv.rollout_method = MIX_PER_ROLL;
-    priv.rollin_method  = MIX_PER_ROLL;
-    priv.subsample_timesteps = 0.;
+void finish_example(vw& all, search& sch, example& ec) {
+  if (ec.end_pass || example_is_newline(ec) || sch.priv->ec_seq.size() >= all.p->ring_size - 2) {
+    print_update(*sch.priv);
+    VW::finish_example(all, &ec);
+    clear_seq(all, *sch.priv);
+  }
+}
 
-    priv.allow_current_policy = true;
+void end_examples(search& sch) {
+  search_private& priv = *sch.priv;
+  vw* all    = priv.all;
+
+  do_actual_learning<true>(*all, sch);
+
+  if( all->training ) {
+    std::stringstream ss1;
+    std::stringstream ss2;
+    ss1 << ((priv.passes_since_new_policy == 0) ? priv.current_policy : (priv.current_policy+1));
+    //use cmd_string_replace_value in case we already loaded a predictor which had a value stored for --search_trained_nb_policies
+    VW::cmd_string_replace_value(all->file_options,"--search_trained_nb_policies", ss1.str());
+    ss2 << priv.total_number_of_policies;
+    //use cmd_string_replace_value in case we already loaded a predictor which had a value stored for --search_total_nb_policies
+    VW::cmd_string_replace_value(all->file_options,"--search_total_nb_policies", ss2.str());
+  }
+}
+
+bool mc_label_is_test(polylabel& lab) {
+  return MC::label_is_test(&lab.multi);
+}
+
+void search_initialize(vw* all, search& sch) {
+  search_private& priv = *sch.priv;
+  priv.all = all;
+
+  priv.auto_condition_features = false;
+  priv.auto_hamming_loss = false;
+  priv.examples_dont_change = false;
+  priv.is_ldf = false;
+
+  priv.label_is_test = mc_label_is_test;
+
+  priv.active_uncertainty = v_init< pair<float,size_t> >();
+  priv.xv = false;
+  priv.A = 1;
+  priv.num_learners = 1;
+  priv.cb_learner = false;
+  priv.state = INITIALIZE;
+  priv.learn_learner_id = 0;
+  priv.mix_per_roll_policy = -2;
+
+  priv.t = 0;
+  priv.T = 0;
+  priv.learn_ec_ref = nullptr;
+  priv.learn_ec_ref_cnt = 0;
+  //priv.allowed_actions_cache = nullptr;
+
+  priv.loss_declared_cnt = 0;
+  priv.learn_t = 0;
+  priv.learn_a_idx = 0;
+  priv.done_with_all_actions = false;
+
+  priv.test_loss = 0.;
+  priv.learn_loss = 0.;
+  priv.train_loss = 0.;
+
+  priv.force_oracle = false;
+  priv.perturb_oracle = 0.;
+
+  priv.last_example_was_newline = false;
+  priv.hit_new_pass = false;
+
+  priv.printed_output_header = false;
+
+  priv.should_produce_string = false;
+  priv.pred_string  = new stringstream();
+  priv.truth_string = new stringstream();
+  priv.bad_string_stream = new stringstream();
+  priv.bad_string_stream->clear(priv.bad_string_stream->badbit);
+
+  priv.beta = 0.5;
+  priv.alpha = 1e-10f;
+
+  priv.rollout_method = MIX_PER_ROLL;
+  priv.rollin_method  = MIX_PER_ROLL;
+  priv.subsample_timesteps = 0.;
+
+  priv.allow_current_policy = true;
+  priv.adaptive_beta = true;
+  priv.passes_per_policy = 1;     //this should be set to the same value as --passes for dagger
+
+  priv.current_policy = 0;
+
+  priv.num_features = 0;
+  priv.total_number_of_policies = 1;
+  priv.read_example_last_id = 0;
+  priv.passes_per_policy = 0;
+  priv.read_example_last_pass = 0;
+  priv.total_examples_generated = 0;
+  priv.total_predictions_made = 0;
+  priv.total_cache_hits = 0;
+
+  priv.history_length = 1;
+  priv.acset.max_bias_ngram_length = 1;
+  priv.acset.max_quad_ngram_length = 0;
+  priv.acset.feature_value = 1.;
+
+  scored_action sa((action)-1,0.);
+  priv.cache_hash_map.set_default_value(sa);
+  priv.cache_hash_map.set_equivalent(cached_item_equivalent);
+
+  priv.task = nullptr;
+  sch.task_data = nullptr;
+
+  priv.empty_example = VW::alloc_examples(sizeof(CS::label), 1);
+  CS::cs_label.default_label(&priv.empty_example->l.cs);
+  priv.empty_example->in_use = true;
+  CS::cs_label.default_label(&priv.empty_cs_label);
+
+  priv.rawOutputStringStream = new stringstream(priv.rawOutputString);
+}
+
+void search_finish(search& sch) {
+  search_private& priv = *sch.priv;
+  cdbg << "search_finish" << endl;
+
+  clear_cache_hash_map(priv);
+
+  delete priv.truth_string;
+  delete priv.pred_string;
+  delete priv.bad_string_stream;
+  priv.neighbor_features.delete_v();
+  priv.timesteps.delete_v();
+  if (priv.cb_learner) priv.learn_losses.cb.costs.delete_v();
+  else                 priv.learn_losses.cs.costs.delete_v();
+  if (priv.cb_learner) priv.gte_label.cb.costs.delete_v();
+  else                 priv.gte_label.cs.costs.delete_v();
+
+  priv.condition_on_actions.delete_v(); // TODO: delete floats
+  priv.learn_allowed_actions.delete_v();
+  priv.ldf_test_label.costs.delete_v();
+
+  if (priv.cb_learner)
+    priv.allowed_actions_cache->cb.costs.delete_v();
+  else
+    priv.allowed_actions_cache->cs.costs.delete_v();
+
+  priv.train_trajectory.delete_v();
+  priv.ptag_to_action.delete_v();
+  clear_memo_foreach_action(priv);
+  priv.memo_foreach_action.delete_v();
+
+  VW::dealloc_example(CS::cs_label.delete_label, *(priv.empty_example));
+  free(priv.empty_example);
+
+  priv.ec_seq.clear();
+
+  // destroy copied examples if we needed them
+  if (! priv.examples_dont_change) {
+    void (*delete_label)(void*) = priv.is_ldf ? CS::cs_label.delete_label : MC::mc_label.delete_label;
+    for(example*ec = priv.learn_ec_copy.begin; ec!=priv.learn_ec_copy.end; ++ec)
+      VW::dealloc_example(delete_label, *ec);
+    priv.learn_ec_copy.delete_v();
+  }
+  priv.learn_condition_on_names.delete_v();
+  priv.learn_condition_on.delete_v();
+  priv.learn_condition_on_act.delete_v();
+
+  if (priv.task->finish) priv.task->finish(sch);
+  if (priv.metatask && priv.metatask->finish) priv.metatask->finish(sch);
+
+  free(priv.allowed_actions_cache);
+  delete priv.rawOutputStringStream;
+  delete sch.priv;
+}
+
+void ensure_param(float &v, float lo, float hi, float def, const char* string) {
+  if ((v < lo) || (v > hi)) {
+    std::cerr << string << endl;
+    v = def;
+  }
+}
+
+bool string_equal(string a, string b) {
+  return a.compare(b) == 0;
+}
+bool float_equal(float a, float b) {
+  return fabs(a-b) < 1e-6;
+}
+bool uint32_equal(uint32_t a, uint32_t b) {
+  return a==b;
+}
+bool size_equal(size_t a, size_t b) {
+  return a==b;
+}
+
+void check_option(bool& ret, vw&all, po::variables_map& vm, const char* opt_name, bool /*default_to_cmdline*/, const char* /*mismatch_error_string*/) {
+  if (vm.count(opt_name)) {
+    ret = true;
+    *all.file_options << " --" << opt_name;
+  } else
+    ret = false;
+}
+
+void handle_condition_options(vw& vw, auto_condition_settings& acset) {
+  new_options(vw, "Search Auto-conditioning Options")
+  ("search_max_bias_ngram_length",   po::value<size_t>(), "add a \"bias\" feature for each ngram up to and including this length. eg., if it's 1 (default), then you get a single feature for each conditional")
+  ("search_max_quad_ngram_length",   po::value<size_t>(), "add bias *times* input features for each ngram up to and including this length (def: 0)")
+  ("search_condition_feature_value", po::value<float> (), "how much weight should the conditional features get? (def: 1.)");
+  add_options(vw);
+
+  po::variables_map& vm = vw.vm;
+
+  check_option<size_t>(acset.max_bias_ngram_length, vw, vm, "search_max_bias_ngram_length", false, size_equal,
+                       "warning: you specified a different value for --search_max_bias_ngram_length than the one loaded from regressor. proceeding with loaded value: ", "");
+
+  check_option<size_t>(acset.max_quad_ngram_length, vw, vm, "search_max_quad_ngram_length", false, size_equal,
+                       "warning: you specified a different value for --search_max_quad_ngram_length than the one loaded from regressor. proceeding with loaded value: ", "");
+
+  check_option<float> (acset.feature_value, vw, vm, "search_condition_feature_value", false, float_equal,
+                       "warning: you specified a different value for --search_condition_feature_value than the one loaded from regressor. proceeding with loaded value: ", "");
+}
+
+v_array<CS::label> read_allowed_transitions(action A, const char* filename) {
+  FILE *f = fopen(filename, "r");
+  if (f == nullptr)
+    THROWERRNO("error: could not read file " << filename << "; assuming all transitions are valid");
+
+  bool* bg = (bool*)malloc((A+1)*(A+1) * sizeof(bool));
+  int rd,from,to,count=0;
+  while ((rd = fscanf(f, "%d:%d", &from, &to)) > 0) {
+    if ((from < 0) || (from > (int)A)) {
+      std::cerr << "warning: ignoring transition from " << from << " because it's out of the range [0," << A << "]" << endl;
+    }
+    if ((to   < 0) || (to   > (int)A)) {
+      std::cerr << "warning: ignoring transition to "   << to   << " because it's out of the range [0," << A << "]" << endl;
+    }
+    bg[from * (A+1) + to] = true;
+    count++;
+  }
+  fclose(f);
+
+  v_array<CS::label> allowed = v_init<CS::label>();
+
+  for (size_t from=0; from<A; from++) {
+    v_array<CS::wclass> costs = v_init<CS::wclass>();
+
+    for (size_t to=0; to<A; to++)
+      if (bg[from * (A+1) + to]) {
+        CS::wclass c = { FLT_MAX, (action)to, 0., 0. };
+        costs.push_back(c);
+      }
+
+    CS::label ld = { costs };
+    allowed.push_back(ld);
+  }
+  free(bg);
+
+  std::cerr << "read " << count << " allowed transitions from " << filename << endl;
+
+  return allowed;
+}
+
+
+void parse_neighbor_features(string& nf_string, search&sch) {
+  search_private& priv = *sch.priv;
+  priv.neighbor_features.erase();
+  size_t len = nf_string.length();
+  if (len == 0) return;
+
+  char * cstr = new char [len+1];
+  strcpy(cstr, nf_string.c_str());
+
+  char * p = strtok(cstr, ",");
+  v_array<substring> cmd = v_init<substring>();
+  while (p != 0) {
+    cmd.erase();
+    substring me = { p, p+strlen(p) };
+    tokenize(':', me, cmd, true);
+
+    int32_t posn = 0;
+    char ns = ' ';
+    if (cmd.size() == 1) {
+      posn = int_of_substring(cmd[0]);
+      ns   = ' ';
+    } else if (cmd.size() == 2) {
+      posn = int_of_substring(cmd[0]);
+      ns   = (cmd[1].end > cmd[1].begin) ? cmd[1].begin[0] : ' ';
+    } else {
+      std::cerr << "warning: ignoring malformed neighbor specification: '" << p << "'" << endl;
+    }
+    int32_t enc = (posn << 24) | (ns & 0xFF);
+    priv.neighbor_features.push_back(enc);
+
+    p = strtok(nullptr, ",");
+  }
+  cmd.delete_v();
+
+  delete[] cstr;
+}
+
+base_learner* setup(vw&all) {
+  if (missing_option<size_t, false>(all, "search", "Use learning to search, argument=maximum action id or 0 for LDF"))
+    return nullptr;
+  new_options(all, "Search Options")
+  ("search_task",              po::value<string>(), "the search task (use \"--search_task list\" to get a list of available tasks)")
+  ("search_metatask",          po::value<string>(), "the search metatask (use \"--search_metatask list\" to get a list of available metatasks)")
+  ("search_interpolation",     po::value<string>(), "at what level should interpolation happen? [*data|policy]")
+  ("search_rollout",           po::value<string>(), "how should rollouts be executed?           [policy|oracle|*mix_per_state|mix_per_roll|none]")
+  ("search_rollin",            po::value<string>(), "how should past trajectories be generated? [policy|oracle|*mix_per_state|mix_per_roll]")
+
+  ("search_passes_per_policy", po::value<size_t>(), "number of passes per policy (only valid for search_interpolation=policy)     [def=1]")
+  ("search_beta",              po::value<float>(),  "interpolation rate for policies (only valid for search_interpolation=policy) [def=0.5]")
+
+  ("search_alpha",             po::value<float>(),  "annealed beta = 1-(1-alpha)^t (only valid for search_interpolation=data)     [def=1e-10]")
+
+  ("search_total_nb_policies", po::value<size_t>(), "if we are going to train the policies through multiple separate calls to vw, we need to specify this parameter and tell vw how many policies are eventually going to be trained")
+
+  ("search_trained_nb_policies", po::value<size_t>(), "the number of trained policies in a file")
+
+  ("search_allowed_transitions",po::value<string>(),"read file of allowed transitions [def: all transitions are allowed]")
+  ("search_subsample_time",    po::value<float>(),  "instead of training at all timesteps, use a subset. if value in (0,1), train on a random v%. if v>=1, train on precisely v steps per example, if v<=-1, use active learning")
+  ("search_neighbor_features", po::value<string>(), "copy features from neighboring lines. argument looks like: '-1:a,+2' meaning copy previous line namespace a and next next line from namespace _unnamed_, where ',' separates them")
+  ("search_rollout_num_steps", po::value<size_t>(), "how many calls of \"loss\" before we stop really predicting on rollouts and switch to oracle (def: 0 means \"infinite\")")
+  ("search_history_length",    po::value<size_t>(), "some tasks allow you to specify how much history their depend on; specify that here [def: 1]")
+
+  ("search_no_caching",                             "turn off the built-in caching ability (makes things slower, but technically more safe)")
+  ("search_xv",                                     "train two separate policies, alternating prediction/learning")
+  ("search_perturb_oracle",    po::value<float>(),  "perturb the oracle on rollin with this probability (def: 0)")
+  ;
+  add_options(all);
+  po::variables_map& vm = all.vm;
+
+  bool has_hook_task = false;
+  for (size_t i=0; i<all.args.size()-1; i++)
+    if (all.args[i] == "--search_task" && all.args[i+1] == "hook")
+      has_hook_task = true;
+  if (has_hook_task)
+    for (int i = (int)all.args.size()-2; i >= 0; i--)
+      if (all.args[i] == "--search_task" && all.args[i+1] != "hook")
+        all.args.erase(all.args.begin() + i, all.args.begin() + i + 2);
+
+  search& sch = calloc_or_die<search>();
+  sch.priv = new search_private();
+  search_initialize(&all, sch);
+  search_private& priv = *sch.priv;
+
+  std::string task_string;
+  std::string metatask_string;
+  std::string interpolation_string = "data";
+  std::string rollout_string = "mix_per_state";
+  std::string rollin_string = "mix_per_state";
+
+  check_option<string>(task_string, all, vm, "search_task", false, string_equal,
+                       "warning: specified --search_task different than the one loaded from regressor. using loaded value of: ",
+                       "error: you must specify a task using --search_task");
+
+  check_option<string>(metatask_string, all, vm, "search_metatask", false, string_equal,
+                       "warning: specified --search_metatask different than the one loaded from regressor. using loaded value of: ", "");
+
+  check_option<string>(interpolation_string, all, vm, "search_interpolation", false, string_equal,
+                       "warning: specified --search_interpolation different than the one loaded from regressor. using loaded value of: ", "");
+
+  if (vm.count("search_passes_per_policy"))       priv.passes_per_policy    = vm["search_passes_per_policy"].as<size_t>();
+  if (vm.count("search_xv"))                      priv.xv       = true;
+  if (vm.count("search_perturb_oracle"))          priv.perturb_oracle       = vm["search_perturb_oracle"].as<float>();
+
+  if (vm.count("search_alpha"))                   priv.alpha                = vm["search_alpha"            ].as<float>();
+  if (vm.count("search_beta"))                    priv.beta                 = vm["search_beta"             ].as<float>();
+
+  if (vm.count("search_subsample_time"))          priv.subsample_timesteps  = vm["search_subsample_time"].as<float>();
+  if (vm.count("search_no_caching"))              priv.no_caching           = true;
+  if (vm.count("search_rollout_num_steps"))       priv.rollout_num_steps    = vm["search_rollout_num_steps"].as<size_t>();
+
+  priv.A = vm["search"].as<size_t>();
+
+  string neighbor_features_string;
+  check_option<string>(neighbor_features_string, all, vm, "search_neighbor_features", false, string_equal,
+                       "warning: you specified a different feature structure with --search_neighbor_features than the one loaded from predictor. using loaded value of: ", "");
+  parse_neighbor_features(neighbor_features_string, sch);
+
+  if (interpolation_string.compare("data") == 0) { // run as dagger
     priv.adaptive_beta = true;
-    priv.passes_per_policy = 1;     //this should be set to the same value as --passes for dagger
+    priv.allow_current_policy = true;
+    priv.passes_per_policy = all.numpasses;
+    if (priv.current_policy > 1) priv.current_policy = 1;
+  } else if (interpolation_string.compare("policy") == 0) {
+  } else
+    THROW("error: --search_interpolation must be 'data' or 'policy'");
 
-    priv.current_policy = 0;
+  if (vm.count("search_rollout")) rollout_string = vm["search_rollout"].as<string>();
+  if (vm.count("search_rollin" )) rollin_string  = vm["search_rollin" ].as<string>();
 
-    priv.num_features = 0;
-    priv.total_number_of_policies = 1;
-    priv.read_example_last_id = 0;
-    priv.passes_per_policy = 0;
-    priv.read_example_last_pass = 0;
-    priv.total_examples_generated = 0;
-    priv.total_predictions_made = 0;
-    priv.total_cache_hits = 0;
+  if      ((rollout_string.compare("policy") == 0)       || (rollout_string.compare("learn") == 0))          priv.rollout_method = POLICY;
+  else if ((rollout_string.compare("oracle") == 0)       || (rollout_string.compare("ref") == 0))            priv.rollout_method = ORACLE;
+  else if ((rollout_string.compare("mix_per_state") == 0))                                                   priv.rollout_method = MIX_PER_STATE;
+  else if ((rollout_string.compare("mix_per_roll") == 0) || (rollout_string.compare("mix") == 0))            priv.rollout_method = MIX_PER_ROLL;
+  else if ((rollout_string.compare("none") == 0))          {
+    priv.rollout_method = NO_ROLLOUT;
+    priv.no_caching = true;
+    if (!all.quiet) std::cerr << "no rollout!" << endl;
+  }
+  else
+    THROW("error: --search_rollout must be 'learn', 'ref', 'mix', 'mix_per_state' or 'none'");
 
-    priv.history_length = 1;
-    priv.acset.max_bias_ngram_length = 1;
-    priv.acset.max_quad_ngram_length = 0;
-    priv.acset.feature_value = 1.;
+  if      ((rollin_string.compare("policy") == 0)       || (rollin_string.compare("learn") == 0))          priv.rollin_method = POLICY;
+  else if ((rollin_string.compare("oracle") == 0)       || (rollin_string.compare("ref") == 0))            priv.rollin_method = ORACLE;
+  else if ((rollin_string.compare("mix_per_state") == 0))                                                  priv.rollin_method = MIX_PER_STATE;
+  else if ((rollin_string.compare("mix_per_roll") == 0) || (rollin_string.compare("mix") == 0))            priv.rollin_method = MIX_PER_ROLL;
+  else
+    THROW("error: --search_rollin must be 'learn', 'ref', 'mix' or 'mix_per_state'");
 
-    scored_action sa((action)-1,0.);
-    priv.cache_hash_map.set_default_value(sa);
-    priv.cache_hash_map.set_equivalent(cached_item_equivalent);
+  check_option<size_t>(priv.A, all, vm, "search", false, size_equal,
+                       "warning: you specified a different number of actions through --search than the one loaded from predictor. using loaded value of: ", "");
 
-    priv.task = nullptr;
-    sch.task_data = nullptr;
+  check_option<size_t>(priv.history_length, all, vm, "search_history_length", false, size_equal,
+                       "warning: you specified a different history length through --search_history_length than the one loaded from predictor. using loaded value of: ", "");
 
-    priv.empty_example = VW::alloc_examples(sizeof(CS::label), 1);
-    CS::cs_label.default_label(&priv.empty_example->l.cs);
-    priv.empty_example->in_use = true;
-    CS::cs_label.default_label(&priv.empty_cs_label);
-
-    priv.rawOutputStringStream = new stringstream(priv.rawOutputString);
+  //check if the base learner is contextual bandit, in which case, we dont rollout all actions.
+  priv.allowed_actions_cache = &calloc_or_die<polylabel>();
+  if (vm.count("cb")) {
+    priv.cb_learner = true;
+    CB::cb_label.default_label(priv.allowed_actions_cache);
+    priv.learn_losses.cb.costs = v_init<CB::cb_class>();
+    priv.gte_label.cb.costs = v_init<CB::cb_class>();
+  } else {
+    priv.cb_learner = false;
+    CS::cs_label.default_label(priv.allowed_actions_cache);
+    priv.learn_losses.cs.costs = v_init<CS::wclass>();
+    priv.gte_label.cs.costs = v_init<CS::wclass>();
   }
 
-  void search_finish(search& sch) {
-    search_private& priv = *sch.priv;
-    cdbg << "search_finish" << endl;
+  //if we loaded a regressor with -i option, --search_trained_nb_policies contains the number of trained policies in the file
+  // and --search_total_nb_policies contains the total number of policies in the file
+  if (vm.count("search_total_nb_policies"))
+    priv.total_number_of_policies = (uint32_t)vm["search_total_nb_policies"].as<size_t>();
 
-    clear_cache_hash_map(priv);
+  ensure_param(priv.beta , 0.0, 1.0, 0.5, "warning: search_beta must be in (0,1); resetting to 0.5");
+  ensure_param(priv.alpha, 0.0, 1.0, 1e-10f, "warning: search_alpha must be in (0,1); resetting to 1e-10");
 
-    delete priv.truth_string;
-    delete priv.pred_string;
-    delete priv.bad_string_stream;
-    priv.neighbor_features.delete_v();
-    priv.timesteps.delete_v();
-    if (priv.cb_learner) priv.learn_losses.cb.costs.delete_v();
-    else                 priv.learn_losses.cs.costs.delete_v();
-    if (priv.cb_learner) priv.gte_label.cb.costs.delete_v();
-    else                 priv.gte_label.cs.costs.delete_v();
+  //compute total number of policies we will have at end of training
+  // we add current_policy for cases where we start from an initial set of policies loaded through -i option
+  uint32_t tmp_number_of_policies = priv.current_policy;
+  if( all.training )
+    tmp_number_of_policies += (int)ceil(((float)all.numpasses) / ((float)priv.passes_per_policy));
 
-    priv.condition_on_actions.delete_v(); // TODO: delete floats
-    priv.learn_allowed_actions.delete_v();
-    priv.ldf_test_label.costs.delete_v();
-
-    if (priv.cb_learner)
-      priv.allowed_actions_cache->cb.costs.delete_v();
-    else
-      priv.allowed_actions_cache->cs.costs.delete_v();
-
-    priv.train_trajectory.delete_v();
-    priv.ptag_to_action.delete_v();
-    clear_memo_foreach_action(priv);
-    priv.memo_foreach_action.delete_v();
-
-    VW::dealloc_example(CS::cs_label.delete_label, *(priv.empty_example));
-    free(priv.empty_example);
-
-    priv.ec_seq.clear();
-
-    // destroy copied examples if we needed them
-    if (! priv.examples_dont_change) {
-      void (*delete_label)(void*) = priv.is_ldf ? CS::cs_label.delete_label : MC::mc_label.delete_label;
-      for(example*ec = priv.learn_ec_copy.begin; ec!=priv.learn_ec_copy.end; ++ec)
-		  VW::dealloc_example(delete_label, *ec);
-      priv.learn_ec_copy.delete_v();
-    }
-    priv.learn_condition_on_names.delete_v();
-    priv.learn_condition_on.delete_v();
-    priv.learn_condition_on_act.delete_v();
-
-    if (priv.task->finish) priv.task->finish(sch);
-    if (priv.metatask && priv.metatask->finish) priv.metatask->finish(sch);
-
-    free(priv.allowed_actions_cache);
-    delete priv.rawOutputStringStream;
-    delete sch.priv;
+  //the user might have specified the number of policies that will eventually be trained through multiple vw calls,
+  //so only set total_number_of_policies to computed value if it is larger
+  cdbg << "current_policy=" << priv.current_policy << " tmp_number_of_policies=" << tmp_number_of_policies << " total_number_of_policies=" << priv.total_number_of_policies << endl;
+  if( tmp_number_of_policies > priv.total_number_of_policies ) {
+    priv.total_number_of_policies = tmp_number_of_policies;
+    if( priv.current_policy > 0 ) //we loaded a file but total number of policies didn't match what is needed for training
+      std::cerr << "warning: you're attempting to train more classifiers than was allocated initially. Likely to cause bad performance." << endl;
   }
 
-  void ensure_param(float &v, float lo, float hi, float def, const char* string) {
-    if ((v < lo) || (v > hi)) {
-      std::cerr << string << endl;
-      v = def;
-    }
-  }
+  //current policy currently points to a new policy we would train
+  //if we are not training and loaded a bunch of policies for testing, we need to subtract 1 from current policy
+  //so that we only use those loaded when testing (as run_prediction is called with allow_current to true)
+  if( !all.training && priv.current_policy > 0 )
+    priv.current_policy--;
 
-  bool string_equal(string a, string b) { return a.compare(b) == 0; }
-  bool float_equal(float a, float b) { return fabs(a-b) < 1e-6; }
-  bool uint32_equal(uint32_t a, uint32_t b) { return a==b; }
-  bool size_equal(size_t a, size_t b) { return a==b; }
+  std::stringstream ss1, ss2;
+  ss1 << priv.current_policy;
+  VW::cmd_string_replace_value(all.file_options,"--search_trained_nb_policies", ss1.str());
+  ss2 << priv.total_number_of_policies;
+  VW::cmd_string_replace_value(all.file_options,"--search_total_nb_policies",   ss2.str());
 
-  void check_option(bool& ret, vw&all, po::variables_map& vm, const char* opt_name, bool /*default_to_cmdline*/, const char* /*mismatch_error_string*/) {
-    if (vm.count(opt_name)) {
-      ret = true;
-      *all.file_options << " --" << opt_name;
-    } else
-      ret = false;
-  }
+  cdbg << "search current_policy = " << priv.current_policy << " total_number_of_policies = " << priv.total_number_of_policies << endl;
 
-  void handle_condition_options(vw& vw, auto_condition_settings& acset) {
-    new_options(vw, "Search Auto-conditioning Options")
-        ("search_max_bias_ngram_length",   po::value<size_t>(), "add a \"bias\" feature for each ngram up to and including this length. eg., if it's 1 (default), then you get a single feature for each conditional")
-        ("search_max_quad_ngram_length",   po::value<size_t>(), "add bias *times* input features for each ngram up to and including this length (def: 0)")
-        ("search_condition_feature_value", po::value<float> (), "how much weight should the conditional features get? (def: 1.)");
-    add_options(vw);
-
-    po::variables_map& vm = vw.vm;
-
-    check_option<size_t>(acset.max_bias_ngram_length, vw, vm, "search_max_bias_ngram_length", false, size_equal,
-                         "warning: you specified a different value for --search_max_bias_ngram_length than the one loaded from regressor. proceeding with loaded value: ", "");
-
-    check_option<size_t>(acset.max_quad_ngram_length, vw, vm, "search_max_quad_ngram_length", false, size_equal,
-                         "warning: you specified a different value for --search_max_quad_ngram_length than the one loaded from regressor. proceeding with loaded value: ", "");
-
-    check_option<float> (acset.feature_value, vw, vm, "search_condition_feature_value", false, float_equal,
-                         "warning: you specified a different value for --search_condition_feature_value than the one loaded from regressor. proceeding with loaded value: ", "");
-  }
-
-  v_array<CS::label> read_allowed_transitions(action A, const char* filename) {
-    FILE *f = fopen(filename, "r");
-	if (f == nullptr)
-	  THROWERRNO("error: could not read file " << filename << "; assuming all transitions are valid");
-
-    bool* bg = (bool*)malloc((A+1)*(A+1) * sizeof(bool));
-    int rd,from,to,count=0;
-    while ((rd = fscanf(f, "%d:%d", &from, &to)) > 0) {
-      if ((from < 0) || (from > (int)A)) { std::cerr << "warning: ignoring transition from " << from << " because it's out of the range [0," << A << "]" << endl; }
-      if ((to   < 0) || (to   > (int)A)) { std::cerr << "warning: ignoring transition to "   << to   << " because it's out of the range [0," << A << "]" << endl; }
-      bg[from * (A+1) + to] = true;
-      count++;
-    }
-    fclose(f);
-
-    v_array<CS::label> allowed = v_init<CS::label>();
-
-    for (size_t from=0; from<A; from++) {
-      v_array<CS::wclass> costs = v_init<CS::wclass>();
-
-      for (size_t to=0; to<A; to++)
-        if (bg[from * (A+1) + to]) {
-          CS::wclass c = { FLT_MAX, (action)to, 0., 0. };
-          costs.push_back(c);
-        }
-
-      CS::label ld = { costs };
-      allowed.push_back(ld);
-    }
-    free(bg);
-
-    std::cerr << "read " << count << " allowed transitions from " << filename << endl;
-
-    return allowed;
-  }
-
-
-  void parse_neighbor_features(string& nf_string, search&sch) {
-    search_private& priv = *sch.priv;
-    priv.neighbor_features.erase();
-    size_t len = nf_string.length();
-    if (len == 0) return;
-
-    char * cstr = new char [len+1];
-    strcpy(cstr, nf_string.c_str());
-
-    char * p = strtok(cstr, ",");
-    v_array<substring> cmd = v_init<substring>();
-    while (p != 0) {
-      cmd.erase();
-      substring me = { p, p+strlen(p) };
-      tokenize(':', me, cmd, true);
-
-      int32_t posn = 0;
-      char ns = ' ';
-      if (cmd.size() == 1) {
-        posn = int_of_substring(cmd[0]);
-        ns   = ' ';
-      } else if (cmd.size() == 2) {
-        posn = int_of_substring(cmd[0]);
-        ns   = (cmd[1].end > cmd[1].begin) ? cmd[1].begin[0] : ' ';
-      } else {
-        std::cerr << "warning: ignoring malformed neighbor specification: '" << p << "'" << endl;
-      }
-      int32_t enc = (posn << 24) | (ns & 0xFF);
-      priv.neighbor_features.push_back(enc);
-
-      p = strtok(nullptr, ",");
-    }
-    cmd.delete_v();
-
-    delete[] cstr;
-  }
-
-  base_learner* setup(vw&all) {
-    if (missing_option<size_t, false>(all, "search", "Use learning to search, argument=maximum action id or 0 for LDF"))
-      return nullptr;
-    new_options(all, "Search Options")
-        ("search_task",              po::value<string>(), "the search task (use \"--search_task list\" to get a list of available tasks)")
-        ("search_metatask",          po::value<string>(), "the search metatask (use \"--search_metatask list\" to get a list of available metatasks)")
-        ("search_interpolation",     po::value<string>(), "at what level should interpolation happen? [*data|policy]")
-        ("search_rollout",           po::value<string>(), "how should rollouts be executed?           [policy|oracle|*mix_per_state|mix_per_roll|none]")
-        ("search_rollin",            po::value<string>(), "how should past trajectories be generated? [policy|oracle|*mix_per_state|mix_per_roll]")
-
-        ("search_passes_per_policy", po::value<size_t>(), "number of passes per policy (only valid for search_interpolation=policy)     [def=1]")
-        ("search_beta",              po::value<float>(),  "interpolation rate for policies (only valid for search_interpolation=policy) [def=0.5]")
-
-        ("search_alpha",             po::value<float>(),  "annealed beta = 1-(1-alpha)^t (only valid for search_interpolation=data)     [def=1e-10]")
-
-        ("search_total_nb_policies", po::value<size_t>(), "if we are going to train the policies through multiple separate calls to vw, we need to specify this parameter and tell vw how many policies are eventually going to be trained")
-
-        ("search_trained_nb_policies", po::value<size_t>(), "the number of trained policies in a file")
-
-        ("search_allowed_transitions",po::value<string>(),"read file of allowed transitions [def: all transitions are allowed]")
-        ("search_subsample_time",    po::value<float>(),  "instead of training at all timesteps, use a subset. if value in (0,1), train on a random v%. if v>=1, train on precisely v steps per example, if v<=-1, use active learning")
-        ("search_neighbor_features", po::value<string>(), "copy features from neighboring lines. argument looks like: '-1:a,+2' meaning copy previous line namespace a and next next line from namespace _unnamed_, where ',' separates them")
-        ("search_rollout_num_steps", po::value<size_t>(), "how many calls of \"loss\" before we stop really predicting on rollouts and switch to oracle (def: 0 means \"infinite\")")
-        ("search_history_length",    po::value<size_t>(), "some tasks allow you to specify how much history their depend on; specify that here [def: 1]")
-
-        ("search_no_caching",                             "turn off the built-in caching ability (makes things slower, but technically more safe)")
-        ("search_xv",                                     "train two separate policies, alternating prediction/learning")
-        ("search_perturb_oracle",    po::value<float>(),  "perturb the oracle on rollin with this probability (def: 0)")
-        ;
-    add_options(all);
-    po::variables_map& vm = all.vm;
-
-    bool has_hook_task = false;
-    for (size_t i=0; i<all.args.size()-1; i++)
-      if (all.args[i] == "--search_task" && all.args[i+1] == "hook")
-        has_hook_task = true;
-    if (has_hook_task)
-      for (int i = (int)all.args.size()-2; i >= 0; i--)
-        if (all.args[i] == "--search_task" && all.args[i+1] != "hook")
-          all.args.erase(all.args.begin() + i, all.args.begin() + i + 2);
-
-    search& sch = calloc_or_die<search>();
-    sch.priv = new search_private();
-    search_initialize(&all, sch);
-    search_private& priv = *sch.priv;
-
-    std::string task_string;
-    std::string metatask_string;
-    std::string interpolation_string = "data";
-    std::string rollout_string = "mix_per_state";
-    std::string rollin_string = "mix_per_state";
-
-    check_option<string>(task_string, all, vm, "search_task", false, string_equal,
-                         "warning: specified --search_task different than the one loaded from regressor. using loaded value of: ",
-                         "error: you must specify a task using --search_task");
-
-    check_option<string>(metatask_string, all, vm, "search_metatask", false, string_equal,
-                         "warning: specified --search_metatask different than the one loaded from regressor. using loaded value of: ", "");
-
-    check_option<string>(interpolation_string, all, vm, "search_interpolation", false, string_equal,
-                         "warning: specified --search_interpolation different than the one loaded from regressor. using loaded value of: ", "");
-
-    if (vm.count("search_passes_per_policy"))       priv.passes_per_policy    = vm["search_passes_per_policy"].as<size_t>();
-    if (vm.count("search_xv"))                      priv.xv       = true;
-    if (vm.count("search_perturb_oracle"))          priv.perturb_oracle       = vm["search_perturb_oracle"].as<float>();
-
-    if (vm.count("search_alpha"))                   priv.alpha                = vm["search_alpha"            ].as<float>();
-    if (vm.count("search_beta"))                    priv.beta                 = vm["search_beta"             ].as<float>();
-
-    if (vm.count("search_subsample_time"))          priv.subsample_timesteps  = vm["search_subsample_time"].as<float>();
-    if (vm.count("search_no_caching"))              priv.no_caching           = true;
-    if (vm.count("search_rollout_num_steps"))       priv.rollout_num_steps    = vm["search_rollout_num_steps"].as<size_t>();
-
-    priv.A = vm["search"].as<size_t>();
-
-    string neighbor_features_string;
-    check_option<string>(neighbor_features_string, all, vm, "search_neighbor_features", false, string_equal,
-                         "warning: you specified a different feature structure with --search_neighbor_features than the one loaded from predictor. using loaded value of: ", "");
-    parse_neighbor_features(neighbor_features_string, sch);
-
-    if (interpolation_string.compare("data") == 0) { // run as dagger
-      priv.adaptive_beta = true;
-      priv.allow_current_policy = true;
-      priv.passes_per_policy = all.numpasses;
-      if (priv.current_policy > 1) priv.current_policy = 1;
-    } else if (interpolation_string.compare("policy") == 0) {
-    } else 
-      THROW("error: --search_interpolation must be 'data' or 'policy'");
-
-    if (vm.count("search_rollout")) rollout_string = vm["search_rollout"].as<string>();
-    if (vm.count("search_rollin" )) rollin_string  = vm["search_rollin" ].as<string>();
-
-    if      ((rollout_string.compare("policy") == 0)       || (rollout_string.compare("learn") == 0))          priv.rollout_method = POLICY;
-    else if ((rollout_string.compare("oracle") == 0)       || (rollout_string.compare("ref") == 0))            priv.rollout_method = ORACLE;
-    else if ((rollout_string.compare("mix_per_state") == 0))                                                   priv.rollout_method = MIX_PER_STATE;
-    else if ((rollout_string.compare("mix_per_roll") == 0) || (rollout_string.compare("mix") == 0))            priv.rollout_method = MIX_PER_ROLL;
-    else if ((rollout_string.compare("none") == 0))          { priv.rollout_method = NO_ROLLOUT; priv.no_caching = true; if (!all.quiet) std::cerr << "no rollout!" << endl; }
-    else 
-      THROW("error: --search_rollout must be 'learn', 'ref', 'mix', 'mix_per_state' or 'none'");
-
-    if      ((rollin_string.compare("policy") == 0)       || (rollin_string.compare("learn") == 0))          priv.rollin_method = POLICY;
-    else if ((rollin_string.compare("oracle") == 0)       || (rollin_string.compare("ref") == 0))            priv.rollin_method = ORACLE;
-    else if ((rollin_string.compare("mix_per_state") == 0))                                                  priv.rollin_method = MIX_PER_STATE;
-	else if ((rollin_string.compare("mix_per_roll") == 0) || (rollin_string.compare("mix") == 0))            priv.rollin_method = MIX_PER_ROLL;
-	else
-	  THROW("error: --search_rollin must be 'learn', 'ref', 'mix' or 'mix_per_state'");
-
-    check_option<size_t>(priv.A, all, vm, "search", false, size_equal,
-                         "warning: you specified a different number of actions through --search than the one loaded from predictor. using loaded value of: ", "");
-
-    check_option<size_t>(priv.history_length, all, vm, "search_history_length", false, size_equal,
-                         "warning: you specified a different history length through --search_history_length than the one loaded from predictor. using loaded value of: ", "");
-
-    //check if the base learner is contextual bandit, in which case, we dont rollout all actions.
-    priv.allowed_actions_cache = &calloc_or_die<polylabel>();
-    if (vm.count("cb")) {
-      priv.cb_learner = true;
-      CB::cb_label.default_label(priv.allowed_actions_cache);
-      priv.learn_losses.cb.costs = v_init<CB::cb_class>();
-      priv.gte_label.cb.costs = v_init<CB::cb_class>();
-    } else {
-      priv.cb_learner = false;
-      CS::cs_label.default_label(priv.allowed_actions_cache);
-      priv.learn_losses.cs.costs = v_init<CS::wclass>();
-      priv.gte_label.cs.costs = v_init<CS::wclass>();
-    }
-
-    //if we loaded a regressor with -i option, --search_trained_nb_policies contains the number of trained policies in the file
-    // and --search_total_nb_policies contains the total number of policies in the file
-    if (vm.count("search_total_nb_policies"))
-      priv.total_number_of_policies = (uint32_t)vm["search_total_nb_policies"].as<size_t>();
-
-    ensure_param(priv.beta , 0.0, 1.0, 0.5, "warning: search_beta must be in (0,1); resetting to 0.5");
-    ensure_param(priv.alpha, 0.0, 1.0, 1e-10f, "warning: search_alpha must be in (0,1); resetting to 1e-10");
-
-    //compute total number of policies we will have at end of training
-    // we add current_policy for cases where we start from an initial set of policies loaded through -i option
-    uint32_t tmp_number_of_policies = priv.current_policy;
-    if( all.training )
-      tmp_number_of_policies += (int)ceil(((float)all.numpasses) / ((float)priv.passes_per_policy));
-
-    //the user might have specified the number of policies that will eventually be trained through multiple vw calls,
-    //so only set total_number_of_policies to computed value if it is larger
-    cdbg << "current_policy=" << priv.current_policy << " tmp_number_of_policies=" << tmp_number_of_policies << " total_number_of_policies=" << priv.total_number_of_policies << endl;
-    if( tmp_number_of_policies > priv.total_number_of_policies ) {
-      priv.total_number_of_policies = tmp_number_of_policies;
-      if( priv.current_policy > 0 ) //we loaded a file but total number of policies didn't match what is needed for training
-        std::cerr << "warning: you're attempting to train more classifiers than was allocated initially. Likely to cause bad performance." << endl;
-    }
-
-    //current policy currently points to a new policy we would train
-    //if we are not training and loaded a bunch of policies for testing, we need to subtract 1 from current policy
-    //so that we only use those loaded when testing (as run_prediction is called with allow_current to true)
-    if( !all.training && priv.current_policy > 0 )
-      priv.current_policy--;
-
-    std::stringstream ss1, ss2;
-    ss1 << priv.current_policy;           VW::cmd_string_replace_value(all.file_options,"--search_trained_nb_policies", ss1.str());
-    ss2 << priv.total_number_of_policies; VW::cmd_string_replace_value(all.file_options,"--search_total_nb_policies",   ss2.str());
-
-    cdbg << "search current_policy = " << priv.current_policy << " total_number_of_policies = " << priv.total_number_of_policies << endl;
-
-    if (task_string.compare("list") == 0) {
-      std::cerr << endl << "available search tasks:" << endl;
-      for (search_task** mytask = all_tasks; *mytask != nullptr; mytask++)
-        std::cerr << "  " << (*mytask)->task_name << endl;
-      std::cerr << endl;
-      exit(0);
-    }
-    if (metatask_string.compare("list") == 0) {
-      std::cerr << endl << "available search metatasks:" << endl;
-      for (search_metatask** mytask = all_metatasks; *mytask != nullptr; mytask++)
-        std::cerr << "  " << (*mytask)->metatask_name << endl;
-      std::cerr << endl;
-      exit(0);
-    }
+  if (task_string.compare("list") == 0) {
+    std::cerr << endl << "available search tasks:" << endl;
     for (search_task** mytask = all_tasks; *mytask != nullptr; mytask++)
-      if (task_string.compare((*mytask)->task_name) == 0) {
-        priv.task = *mytask;
-        sch.task_name = (*mytask)->task_name;
-        break;
-      }
-    if (priv.task == nullptr) {
-      if (! vm.count("help")) 
-	THROW("fail: unknown task for --search_task '" << task_string << "'; use --search_task list to get a list");
-    }
-    priv.metatask = nullptr;
+      std::cerr << "  " << (*mytask)->task_name << endl;
+    std::cerr << endl;
+    exit(0);
+  }
+  if (metatask_string.compare("list") == 0) {
+    std::cerr << endl << "available search metatasks:" << endl;
     for (search_metatask** mytask = all_metatasks; *mytask != nullptr; mytask++)
-      if (metatask_string.compare((*mytask)->metatask_name) == 0) {
-        priv.metatask = *mytask;
-        sch.metatask_name = (*mytask)->metatask_name;
-        break;
-      }
-    all.p->emptylines_separate_examples = true;
-
-    if (count(all.args.begin(), all.args.end(),"--csoaa") == 0 
-        && count(all.args.begin(), all.args.end(),"--csoaa_ldf") == 0 
-        && count(all.args.begin(), all.args.end(),"--wap_ldf") == 0 
-        &&  count(all.args.begin(), all.args.end(),"--cb") == 0)
-    {
-      all.args.push_back("--csoaa");
-      stringstream ss;
-      ss << vm["search"].as<size_t>();
-      all.args.push_back(ss.str());
+      std::cerr << "  " << (*mytask)->metatask_name << endl;
+    std::cerr << endl;
+    exit(0);
+  }
+  for (search_task** mytask = all_tasks; *mytask != nullptr; mytask++)
+    if (task_string.compare((*mytask)->task_name) == 0) {
+      priv.task = *mytask;
+      sch.task_name = (*mytask)->task_name;
+      break;
     }
-    base_learner* base = setup_base(all);
-
-    // default to OAA labels unless the task wants to override this (which they can do in initialize)
-    all.p->lp = MC::mc_label;
-    if (priv.task && priv.task->initialize)
-      priv.task->initialize(sch, priv.A, vm);
-    if (priv.metatask && priv.metatask->initialize)
-      priv.metatask->initialize(sch, priv.A, vm);
-    priv.meta_t = 0;
-
-    if (vm.count("search_allowed_transitions"))     read_allowed_transitions((action)priv.A, vm["search_allowed_transitions"].as<string>().c_str());
-
-    // set up auto-history if they want it
-    if (priv.auto_condition_features) {
-      handle_condition_options(all, priv.acset);
-
-      // turn off auto-condition if it's irrelevant
-      if (((priv.acset.max_bias_ngram_length == 0) && (priv.acset.max_quad_ngram_length == 0)) ||
-          (priv.acset.feature_value == 0.f)) {
-        std::cerr << "warning: turning off AUTO_CONDITION_FEATURES because settings make it useless" << endl;
-        priv.auto_condition_features = false;
-      }
+  if (priv.task == nullptr) {
+    if (! vm.count("help"))
+      THROW("fail: unknown task for --search_task '" << task_string << "'; use --search_task list to get a list");
+  }
+  priv.metatask = nullptr;
+  for (search_metatask** mytask = all_metatasks; *mytask != nullptr; mytask++)
+    if (metatask_string.compare((*mytask)->metatask_name) == 0) {
+      priv.metatask = *mytask;
+      sch.metatask_name = (*mytask)->metatask_name;
+      break;
     }
+  all.p->emptylines_separate_examples = true;
 
-    if (!priv.allow_current_policy) // if we're not dagger
-      all.check_holdout_every_n_passes = priv.passes_per_policy;
-
-    all.searchstr = &sch;
-
-    priv.start_clock_time = clock();
-
-    if (priv.xv) priv.num_learners *= 3;
-
-    cdbg << "num_learners = " << priv.num_learners << endl;
-
-    learner<search>& l = init_learner(&sch, base,
-                                      search_predict_or_learn<true>,
-                                      search_predict_or_learn<false>,
-                                      priv.total_number_of_policies * priv.num_learners);
-    l.set_finish_example(finish_example);
-    l.set_end_examples(end_examples);
-    l.set_finish(search_finish);
-    l.set_end_pass(end_pass);
-
-    return make_base(l);
+  if (count(all.args.begin(), all.args.end(),"--csoaa") == 0
+      && count(all.args.begin(), all.args.end(),"--csoaa_ldf") == 0
+      && count(all.args.begin(), all.args.end(),"--wap_ldf") == 0
+      &&  count(all.args.begin(), all.args.end(),"--cb") == 0)
+  {
+    all.args.push_back("--csoaa");
+    stringstream ss;
+    ss << vm["search"].as<size_t>();
+    all.args.push_back(ss.str());
   }
+  base_learner* base = setup_base(all);
 
-  float action_hamming_loss(action a, const action* A, size_t sz) {
-    if (sz == 0) return 0.;   // latent variables have zero loss
-    for (size_t i=0; i<sz; i++)
-      if (a == A[i]) return 0.;
-    return 1.;
-  }
+  // default to OAA labels unless the task wants to override this (which they can do in initialize)
+  all.p->lp = MC::mc_label;
+  if (priv.task && priv.task->initialize)
+    priv.task->initialize(sch, priv.A, vm);
+  if (priv.metatask && priv.metatask->initialize)
+    priv.metatask->initialize(sch, priv.A, vm);
+  priv.meta_t = 0;
 
-  // the interface:
-  bool search::is_ldf() { return priv->is_ldf; }
+  if (vm.count("search_allowed_transitions"))     read_allowed_transitions((action)priv.A, vm["search_allowed_transitions"].as<string>().c_str());
 
-  action search::predict(example& ec, ptag mytag, const action* oracle_actions, size_t oracle_actions_cnt, const ptag* condition_on, const char* condition_on_names, const action* allowed_actions, size_t allowed_actions_cnt, size_t learner_id, float weight) {
-    float a_cost = 0.;
-    action a = search_predict(*priv, &ec, 1, mytag, oracle_actions, oracle_actions_cnt, condition_on, condition_on_names, allowed_actions, allowed_actions_cnt, learner_id, a_cost, weight);
-    if (priv->state == INIT_TEST) priv->test_action_sequence.push_back(a);
-    if (mytag != 0) push_at(priv->ptag_to_action, a, mytag);
-    if (priv->auto_hamming_loss)
-      loss(action_hamming_loss(a, oracle_actions, oracle_actions_cnt));
-    cdbg << "predict returning " << a << endl;
-    return a;
-  }
+  // set up auto-history if they want it
+  if (priv.auto_condition_features) {
+    handle_condition_options(all, priv.acset);
 
-  action search::predictLDF(example* ecs, size_t ec_cnt, ptag mytag, const action* oracle_actions, size_t oracle_actions_cnt, const ptag* condition_on, const char* condition_on_names, size_t learner_id, float weight) {
-    float a_cost = 0.;
-    action a = search_predict(*priv, ecs, ec_cnt, mytag, oracle_actions, oracle_actions_cnt, condition_on, condition_on_names, nullptr, 0, learner_id, a_cost, weight);
-    if (priv->state == INIT_TEST) priv->test_action_sequence.push_back(a);
-    if ((mytag != 0) && ecs[a].l.cs.costs.size() > 0)
-      push_at(priv->ptag_to_action, ecs[a].l.cs.costs[0].class_index, mytag);
-    if (priv->auto_hamming_loss)
-      loss(action_hamming_loss(a, oracle_actions, oracle_actions_cnt));
-    cdbg << "predict returning " << a << endl;
-    return a;
-  }
-
-  void search::loss(float loss) { search_declare_loss(*this->priv, loss); }
-
-  bool search::predictNeedsExample() { return search_predictNeedsExample(*this->priv); }
-
-  stringstream& search::output() {
-    if      (!this->priv->should_produce_string    ) return *(this->priv->bad_string_stream);
-    else if ( this->priv->state == GET_TRUTH_STRING) return *(this->priv->truth_string);
-    else                                             return *(this->priv->pred_string);
-  }
-
-  void  search::set_options(uint32_t opts) {
-    if (this->priv->all->vw_is_main && (this->priv->state != INITIALIZE))
-      std::cerr << "warning: task should not set options except in initialize function!" << endl;
-    if ((opts & AUTO_CONDITION_FEATURES) != 0) this->priv->auto_condition_features = true;
-    if ((opts & AUTO_HAMMING_LOSS)       != 0) this->priv->auto_hamming_loss = true;
-    if ((opts & EXAMPLES_DONT_CHANGE)    != 0) this->priv->examples_dont_change = true;
-    if ((opts & IS_LDF)                  != 0) this->priv->is_ldf = true;
-    if ((opts & NO_CACHING)              != 0) this->priv->no_caching = true;
-  }
-
-  void search::set_label_parser(label_parser&lp, bool (*is_test)(polylabel&)) {
-    if (this->priv->all->vw_is_main && (this->priv->state != INITIALIZE))
-      std::cerr << "warning: task should not set label parser except in initialize function!" << endl;
-    this->priv->all->p->lp = lp;
-    this->priv->label_is_test = is_test;
-  }
-
-  void search::get_test_action_sequence(vector<action>& V) {
-    V.clear();
-    for (size_t i=0; i<this->priv->test_action_sequence.size(); i++)
-      V.push_back(this->priv->test_action_sequence[i]);
-  }
-
-
-  void search::set_num_learners(size_t num_learners) { this->priv->num_learners = num_learners; }
-  void search::add_program_options(po::variables_map& /*vw*/, po::options_description& opts) { add_options( *this->priv->all, opts ); }
-
-  size_t search::get_mask() { return this->priv->all->reg.weight_mask;}
-  size_t search::get_stride_shift() { return this->priv->all->reg.stride_shift;}
-  uint32_t search::get_history_length() { return (uint32_t)this->priv->history_length; }
-
-  string search::pretty_label(action a) {
-    if (this->priv->all->sd->ldict) {
-      substring ss = this->priv->all->sd->ldict->get(a);
-      return string(ss.begin, ss.end-ss.begin);
-    } else {
-      ostringstream os;
-      os << a;
-      return os.str();
-    }
-  }
-  
-  vw& search::get_vw_pointer_unsafe() { return *this->priv->all; }
-  void search::set_force_oracle(bool force) { this->priv->force_oracle = force; }
-
-  // predictor implementation
-  predictor::predictor(search& sch, ptag my_tag) : is_ldf(false), my_tag(my_tag), ec(nullptr), ec_cnt(0), ec_alloced(false), weight(1.), oracle_is_pointer(false), allowed_is_pointer(false), learner_id(0), sch(sch) { 
-    oracle_actions = v_init<action>(); 
-    condition_on_tags = v_init<ptag>();
-    condition_on_names = v_init<char>();
-    allowed_actions = v_init<action>();
-  }
-
-  void predictor::free_ec() {
-    if (ec_alloced) {
-      if (is_ldf)
-        for (size_t i=0; i<ec_cnt; i++)
-          VW::dealloc_example(CS::cs_label.delete_label, ec[i]);
-      else
-		  VW::dealloc_example(nullptr, *ec);
-      free(ec);
+    // turn off auto-condition if it's irrelevant
+    if (((priv.acset.max_bias_ngram_length == 0) && (priv.acset.max_quad_ngram_length == 0)) ||
+        (priv.acset.feature_value == 0.f)) {
+      std::cerr << "warning: turning off AUTO_CONDITION_FEATURES because settings make it useless" << endl;
+      priv.auto_condition_features = false;
     }
   }
 
-  predictor::~predictor() {
-    if (! oracle_is_pointer) oracle_actions.delete_v();
-    if (! allowed_is_pointer) allowed_actions.delete_v();
-    free_ec();
-    condition_on_tags.delete_v();
-    condition_on_names.delete_v();
-  }
+  if (!priv.allow_current_policy) // if we're not dagger
+    all.check_holdout_every_n_passes = priv.passes_per_policy;
 
-  predictor& predictor::set_input(example&input_example) {
-    free_ec();
-    is_ldf = false;
-    ec = &input_example;
-    ec_cnt = 1;
-    ec_alloced = false;
-    return *this;
-  }
+  all.searchstr = &sch;
 
-  predictor& predictor::set_input(example*input_example, size_t input_length) {
-    free_ec();
-    is_ldf = true;
-    ec = input_example;
-    ec_cnt = input_length;
-    ec_alloced = false;
-    return *this;
-  }
+  priv.start_clock_time = clock();
 
-  void predictor::set_input_length(size_t input_length) {
-    is_ldf = true;
-    if (ec_alloced) 
-      {
-	example* temp = (example*)realloc(ec, input_length * sizeof(example));
-	if (temp != nullptr)
-	  ec = temp;
-	else
-	  THROW("realloc failed in search.cc");
-      }
-    else            ec = calloc_or_die<example>(input_length);
-    ec_cnt = input_length;
-    ec_alloced = true;
-  }
-  void predictor::set_input_at(size_t posn, example&ex) {
-    if (!ec_alloced)
-      THROW("call to set_input_at without previous call to set_input_length");
-    
-    if (posn >= ec_cnt)
-      THROW("call to set_input_at with too large a position: posn (" << posn << ") >= ec_cnt(" << ec_cnt << ")");
+  if (priv.xv) priv.num_learners *= 3;
 
-    VW::copy_example_data(false, ec+posn, &ex, CS::cs_label.label_size, CS::cs_label.copy_label); // TODO: the false is "audit"
-  }
+  cdbg << "num_learners = " << priv.num_learners << endl;
 
-  void predictor::make_new_pointer(v_array<action>& A, size_t new_size) {
-    size_t old_size      = A.size();
-    action* old_pointer  = A.begin;
-    A.begin     = calloc_or_die<action>(new_size);
-    A.end       = A.begin + new_size;
-    A.end_array = A.end;
-    memcpy(A.begin, old_pointer, old_size * sizeof(action));
-  }
+  learner<search>& l = init_learner(&sch, base,
+                                    search_predict_or_learn<true>,
+                                    search_predict_or_learn<false>,
+                                    priv.total_number_of_policies * priv.num_learners);
+  l.set_finish_example(finish_example);
+  l.set_end_examples(end_examples);
+  l.set_finish(search_finish);
+  l.set_end_pass(end_pass);
 
-  predictor& predictor::add_to(v_array<action>& A, bool& A_is_ptr, action a, bool clear_first) {
+  return make_base(l);
+}
+
+float action_hamming_loss(action a, const action* A, size_t sz) {
+  if (sz == 0) return 0.;   // latent variables have zero loss
+  for (size_t i=0; i<sz; i++)
+    if (a == A[i]) return 0.;
+  return 1.;
+}
+
+// the interface:
+bool search::is_ldf() {
+  return priv->is_ldf;
+}
+
+action search::predict(example& ec, ptag mytag, const action* oracle_actions, size_t oracle_actions_cnt, const ptag* condition_on, const char* condition_on_names, const action* allowed_actions, size_t allowed_actions_cnt, size_t learner_id, float weight) {
+  float a_cost = 0.;
+  action a = search_predict(*priv, &ec, 1, mytag, oracle_actions, oracle_actions_cnt, condition_on, condition_on_names, allowed_actions, allowed_actions_cnt, learner_id, a_cost, weight);
+  if (priv->state == INIT_TEST) priv->test_action_sequence.push_back(a);
+  if (mytag != 0) push_at(priv->ptag_to_action, a, mytag);
+  if (priv->auto_hamming_loss)
+    loss(action_hamming_loss(a, oracle_actions, oracle_actions_cnt));
+  cdbg << "predict returning " << a << endl;
+  return a;
+}
+
+action search::predictLDF(example* ecs, size_t ec_cnt, ptag mytag, const action* oracle_actions, size_t oracle_actions_cnt, const ptag* condition_on, const char* condition_on_names, size_t learner_id, float weight) {
+  float a_cost = 0.;
+  action a = search_predict(*priv, ecs, ec_cnt, mytag, oracle_actions, oracle_actions_cnt, condition_on, condition_on_names, nullptr, 0, learner_id, a_cost, weight);
+  if (priv->state == INIT_TEST) priv->test_action_sequence.push_back(a);
+  if ((mytag != 0) && ecs[a].l.cs.costs.size() > 0)
+    push_at(priv->ptag_to_action, ecs[a].l.cs.costs[0].class_index, mytag);
+  if (priv->auto_hamming_loss)
+    loss(action_hamming_loss(a, oracle_actions, oracle_actions_cnt));
+  cdbg << "predict returning " << a << endl;
+  return a;
+}
+
+void search::loss(float loss) {
+  search_declare_loss(*this->priv, loss);
+}
+
+bool search::predictNeedsExample() {
+  return search_predictNeedsExample(*this->priv);
+}
+
+stringstream& search::output() {
+  if      (!this->priv->should_produce_string    ) return *(this->priv->bad_string_stream);
+  else if ( this->priv->state == GET_TRUTH_STRING) return *(this->priv->truth_string);
+  else                                             return *(this->priv->pred_string);
+}
+
+void  search::set_options(uint32_t opts) {
+  if (this->priv->all->vw_is_main && (this->priv->state != INITIALIZE))
+    std::cerr << "warning: task should not set options except in initialize function!" << endl;
+  if ((opts & AUTO_CONDITION_FEATURES) != 0) this->priv->auto_condition_features = true;
+  if ((opts & AUTO_HAMMING_LOSS)       != 0) this->priv->auto_hamming_loss = true;
+  if ((opts & EXAMPLES_DONT_CHANGE)    != 0) this->priv->examples_dont_change = true;
+  if ((opts & IS_LDF)                  != 0) this->priv->is_ldf = true;
+  if ((opts & NO_CACHING)              != 0) this->priv->no_caching = true;
+}
+
+void search::set_label_parser(label_parser&lp, bool (*is_test)(polylabel&)) {
+  if (this->priv->all->vw_is_main && (this->priv->state != INITIALIZE))
+    std::cerr << "warning: task should not set label parser except in initialize function!" << endl;
+  this->priv->all->p->lp = lp;
+  this->priv->label_is_test = is_test;
+}
+
+void search::get_test_action_sequence(vector<action>& V) {
+  V.clear();
+  for (size_t i=0; i<this->priv->test_action_sequence.size(); i++)
+    V.push_back(this->priv->test_action_sequence[i]);
+}
+
+
+void search::set_num_learners(size_t num_learners) {
+  this->priv->num_learners = num_learners;
+}
+void search::add_program_options(po::variables_map& /*vw*/, po::options_description& opts) {
+  add_options( *this->priv->all, opts );
+}
+
+size_t search::get_mask() {
+  return this->priv->all->reg.weight_mask;
+}
+size_t search::get_stride_shift() {
+  return this->priv->all->reg.stride_shift;
+}
+uint32_t search::get_history_length() {
+  return (uint32_t)this->priv->history_length;
+}
+
+string search::pretty_label(action a) {
+  if (this->priv->all->sd->ldict) {
+    substring ss = this->priv->all->sd->ldict->get(a);
+    return string(ss.begin, ss.end-ss.begin);
+  } else {
+    ostringstream os;
+    os << a;
+    return os.str();
+  }
+}
+
+vw& search::get_vw_pointer_unsafe() {
+  return *this->priv->all;
+}
+void search::set_force_oracle(bool force) {
+  this->priv->force_oracle = force;
+}
+
+// predictor implementation
+predictor::predictor(search& sch, ptag my_tag) : is_ldf(false), my_tag(my_tag), ec(nullptr), ec_cnt(0), ec_alloced(false), weight(1.), oracle_is_pointer(false), allowed_is_pointer(false), learner_id(0), sch(sch) {
+  oracle_actions = v_init<action>();
+  condition_on_tags = v_init<ptag>();
+  condition_on_names = v_init<char>();
+  allowed_actions = v_init<action>();
+}
+
+void predictor::free_ec() {
+  if (ec_alloced) {
+    if (is_ldf)
+      for (size_t i=0; i<ec_cnt; i++)
+        VW::dealloc_example(CS::cs_label.delete_label, ec[i]);
+    else
+      VW::dealloc_example(nullptr, *ec);
+    free(ec);
+  }
+}
+
+predictor::~predictor() {
+  if (! oracle_is_pointer) oracle_actions.delete_v();
+  if (! allowed_is_pointer) allowed_actions.delete_v();
+  free_ec();
+  condition_on_tags.delete_v();
+  condition_on_names.delete_v();
+}
+
+predictor& predictor::set_input(example&input_example) {
+  free_ec();
+  is_ldf = false;
+  ec = &input_example;
+  ec_cnt = 1;
+  ec_alloced = false;
+  return *this;
+}
+
+predictor& predictor::set_input(example*input_example, size_t input_length) {
+  free_ec();
+  is_ldf = true;
+  ec = input_example;
+  ec_cnt = input_length;
+  ec_alloced = false;
+  return *this;
+}
+
+void predictor::set_input_length(size_t input_length) {
+  is_ldf = true;
+  if (ec_alloced)
+  {
+    example* temp = (example*)realloc(ec, input_length * sizeof(example));
+    if (temp != nullptr)
+      ec = temp;
+    else
+      THROW("realloc failed in search.cc");
+  }
+  else            ec = calloc_or_die<example>(input_length);
+  ec_cnt = input_length;
+  ec_alloced = true;
+}
+void predictor::set_input_at(size_t posn, example&ex) {
+  if (!ec_alloced)
+    THROW("call to set_input_at without previous call to set_input_length");
+
+  if (posn >= ec_cnt)
+    THROW("call to set_input_at with too large a position: posn (" << posn << ") >= ec_cnt(" << ec_cnt << ")");
+
+  VW::copy_example_data(false, ec+posn, &ex, CS::cs_label.label_size, CS::cs_label.copy_label); // TODO: the false is "audit"
+}
+
+void predictor::make_new_pointer(v_array<action>& A, size_t new_size) {
+  size_t old_size      = A.size();
+  action* old_pointer  = A.begin;
+  A.begin     = calloc_or_die<action>(new_size);
+  A.end       = A.begin + new_size;
+  A.end_array = A.end;
+  memcpy(A.begin, old_pointer, old_size * sizeof(action));
+}
+
+predictor& predictor::add_to(v_array<action>& A, bool& A_is_ptr, action a, bool clear_first) {
+  if (A_is_ptr) { // we need to make our own memory
+    if (clear_first)
+      A.end = A.begin;
+    size_t new_size = clear_first ? 1 : (A.size() + 1);
+    make_new_pointer(A, new_size);
+    A_is_ptr = false;
+    A[new_size-1] = a;
+  } else { // we've already allocated our own memory
+    if (clear_first) A.erase();
+    A.push_back(a);
+  }
+  return *this;
+}
+
+predictor& predictor::add_to(v_array<action>&A, bool& A_is_ptr, action*a, size_t action_count, bool clear_first) {
+  size_t old_size = A.size();
+  if (old_size > 0) {
     if (A_is_ptr) { // we need to make our own memory
-      if (clear_first)
+      if (clear_first) {
         A.end = A.begin;
-      size_t new_size = clear_first ? 1 : (A.size() + 1);
+        old_size = 0;
+      }
+      size_t new_size = old_size + action_count;
       make_new_pointer(A, new_size);
       A_is_ptr = false;
-      A[new_size-1] = a;
-    } else { // we've already allocated our own memory
+      memcpy(A.begin + old_size, a, action_count * sizeof(action));
+    } else { // we already have our own memory
       if (clear_first) A.erase();
-      A.push_back(a);
+      push_many<action>(A, a, action_count);
     }
-    return *this;
-  }    
+  } else { // old_size == 0, clear_first is irrelevant
+    if (! A_is_ptr)
+      A.delete_v(); // avoid memory leak
 
-  predictor& predictor::add_to(v_array<action>&A, bool& A_is_ptr, action*a, size_t action_count, bool clear_first) {
-    size_t old_size = A.size();
-    if (old_size > 0) {
-      if (A_is_ptr) { // we need to make our own memory
-        if (clear_first) {
-          A.end = A.begin;
-          old_size = 0;
-        }
-        size_t new_size = old_size + action_count;
-        make_new_pointer(A, new_size);
-        A_is_ptr = false;
-        memcpy(A.begin + old_size, a, action_count * sizeof(action));
-      } else { // we already have our own memory
-        if (clear_first) A.erase();
-        push_many<action>(A, a, action_count);
-      }
-    } else { // old_size == 0, clear_first is irrelevant
-      if (! A_is_ptr)
-        A.delete_v(); // avoid memory leak
-
-      A.begin = a;
-      A.end   = a + action_count;
-      A.end_array = A.end;
-      A_is_ptr = true;
-    }
-    return *this;
+    A.begin = a;
+    A.end   = a + action_count;
+    A.end_array = A.end;
+    A_is_ptr = true;
   }
+  return *this;
+}
 
-  predictor& predictor::erase_oracles() { if (oracle_is_pointer) oracle_actions.end = oracle_actions.begin; else oracle_actions.erase(); return *this; }
-  predictor& predictor::add_oracle(action a) { return add_to(oracle_actions, oracle_is_pointer, a, false); }
-  predictor& predictor::add_oracle(action*a, size_t action_count) { return add_to(oracle_actions, oracle_is_pointer, a, action_count, false); }
-  predictor& predictor::add_oracle(v_array<action>& a) { return add_to(oracle_actions, oracle_is_pointer, a.begin, a.size(), false); }
+predictor& predictor::erase_oracles() {
+  if (oracle_is_pointer) oracle_actions.end = oracle_actions.begin;
+  else oracle_actions.erase();
+  return *this;
+}
+predictor& predictor::add_oracle(action a) {
+  return add_to(oracle_actions, oracle_is_pointer, a, false);
+}
+predictor& predictor::add_oracle(action*a, size_t action_count) {
+  return add_to(oracle_actions, oracle_is_pointer, a, action_count, false);
+}
+predictor& predictor::add_oracle(v_array<action>& a) {
+  return add_to(oracle_actions, oracle_is_pointer, a.begin, a.size(), false);
+}
 
-  predictor& predictor::set_oracle(action a) { return add_to(oracle_actions, oracle_is_pointer, a, true); }
-  predictor& predictor::set_oracle(action*a, size_t action_count) { return add_to(oracle_actions, oracle_is_pointer, a, action_count, true); }
-  predictor& predictor::set_oracle(v_array<action>& a) { return add_to(oracle_actions, oracle_is_pointer, a.begin, a.size(), true); }
+predictor& predictor::set_oracle(action a) {
+  return add_to(oracle_actions, oracle_is_pointer, a, true);
+}
+predictor& predictor::set_oracle(action*a, size_t action_count) {
+  return add_to(oracle_actions, oracle_is_pointer, a, action_count, true);
+}
+predictor& predictor::set_oracle(v_array<action>& a) {
+  return add_to(oracle_actions, oracle_is_pointer, a.begin, a.size(), true);
+}
 
-  predictor& predictor::set_weight(float w) { weight = w; return *this; }
-  
-  predictor& predictor::erase_alloweds() { if (allowed_is_pointer) allowed_actions.end = allowed_actions.begin; else allowed_actions.erase(); return *this; }
-  predictor& predictor::add_allowed(action a) { return add_to(allowed_actions, allowed_is_pointer, a, false); }
-  predictor& predictor::add_allowed(action*a, size_t action_count) { return add_to(allowed_actions, allowed_is_pointer, a, action_count, false); }
-  predictor& predictor::add_allowed(v_array<action>& a) { return add_to(allowed_actions, allowed_is_pointer, a.begin, a.size(), false); }
+predictor& predictor::set_weight(float w) {
+  weight = w;
+  return *this;
+}
 
-  predictor& predictor::set_allowed(action a) { return add_to(allowed_actions, allowed_is_pointer, a, true); }
-  predictor& predictor::set_allowed(action*a, size_t action_count) { return add_to(allowed_actions, allowed_is_pointer, a, action_count, true); }
-  predictor& predictor::set_allowed(v_array<action>& a) { return add_to(allowed_actions, allowed_is_pointer, a.begin, a.size(), true); }
+predictor& predictor::erase_alloweds() {
+  if (allowed_is_pointer) allowed_actions.end = allowed_actions.begin;
+  else allowed_actions.erase();
+  return *this;
+}
+predictor& predictor::add_allowed(action a) {
+  return add_to(allowed_actions, allowed_is_pointer, a, false);
+}
+predictor& predictor::add_allowed(action*a, size_t action_count) {
+  return add_to(allowed_actions, allowed_is_pointer, a, action_count, false);
+}
+predictor& predictor::add_allowed(v_array<action>& a) {
+  return add_to(allowed_actions, allowed_is_pointer, a.begin, a.size(), false);
+}
 
-  predictor& predictor::add_condition(ptag tag, char name) { condition_on_tags.push_back(tag); condition_on_names.push_back(name); return *this; }
-  predictor& predictor::set_condition(ptag tag, char name) { condition_on_tags.erase(); condition_on_names.erase(); return add_condition(tag, name); }
+predictor& predictor::set_allowed(action a) {
+  return add_to(allowed_actions, allowed_is_pointer, a, true);
+}
+predictor& predictor::set_allowed(action*a, size_t action_count) {
+  return add_to(allowed_actions, allowed_is_pointer, a, action_count, true);
+}
+predictor& predictor::set_allowed(v_array<action>& a) {
+  return add_to(allowed_actions, allowed_is_pointer, a.begin, a.size(), true);
+}
 
-  predictor& predictor::add_condition_range(ptag hi, ptag count, char name0) {
-    if (count == 0) return *this;
-    for (ptag i=0; i<count; i++) {
-      if (i > hi) break;
-      char name = name0 + i;
-      condition_on_tags.push_back(hi-i);
-      condition_on_names.push_back(name);
-    }
-    return *this;
+predictor& predictor::add_condition(ptag tag, char name) {
+  condition_on_tags.push_back(tag);
+  condition_on_names.push_back(name);
+  return *this;
+}
+predictor& predictor::set_condition(ptag tag, char name) {
+  condition_on_tags.erase();
+  condition_on_names.erase();
+  return add_condition(tag, name);
+}
+
+predictor& predictor::add_condition_range(ptag hi, ptag count, char name0) {
+  if (count == 0) return *this;
+  for (ptag i=0; i<count; i++) {
+    if (i > hi) break;
+    char name = name0 + i;
+    condition_on_tags.push_back(hi-i);
+    condition_on_names.push_back(name);
   }
-  predictor& predictor::set_condition_range(ptag hi, ptag count, char name0) { condition_on_tags.erase(); condition_on_names.erase(); return add_condition_range(hi, count, name0); }
+  return *this;
+}
+predictor& predictor::set_condition_range(ptag hi, ptag count, char name0) {
+  condition_on_tags.erase();
+  condition_on_names.erase();
+  return add_condition_range(hi, count, name0);
+}
 
-  predictor& predictor::set_learner_id(size_t id) { learner_id = id; return *this; }
+predictor& predictor::set_learner_id(size_t id) {
+  learner_id = id;
+  return *this;
+}
 
-  predictor& predictor::set_tag(ptag tag) { my_tag = tag; return *this; }
+predictor& predictor::set_tag(ptag tag) {
+  my_tag = tag;
+  return *this;
+}
 
-  action predictor::predict() {
-    const action* orA = oracle_actions.size() == 0 ? nullptr : oracle_actions.begin;
-    const ptag*   cOn = condition_on_names.size() == 0 ? nullptr : condition_on_tags.begin;
-    const char*   cNa = nullptr;
-    if (condition_on_names.size() > 0) {
-      condition_on_names.push_back((char)0);  // null terminate
-      cNa = condition_on_names.begin;
-    }
-    const action* alA = (allowed_actions.size() == 0) ? nullptr : allowed_actions.begin;
-    action p = is_ldf ? sch.predictLDF(ec, ec_cnt, my_tag, orA, oracle_actions.size(), cOn, cNa, learner_id, weight)
-                      : sch.predict(*ec, my_tag, orA, oracle_actions.size(), cOn, cNa, alA, allowed_actions.size(), learner_id, weight);
-
-    if (condition_on_names.size() > 0)
-      condition_on_names.pop();  // un-null-terminate
-    return p;
+action predictor::predict() {
+  const action* orA = oracle_actions.size() == 0 ? nullptr : oracle_actions.begin;
+  const ptag*   cOn = condition_on_names.size() == 0 ? nullptr : condition_on_tags.begin;
+  const char*   cNa = nullptr;
+  if (condition_on_names.size() > 0) {
+    condition_on_names.push_back((char)0);  // null terminate
+    cNa = condition_on_names.begin;
   }
+  const action* alA = (allowed_actions.size() == 0) ? nullptr : allowed_actions.begin;
+  action p = is_ldf ? sch.predictLDF(ec, ec_cnt, my_tag, orA, oracle_actions.size(), cOn, cNa, learner_id, weight)
+             : sch.predict(*ec, my_tag, orA, oracle_actions.size(), cOn, cNa, alA, allowed_actions.size(), learner_id, weight);
+
+  if (condition_on_names.size() > 0)
+    condition_on_names.pop();  // un-null-terminate
+  return p;
+}
 }
 
 // valgrind --leak-check=full ./vw --search 2 -k -c --passes 1 --search_task sequence -d test_beam --holdout_off --search_rollin policy --search_metatask selective_branching 2>&1 | less

--- a/vowpalwabbit/search.h
+++ b/vowpalwabbit/search.h
@@ -15,296 +15,329 @@ typedef uint32_t    action;
 typedef uint32_t    ptag;
 
 namespace Search {
-  struct search_private;
-  struct search_task;
+struct search_private;
+struct search_task;
 
-  extern uint32_t AUTO_CONDITION_FEATURES, AUTO_HAMMING_LOSS, EXAMPLES_DONT_CHANGE, IS_LDF, NO_CACHING;
+extern uint32_t AUTO_CONDITION_FEATURES, AUTO_HAMMING_LOSS, EXAMPLES_DONT_CHANGE, IS_LDF, NO_CACHING;
 
-  struct search;
-  
-  class BaseTask {
-    public:
-    BaseTask(search* _sch, vector<example*>& _ec) : sch(_sch), ec(_ec) { _foreach_action = nullptr; _post_prediction = nullptr; _maybe_override_prediction = nullptr; _with_output_string = nullptr; _final_run = false; }
-    inline BaseTask& foreach_action(void (*f)(search&,size_t,float,action,bool,float)) { _foreach_action = f; return *this; }
-    inline BaseTask& post_prediction(void (*f)(search&,size_t,action,float)) { _post_prediction = f; return *this; }
-    inline BaseTask& maybe_override_prediction(bool (*f)(search&,size_t,action&,float&)) { _maybe_override_prediction = f; return *this; }
-    inline BaseTask& with_output_string(void (*f)(search&,stringstream&)) { _with_output_string = f; return *this; }
-    inline BaseTask& final_run() { _final_run = true; return *this; }
-    
-    void Run();
-    
-    // data
-    search* sch;
-    vector<example*>& ec;
-    bool _final_run;
-    void (*_foreach_action)(search&,size_t,float,action,bool,float);
-    void (*_post_prediction)(search&,size_t,action,float);
-    bool (*_maybe_override_prediction)(search&,size_t,action&,float&);
-    void (*_with_output_string)(search&,stringstream&);
-  };
-  
-  struct search {
-    // INTERFACE
-    // for managing task-specific data that you want on the heap:
-    template<class T> void  set_task_data(T*data)           { task_data = data; }
-    template<class T> T*    get_task_data()                 { return (T*)task_data; }
+struct search;
 
-    // for managing metatask-specific data
-    template<class T> void  set_metatask_data(T*data)           { metatask_data = data; }
-    template<class T> T*    get_metatask_data()                 { return (T*)metatask_data; }
+class BaseTask {
+public:
+  BaseTask(search* _sch, vector<example*>& _ec) : sch(_sch), ec(_ec) {
+    _foreach_action = nullptr;
+    _post_prediction = nullptr;
+    _maybe_override_prediction = nullptr;
+    _with_output_string = nullptr;
+    _final_run = false;
+  }
+  inline BaseTask& foreach_action(void (*f)(search&,size_t,float,action,bool,float)) {
+    _foreach_action = f;
+    return *this;
+  }
+  inline BaseTask& post_prediction(void (*f)(search&,size_t,action,float)) {
+    _post_prediction = f;
+    return *this;
+  }
+  inline BaseTask& maybe_override_prediction(bool (*f)(search&,size_t,action&,float&)) {
+    _maybe_override_prediction = f;
+    return *this;
+  }
+  inline BaseTask& with_output_string(void (*f)(search&,stringstream&)) {
+    _with_output_string = f;
+    return *this;
+  }
+  inline BaseTask& final_run() {
+    _final_run = true;
+    return *this;
+  }
 
-    // for setting programmatic options during initialization
-    // this should be an or ("|") of AUTO_CONDITION_FEATURES, etc.
-    void set_options(uint32_t opts);
+  void Run();
 
-    // change the default label parser, but you _must_ tell me how
-    // to detect test examples!
-    void set_label_parser(label_parser&lp, bool (*is_test)(polylabel&));
+  // data
+  search* sch;
+  vector<example*>& ec;
+  bool _final_run;
+  void (*_foreach_action)(search&,size_t,float,action,bool,float);
+  void (*_post_prediction)(search&,size_t,action,float);
+  bool (*_maybe_override_prediction)(search&,size_t,action&,float&);
+  void (*_with_output_string)(search&,stringstream&);
+};
 
-    // for adding command-line options
-    void add_program_options(po::variables_map& vw, po::options_description& opts);
-    
-    // for explicitly declaring a loss incrementally
-    void loss(float incr_loss);
+struct search {
+  // INTERFACE
+  // for managing task-specific data that you want on the heap:
+  template<class T> void  set_task_data(T*data)           {
+    task_data = data;
+  }
+  template<class T> T*    get_task_data()                 {
+    return (T*)task_data;
+  }
 
-    // make a prediction on an example. returns the predicted action.
-    // arguments:
-    //   ec                    the example (features) on which to make a prediction
-    //   my_tag                a tag for this prediction, so that you can explicitly
-    //                           state, for future predictions, which ones depend
-    //                           explicitely or implicitly on this prediction
-    //   oracle_actions        an array of actions that the oracle would take
-    //                           nullptr => the oracle doesn't know (is random!)
-    //   oracle_actions_cnt    the length of the previous array, or 0 if it's nullptr
-    //   condition_on          an array of previous (or future) predictions on which
-    //                           this prediction depends. the semantics of conditioning
-    //                           is that IF the predictions for all the tags in
-    //                           condition_on were the same, then the prediction for
-    //                           _this_ example will also be the same. i.e., same
-    //                           features, etc. (also assuming same policy). if
-    //                           AUTO_CONDITION_FEATURES is on, then we will automatically
-    //                           add features to ec based on what you're conditioning on.
-    //                           nullptr => independent prediction
-    //   condition_on_names    a string containing the list of names of features you're
-    //                           conditioning on. used explicitly for auditing, implicitly
-    //                           for keeping tags separated. also, strlen(condition_on_names)
-    //                           tells us how long condition_on is
-    //   allowed_actions       an array of actions that are allowed at this step, or
-    //                           nullptr if everything is allowed
-    //   allowed_actions_cnt   the length of allowed_actions
-    //   learner_id            the id for the underlying learner to use (via set_num_learners)
-    action predict(        example& ec
-                   ,       ptag     my_tag
-                   , const action*  oracle_actions
-                   ,       size_t   oracle_actions_cnt   = 1
-                   , const ptag*    condition_on         = nullptr
-                   , const char*    condition_on_names   = nullptr   // strlen(condition_on_names) should == |condition_on|
-                   , const action*  allowed_actions      = nullptr
-                   ,       size_t   allowed_actions_cnt  = 0
-                   ,       size_t   learner_id           = 0
-                   ,       float    weight               = 0.
+  // for managing metatask-specific data
+  template<class T> void  set_metatask_data(T*data)           {
+    metatask_data = data;
+  }
+  template<class T> T*    get_metatask_data()                 {
+    return (T*)metatask_data;
+  }
+
+  // for setting programmatic options during initialization
+  // this should be an or ("|") of AUTO_CONDITION_FEATURES, etc.
+  void set_options(uint32_t opts);
+
+  // change the default label parser, but you _must_ tell me how
+  // to detect test examples!
+  void set_label_parser(label_parser&lp, bool (*is_test)(polylabel&));
+
+  // for adding command-line options
+  void add_program_options(po::variables_map& vw, po::options_description& opts);
+
+  // for explicitly declaring a loss incrementally
+  void loss(float incr_loss);
+
+  // make a prediction on an example. returns the predicted action.
+  // arguments:
+  //   ec                    the example (features) on which to make a prediction
+  //   my_tag                a tag for this prediction, so that you can explicitly
+  //                           state, for future predictions, which ones depend
+  //                           explicitely or implicitly on this prediction
+  //   oracle_actions        an array of actions that the oracle would take
+  //                           nullptr => the oracle doesn't know (is random!)
+  //   oracle_actions_cnt    the length of the previous array, or 0 if it's nullptr
+  //   condition_on          an array of previous (or future) predictions on which
+  //                           this prediction depends. the semantics of conditioning
+  //                           is that IF the predictions for all the tags in
+  //                           condition_on were the same, then the prediction for
+  //                           _this_ example will also be the same. i.e., same
+  //                           features, etc. (also assuming same policy). if
+  //                           AUTO_CONDITION_FEATURES is on, then we will automatically
+  //                           add features to ec based on what you're conditioning on.
+  //                           nullptr => independent prediction
+  //   condition_on_names    a string containing the list of names of features you're
+  //                           conditioning on. used explicitly for auditing, implicitly
+  //                           for keeping tags separated. also, strlen(condition_on_names)
+  //                           tells us how long condition_on is
+  //   allowed_actions       an array of actions that are allowed at this step, or
+  //                           nullptr if everything is allowed
+  //   allowed_actions_cnt   the length of allowed_actions
+  //   learner_id            the id for the underlying learner to use (via set_num_learners)
+  action predict(        example& ec
+                         ,       ptag     my_tag
+                         , const action*  oracle_actions
+                         ,       size_t   oracle_actions_cnt   = 1
+                             , const ptag*    condition_on         = nullptr
+                                 , const char*    condition_on_names   = nullptr   // strlen(condition_on_names) should == |condition_on|
+                                     , const action*  allowed_actions      = nullptr
+                                         ,       size_t   allowed_actions_cnt  = 0
+                                             ,       size_t   learner_id           = 0
+                                                 ,       float    weight               = 0.
+                );
+
+  // make an LDF prediction on a list of examples. arguments are identical to predict(...)
+  // with the following exceptions:
+  //   * ecs/ec_cnt replace ec. ecs is the list of examples the make up a single
+  //     LDF example, and ec_cnt is its length
+  //   * there are no more "allowed_actions" because that is implicit in the LDF
+  //     example structure
+  action predictLDF(        example* ecs
+                            ,       size_t   ec_cnt
+                            ,       ptag     my_tag
+                            , const action*  oracle_actions
+                            ,       size_t   oracle_actions_cnt   = 1
+                                , const ptag*    condition_on         = nullptr
+                                    , const char*    condition_on_names   = nullptr
+                                        ,       size_t   learner_id           = 0
+                                            ,       float    weight               = 0.
                    );
 
-    // make an LDF prediction on a list of examples. arguments are identical to predict(...)
-    // with the following exceptions:
-    //   * ecs/ec_cnt replace ec. ecs is the list of examples the make up a single
-    //     LDF example, and ec_cnt is its length
-    //   * there are no more "allowed_actions" because that is implicit in the LDF
-    //     example structure
-    action predictLDF(        example* ecs
-                      ,       size_t   ec_cnt
-                      ,       ptag     my_tag
-                      , const action*  oracle_actions
-                      ,       size_t   oracle_actions_cnt   = 1
-                      , const ptag*    condition_on         = nullptr
-                      , const char*    condition_on_names   = nullptr
-                      ,       size_t   learner_id           = 0
-                      ,       float    weight               = 0.
-                      );
+  // some times during training, a call to "predict" doesn't
+  // actually use the example you pass (*), and for efficiency you
+  // might want to forgo the construction of examples in those
+  // cases. if a call to predictNeedsExample() returns true, then
+  // then any subsequent call to predict should be sure to include
+  // correctly processed examples. if it returns false, you can pass
+  // anything to the next call to predict.
+  //
+  // (*) the slight exception is for predictLDF. in this case, we
+  // always need to provide some examples so that we know which
+  // actions are possible. in LDF mode, if predictNeedsExample()
+  // returns false, then it's okay to just provide the labels in
+  // your subsequent call to predictLDF(), and skip the feature
+  // values.
+  bool   predictNeedsExample();
 
-    // some times during training, a call to "predict" doesn't
-    // actually use the example you pass (*), and for efficiency you
-    // might want to forgo the construction of examples in those
-    // cases. if a call to predictNeedsExample() returns true, then
-    // then any subsequent call to predict should be sure to include
-    // correctly processed examples. if it returns false, you can pass
-    // anything to the next call to predict.
-    //
-    // (*) the slight exception is for predictLDF. in this case, we
-    // always need to provide some examples so that we know which
-    // actions are possible. in LDF mode, if predictNeedsExample()
-    // returns false, then it's okay to just provide the labels in
-    // your subsequent call to predictLDF(), and skip the feature
-    // values.
-    bool   predictNeedsExample();
-    
-    // get the value specified by --search_history_length
-    uint32_t get_history_length();
+  // get the value specified by --search_history_length
+  uint32_t get_history_length();
 
-    // check if the user declared ldf mode
-    bool is_ldf();
-    
-    // where you should write output
-    std::stringstream& output();
+  // check if the user declared ldf mode
+  bool is_ldf();
 
-    // set the number of learners
-    void set_num_learners(size_t num_learners);
+  // where you should write output
+  std::stringstream& output();
 
-    // get the action sequence from the test run (only run if test_only or -t or...)
-    void get_test_action_sequence(vector<action>&);
+  // set the number of learners
+  void set_num_learners(size_t num_learners);
 
-    // get feature index mask
-    size_t get_mask();
+  // get the action sequence from the test run (only run if test_only or -t or...)
+  void get_test_action_sequence(vector<action>&);
 
-    // get stride_shift
-    size_t get_stride_shift();
+  // get feature index mask
+  size_t get_mask();
 
-    // pretty print a label
-    std::string pretty_label(action a);
-    
-    // for meta-tasks:
-    BaseTask base_task(vector<example*>& ec) { return BaseTask(this, ec); }
-    
-    // internal data that you don't get to see!
-    search_private* priv;
-    void*           task_data;  // your task data!
-    void*           metatask_data;  // your metatask data!
-    const char*     task_name;
-    const char*     metatask_name;
-    
-    vw& get_vw_pointer_unsafe();   // although you should rarely need this, some times you need a poiter to the vw data structure :(
-    void set_force_oracle(bool force);  // if the library wants to force search to use the oracle, set this to true
-  };
+  // get stride_shift
+  size_t get_stride_shift();
 
-  // for defining new tasks, you must fill out a search_task
-  struct search_task {
-    // required
-    const char* task_name;
-    void (*run)(search&, std::vector<example*>&);
+  // pretty print a label
+  std::string pretty_label(action a);
 
-    // optional
-    void (*initialize)(search&,size_t&, po::variables_map&);
-    void (*finish)(search&);
-    void (*run_setup)(search&, std::vector<example*>&);
-    void (*run_takedown)(search&, std::vector<example*>&);
-  };
-
-  struct search_metatask {
-    // required
-    const char* metatask_name;
-    void (*run)(search&,std::vector<example*>&);
-
-    // optional
-    void (*initialize)(search&,size_t&,po::variables_map&);
-    void (*finish)(search&);
-    void (*run_setup)(search&,std::vector<example*>&);
-    void (*run_takedown)(search&,std::vector<example*>&);
-  };
-  
-  // to make calls to "predict" (and "predictLDF") cleaner when you
-  // want to use crazy combinations of arguments
-  class predictor {
-    public:
-    predictor(search& sch, ptag my_tag);
-    ~predictor();
-
-    // tell the predictor what to use as input. a single example input
-    // means non-LDF mode; an array of inputs means LDF mode
-    predictor& set_input(example& input_example);
-    predictor& set_input(example* input_example, size_t input_length);    // if you're lucky and have an array of examples
-
-    // the following is mostly to make life manageable for the Python interface
-    void set_input_length(size_t input_length);  // declare that we have an input_length-long LDF example
-    void set_input_at(size_t posn, example&input_example); // set the corresponding input (*after* set_input_length)
-
-    // different ways of adding to the list of oracle actions. you can
-    // either add_ or set_; setting erases previous actions. these
-    // functions attempt to allocate as little memory as possible, so if
-    // you pass a v_array or an action*, unless you later add something
-    // else, we'll just store a pointer to your memory. this means that
-    // you probably shouldn't change the data there, or free that pointer,
-    // between calling add/set_oracle and calling predict()
-    predictor& erase_oracles();
-
-    predictor& add_oracle(action a);
-    predictor& add_oracle(action*a, size_t action_count);
-    predictor& add_oracle(v_array<action>& a);
-
-    predictor& set_oracle(action a);
-    predictor& set_oracle(action*a, size_t action_count);
-    predictor& set_oracle(v_array<action>& a);
-
-    predictor& set_weight(float w);
-    
-    // same as add/set_oracle but for allowed actions
-    predictor& erase_alloweds();
-
-    predictor& add_allowed(action a);
-    predictor& add_allowed(action*a, size_t action_count);
-    predictor& add_allowed(v_array<action>& a);
-    
-    predictor& set_allowed(action a);
-    predictor& set_allowed(action*a, size_t action_count);
-    predictor& set_allowed(v_array<action>& a);
-
-    // add a tag to condition on with a name, or set the conditioning
-    // variables (i.e., erase previous ones)
-    predictor& add_condition(ptag tag, char name);
-    predictor& set_condition(ptag tag, char name);
-    predictor& add_condition_range(ptag hi, ptag count, char name0); // add (hi,name0), (hi-1,name0+1), ..., (h-count,name0+count)
-    predictor& set_condition_range(ptag hi, ptag count, char name0); // set (hi,name0), (hi-1,name0+1), ..., (h-count,name0+count)
-
-    // set learner id
-    predictor& set_learner_id(size_t id);
-
-    // change the current tag
-    predictor& set_tag(ptag tag);
-
-    // make a prediction
-    action predict();
-    
-    private:
-    bool is_ldf;
-    ptag my_tag;
-    example* ec;
-    size_t ec_cnt;
-    bool ec_alloced;
-    float weight;
-    v_array<action> oracle_actions;    bool oracle_is_pointer;   // if we're pointing to your memory TRUE; if it's our own memory FALSE
-    v_array<ptag> condition_on_tags;
-    v_array<char> condition_on_names;
-    v_array<action> allowed_actions;   bool allowed_is_pointer;  // if we're pointing to your memory TRUE; if it's our own memory FALSE
-    size_t learner_id;
-    search&sch;
-
-    void make_new_pointer(v_array<action>& A, size_t new_size);
-    predictor& add_to(v_array<action>& A, bool& A_is_ptr, action a, bool clear_first);
-    predictor& add_to(v_array<action>&A, bool& A_is_ptr, action*a, size_t action_count, bool clear_first);
-    void free_ec();
-    
-    // prevent the user from doing something stupid :) ... ugh needed to turn this off for python :(
-    //predictor(const predictor&P);
-    //predictor&operator=(const predictor&P);
-  };
-  
-  // some helper functions you might find helpful
-  template<class T> void check_option(T& ret, vw&all, po::variables_map& vm, const char* opt_name, bool default_to_cmdline, bool(*equal)(T,T), const char* mismatch_error_string, const char* required_error_string) {
-    if (vm.count(opt_name)) {
-      ret = vm[opt_name].as<T>();
-      *all.file_options << " --" << opt_name << " " << ret;
-    } else if (strlen(required_error_string)>0) {
-      std::cerr << required_error_string << endl;
-      if (! vm.count("help"))
-        THROW(required_error_string);
-    }
+  // for meta-tasks:
+  BaseTask base_task(vector<example*>& ec) {
+    return BaseTask(this, ec);
   }
-  
-  void check_option(bool& ret, vw&all, po::variables_map& vm, const char* opt_name, bool default_to_cmdline, const char* mismatch_error_string);
-  bool string_equal(string a, string b);
-  bool float_equal(float a, float b);
-  bool uint32_equal(uint32_t a, uint32_t b);
-  bool size_equal(size_t a, size_t b);
-  
-  // our interface within VW
-  LEARNER::base_learner* setup(vw&);
+
+  // internal data that you don't get to see!
+  search_private* priv;
+  void*           task_data;  // your task data!
+  void*           metatask_data;  // your metatask data!
+  const char*     task_name;
+  const char*     metatask_name;
+
+  vw& get_vw_pointer_unsafe();   // although you should rarely need this, some times you need a poiter to the vw data structure :(
+  void set_force_oracle(bool force);  // if the library wants to force search to use the oracle, set this to true
+};
+
+// for defining new tasks, you must fill out a search_task
+struct search_task {
+  // required
+  const char* task_name;
+  void (*run)(search&, std::vector<example*>&);
+
+  // optional
+  void (*initialize)(search&,size_t&, po::variables_map&);
+  void (*finish)(search&);
+  void (*run_setup)(search&, std::vector<example*>&);
+  void (*run_takedown)(search&, std::vector<example*>&);
+};
+
+struct search_metatask {
+  // required
+  const char* metatask_name;
+  void (*run)(search&,std::vector<example*>&);
+
+  // optional
+  void (*initialize)(search&,size_t&,po::variables_map&);
+  void (*finish)(search&);
+  void (*run_setup)(search&,std::vector<example*>&);
+  void (*run_takedown)(search&,std::vector<example*>&);
+};
+
+// to make calls to "predict" (and "predictLDF") cleaner when you
+// want to use crazy combinations of arguments
+class predictor {
+public:
+  predictor(search& sch, ptag my_tag);
+  ~predictor();
+
+  // tell the predictor what to use as input. a single example input
+  // means non-LDF mode; an array of inputs means LDF mode
+  predictor& set_input(example& input_example);
+  predictor& set_input(example* input_example, size_t input_length);    // if you're lucky and have an array of examples
+
+  // the following is mostly to make life manageable for the Python interface
+  void set_input_length(size_t input_length);  // declare that we have an input_length-long LDF example
+  void set_input_at(size_t posn, example&input_example); // set the corresponding input (*after* set_input_length)
+
+  // different ways of adding to the list of oracle actions. you can
+  // either add_ or set_; setting erases previous actions. these
+  // functions attempt to allocate as little memory as possible, so if
+  // you pass a v_array or an action*, unless you later add something
+  // else, we'll just store a pointer to your memory. this means that
+  // you probably shouldn't change the data there, or free that pointer,
+  // between calling add/set_oracle and calling predict()
+  predictor& erase_oracles();
+
+  predictor& add_oracle(action a);
+  predictor& add_oracle(action*a, size_t action_count);
+  predictor& add_oracle(v_array<action>& a);
+
+  predictor& set_oracle(action a);
+  predictor& set_oracle(action*a, size_t action_count);
+  predictor& set_oracle(v_array<action>& a);
+
+  predictor& set_weight(float w);
+
+  // same as add/set_oracle but for allowed actions
+  predictor& erase_alloweds();
+
+  predictor& add_allowed(action a);
+  predictor& add_allowed(action*a, size_t action_count);
+  predictor& add_allowed(v_array<action>& a);
+
+  predictor& set_allowed(action a);
+  predictor& set_allowed(action*a, size_t action_count);
+  predictor& set_allowed(v_array<action>& a);
+
+  // add a tag to condition on with a name, or set the conditioning
+  // variables (i.e., erase previous ones)
+  predictor& add_condition(ptag tag, char name);
+  predictor& set_condition(ptag tag, char name);
+  predictor& add_condition_range(ptag hi, ptag count, char name0); // add (hi,name0), (hi-1,name0+1), ..., (h-count,name0+count)
+  predictor& set_condition_range(ptag hi, ptag count, char name0); // set (hi,name0), (hi-1,name0+1), ..., (h-count,name0+count)
+
+  // set learner id
+  predictor& set_learner_id(size_t id);
+
+  // change the current tag
+  predictor& set_tag(ptag tag);
+
+  // make a prediction
+  action predict();
+
+private:
+  bool is_ldf;
+  ptag my_tag;
+  example* ec;
+  size_t ec_cnt;
+  bool ec_alloced;
+  float weight;
+  v_array<action> oracle_actions;
+  bool oracle_is_pointer;   // if we're pointing to your memory TRUE; if it's our own memory FALSE
+  v_array<ptag> condition_on_tags;
+  v_array<char> condition_on_names;
+  v_array<action> allowed_actions;
+  bool allowed_is_pointer;  // if we're pointing to your memory TRUE; if it's our own memory FALSE
+  size_t learner_id;
+  search&sch;
+
+  void make_new_pointer(v_array<action>& A, size_t new_size);
+  predictor& add_to(v_array<action>& A, bool& A_is_ptr, action a, bool clear_first);
+  predictor& add_to(v_array<action>&A, bool& A_is_ptr, action*a, size_t action_count, bool clear_first);
+  void free_ec();
+
+  // prevent the user from doing something stupid :) ... ugh needed to turn this off for python :(
+  //predictor(const predictor&P);
+  //predictor&operator=(const predictor&P);
+};
+
+// some helper functions you might find helpful
+template<class T> void check_option(T& ret, vw&all, po::variables_map& vm, const char* opt_name, bool default_to_cmdline, bool(*equal)(T,T), const char* mismatch_error_string, const char* required_error_string) {
+  if (vm.count(opt_name)) {
+    ret = vm[opt_name].as<T>();
+    *all.file_options << " --" << opt_name << " " << ret;
+  } else if (strlen(required_error_string)>0) {
+    std::cerr << required_error_string << endl;
+    if (! vm.count("help"))
+      THROW(required_error_string);
+  }
+}
+
+void check_option(bool& ret, vw&all, po::variables_map& vm, const char* opt_name, bool default_to_cmdline, const char* mismatch_error_string);
+bool string_equal(string a, string b);
+bool float_equal(float a, float b);
+bool uint32_equal(uint32_t a, uint32_t b);
+bool size_equal(size_t a, size_t b);
+
+// our interface within VW
+LEARNER::base_learner* setup(vw&);
 }

--- a/vowpalwabbit/search_dep_parser.cc
+++ b/vowpalwabbit/search_dep_parser.cc
@@ -13,7 +13,9 @@
 #define val_namespace 100 // valency and distance feature space
 #define offset_const 344429
 
-namespace DepParserTask         {  Search::search_task task = { "dep_parser", run, initialize, finish, setup, nullptr};  }
+namespace DepParserTask         {
+Search::search_task task = { "dep_parser", run, initialize, finish, setup, nullptr};
+}
 
 struct task_data {
   example *ex;
@@ -25,374 +27,374 @@ struct task_data {
 };
 
 namespace DepParserTask {
-  using namespace Search;
+using namespace Search;
 
-  const action SHIFT        = 1;
-  const action REDUCE_RIGHT = 2;
-  const action REDUCE_LEFT  = 3;
+const action SHIFT        = 1;
+const action REDUCE_RIGHT = 2;
+const action REDUCE_LEFT  = 3;
 
-  void initialize(Search::search& sch, size_t& /*num_actions*/, po::variables_map& vm) {
-    vw& all = sch.get_vw_pointer_unsafe();
-    task_data *data = new task_data();
-    data->action_loss.resize(4,true);
-    data->ex = NULL;
-    sch.set_num_learners(3);
-    sch.set_task_data<task_data>(data);
-    
-	new_options(all, "Dependency Parser Options")		
-        ("root_label", po::value<size_t>(&(data->root_label))->default_value(8), "Ensure that there is only one root in each sentence")
-        ("num_label", po::value<size_t>(&(data->num_label))->default_value(12), "Number of arc labels")
-        ("old_style_labels", "Use old hack of label information");
-	add_options(all);
+void initialize(Search::search& sch, size_t& /*num_actions*/, po::variables_map& vm) {
+  vw& all = sch.get_vw_pointer_unsafe();
+  task_data *data = new task_data();
+  data->action_loss.resize(4,true);
+  data->ex = NULL;
+  sch.set_num_learners(3);
+  sch.set_task_data<task_data>(data);
 
-	check_option<size_t>(data->root_label, all, vm, "root_label", false, size_equal,
-                         "warning: you specified a different value for --root_label than the one loaded from regressor. proceeding with loaded value: ", "");
-    check_option<size_t>(data->num_label, all, vm, "num_label", false, size_equal,
-                         "warning: you specified a different value for --num_label than the one loaded from regressor. proceeding with loaded value: ", "");
-    check_option(data->old_style_labels, all, vm, "old_style_labels", false,
-                         "warning: you specified a different value for --old_style_labels than the one loaded from regressor. proceeding with loaded value: ");
+  new_options(all, "Dependency Parser Options")
+  ("root_label", po::value<size_t>(&(data->root_label))->default_value(8), "Ensure that there is only one root in each sentence")
+  ("num_label", po::value<size_t>(&(data->num_label))->default_value(12), "Number of arc labels")
+  ("old_style_labels", "Use old hack of label information");
+  add_options(all);
 
-    data->ex = VW::alloc_examples(sizeof(polylabel), 1);
-    data->ex->indices.push_back(val_namespace);
-    for(size_t i=1; i<14; i++)
-      data->ex->indices.push_back((unsigned char)i+'A');
-    data->ex->indices.push_back(constant_namespace);
+  check_option<size_t>(data->root_label, all, vm, "root_label", false, size_equal,
+                       "warning: you specified a different value for --root_label than the one loaded from regressor. proceeding with loaded value: ", "");
+  check_option<size_t>(data->num_label, all, vm, "num_label", false, size_equal,
+                       "warning: you specified a different value for --num_label than the one loaded from regressor. proceeding with loaded value: ", "");
+  check_option(data->old_style_labels, all, vm, "old_style_labels", false,
+               "warning: you specified a different value for --old_style_labels than the one loaded from regressor. proceeding with loaded value: ");
 
-    data->old_style_labels = vm.count("old_style_labels") > 0;
-    	
-    const char* pair[] = {"BC", "BE", "BB", "CC", "DD", "EE", "FF", "GG", "EF", "BH", "BJ", "EL", "dB", "dC", "dD", "dE", "dF", "dG", "dd"};
-    const char* triple[] = {"EFG", "BEF", "BCE", "BCD", "BEL", "ELM", "BHI", "BCC", "BJE", "BHE", "BJK", "BEH", "BEN", "BEJ"};
-    vector<string> newpairs(pair, pair+19);
-    vector<string> newtriples(triple, triple+14);
-    all.pairs.swap(newpairs);
-    all.triples.swap(newtriples);
+  data->ex = VW::alloc_examples(sizeof(polylabel), 1);
+  data->ex->indices.push_back(val_namespace);
+  for(size_t i=1; i<14; i++)
+    data->ex->indices.push_back((unsigned char)i+'A');
+  data->ex->indices.push_back(constant_namespace);
 
-    for (v_string* i = all.interactions.begin; i != all.interactions.end; ++i)
-        i->delete_v();
-    all.interactions.erase();
-    for (vector<string>::const_iterator i = all.pairs.begin(); i != all.pairs.end(); ++i)
-        all.interactions.push_back(string2v_string(*i));
-    for (vector<string>::const_iterator i = all.triples.begin(); i != all.triples.end(); ++i)
-        all.interactions.push_back(string2v_string(*i));
-    
-    sch.set_options(AUTO_CONDITION_FEATURES | NO_CACHING);
-    sch.set_label_parser( COST_SENSITIVE::cs_label, [](polylabel&l) -> bool { return l.cs.costs.size() == 0; });
+  data->old_style_labels = vm.count("old_style_labels") > 0;
+
+  const char* pair[] = {"BC", "BE", "BB", "CC", "DD", "EE", "FF", "GG", "EF", "BH", "BJ", "EL", "dB", "dC", "dD", "dE", "dF", "dG", "dd"};
+  const char* triple[] = {"EFG", "BEF", "BCE", "BCD", "BEL", "ELM", "BHI", "BCC", "BJE", "BHE", "BJK", "BEH", "BEN", "BEJ"};
+  vector<string> newpairs(pair, pair+19);
+  vector<string> newtriples(triple, triple+14);
+  all.pairs.swap(newpairs);
+  all.triples.swap(newtriples);
+
+  for (v_string* i = all.interactions.begin; i != all.interactions.end; ++i)
+    i->delete_v();
+  all.interactions.erase();
+  for (vector<string>::const_iterator i = all.pairs.begin(); i != all.pairs.end(); ++i)
+    all.interactions.push_back(string2v_string(*i));
+  for (vector<string>::const_iterator i = all.triples.begin(); i != all.triples.end(); ++i)
+    all.interactions.push_back(string2v_string(*i));
+
+  sch.set_options(AUTO_CONDITION_FEATURES | NO_CACHING);
+  sch.set_label_parser( COST_SENSITIVE::cs_label, [](polylabel&l) -> bool { return l.cs.costs.size() == 0; });
+}
+
+void finish(Search::search& sch) {
+  task_data *data = sch.get_task_data<task_data>();
+  data->valid_actions.delete_v();
+  data->gold_heads.delete_v();
+  data->gold_tags.delete_v();
+  data->stack.delete_v();
+  data->heads.delete_v();
+  data->tags.delete_v();
+  data->temp.delete_v();
+  data->action_loss.delete_v();
+  VW::dealloc_example(COST_SENSITIVE::cs_label.delete_label, *data->ex);
+  free(data->ex);
+  for (size_t i=0; i<6; i++) data->children[i].delete_v();
+  delete data;
+}
+
+void inline add_feature(example& ex, uint32_t idx, unsigned char ns, size_t mask, uint32_t multiplier, bool audit=false) {
+  feature f = {1.0f, (idx * multiplier) & (uint32_t)mask};
+  ex.atomics[(int)ns].push_back(f);
+  if (audit) {
+    audit_data a = { nullptr, nullptr, f.weight_index, 1.f, true };
+    ex.audit_features[(int)ns].push_back(a);
   }
+}
 
-  void finish(Search::search& sch) {
-    task_data *data = sch.get_task_data<task_data>();
-    data->valid_actions.delete_v();
-    data->gold_heads.delete_v();
-    data->gold_tags.delete_v();
-    data->stack.delete_v();
-    data->heads.delete_v();
-    data->tags.delete_v();
-    data->temp.delete_v();
-    data->action_loss.delete_v();
-	VW::dealloc_example(COST_SENSITIVE::cs_label.delete_label, *data->ex);
-    free(data->ex);
-    for (size_t i=0; i<6; i++) data->children[i].delete_v();
-    delete data;
-  } 
-
-  void inline add_feature(example& ex, uint32_t idx, unsigned char ns, size_t mask, uint32_t multiplier, bool audit=false){
-    feature f = {1.0f, (idx * multiplier) & (uint32_t)mask};
-    ex.atomics[(int)ns].push_back(f);
-    if (audit) {
-      audit_data a = { nullptr, nullptr, f.weight_index, 1.f, true };
-      ex.audit_features[(int)ns].push_back(a);
-  }
-  }
-
-  void add_all_features(example& ex, example& src, unsigned char tgt_ns, size_t mask, uint32_t multiplier, uint32_t offset, bool audit=false) {
-    for (unsigned char* ns = src.indices.begin; ns != src.indices.end; ++ns)
-      if(*ns != constant_namespace) // ignore constant_namespace
-        for (size_t k=0; k<src.atomics[*ns].size(); k++) {
-          uint32_t i = src.atomics[*ns][k].weight_index / multiplier;
-          feature  f = { 1., ((i + offset) * multiplier) & (uint32_t)mask };
-          ex.atomics[tgt_ns].push_back(f);
-          if (audit) {
-            audit_data a = { nullptr, nullptr, f.weight_index, 1.f, true };
-            ex.audit_features[tgt_ns].push_back(a);
-          }
+void add_all_features(example& ex, example& src, unsigned char tgt_ns, size_t mask, uint32_t multiplier, uint32_t offset, bool audit=false) {
+  for (unsigned char* ns = src.indices.begin; ns != src.indices.end; ++ns)
+    if(*ns != constant_namespace) // ignore constant_namespace
+      for (size_t k=0; k<src.atomics[*ns].size(); k++) {
+        uint32_t i = src.atomics[*ns][k].weight_index / multiplier;
+        feature  f = { 1., ((i + offset) * multiplier) & (uint32_t)mask };
+        ex.atomics[tgt_ns].push_back(f);
+        if (audit) {
+          audit_data a = { nullptr, nullptr, f.weight_index, 1.f, true };
+          ex.audit_features[tgt_ns].push_back(a);
         }
+      }
+}
+
+void inline reset_ex(example *ex, bool audit=false) {
+  ex->num_features = 0;
+  ex->total_sum_feat_sq = 0;
+  for(unsigned char *ns = ex->indices.begin; ns!=ex->indices.end; ns++) {
+    ex->sum_feat_sq[(int)*ns] = 0;
+    ex->atomics[(int)*ns].erase();
+    if (audit) ex->audit_features[(int)*ns].erase();
   }
-  
-  void inline reset_ex(example *ex, bool audit=false){
-    ex->num_features = 0;
-    ex->total_sum_feat_sq = 0;
-    for(unsigned char *ns = ex->indices.begin; ns!=ex->indices.end; ns++){
-      ex->sum_feat_sq[(int)*ns] = 0;
-      ex->atomics[(int)*ns].erase();
-      if (audit) ex->audit_features[(int)*ns].erase();
-    }
+}
+
+// arc-hybrid System.
+uint32_t transition_hybrid(Search::search& sch, uint32_t a_id, uint32_t idx, uint32_t t_id) {
+  task_data *data = sch.get_task_data<task_data>();
+  v_array<uint32_t> &heads=data->heads, &stack=data->stack, &gold_heads=data->gold_heads, &gold_tags=data->gold_tags, &tags = data->tags;
+  v_array<uint32_t> *children = data->children;
+  if (a_id == SHIFT) {
+    stack.push_back(idx);
+    return idx+1;
+  } else if (a_id == REDUCE_RIGHT) {
+    uint32_t last   = stack.last();
+    size_t   hd     = stack[ stack.size() - 2 ];
+    heads[last]     = hd;
+    children[5][hd] = children[4][hd];
+    children[4][hd] = last;
+    children[1][hd] ++;
+    tags[last]      = t_id;
+    sch.loss(gold_heads[last] != heads[last] ? 2 : (gold_tags[last] != t_id) ? 1.f : 0.f);
+    assert(! stack.empty());
+    stack.pop();
+    return idx;
+  } else if (a_id == REDUCE_LEFT) {
+    uint32_t last    = stack.last();
+    heads[last]      = idx;
+    children[3][idx] = children[2][idx];
+    children[2][idx] = last;
+    children[0][idx] ++;
+    tags[last]       = t_id;
+    sch.loss(gold_heads[last] != heads[last] ? 2 : (gold_tags[last] != t_id) ? 1.f : 0.f);
+    assert(! stack.empty());
+    stack.pop();
+    return idx;
   }
+  THROW("transition_hybrid failed");
+}
 
-  // arc-hybrid System.
-  uint32_t transition_hybrid(Search::search& sch, uint32_t a_id, uint32_t idx, uint32_t t_id) {
-    task_data *data = sch.get_task_data<task_data>();
-    v_array<uint32_t> &heads=data->heads, &stack=data->stack, &gold_heads=data->gold_heads, &gold_tags=data->gold_tags, &tags = data->tags;
-    v_array<uint32_t> *children = data->children;
-    if (a_id == SHIFT) {
-        stack.push_back(idx);
-        return idx+1;
-    } else if (a_id == REDUCE_RIGHT) {
-      uint32_t last   = stack.last();
-      size_t   hd     = stack[ stack.size() - 2 ];
-      heads[last]     = hd;
-      children[5][hd] = children[4][hd];
-      children[4][hd] = last;
-      children[1][hd] ++;
-      tags[last]      = t_id;
-      sch.loss(gold_heads[last] != heads[last] ? 2 : (gold_tags[last] != t_id) ? 1.f : 0.f);
-        assert(! stack.empty());
-        stack.pop();
-        return idx;
-    } else if (a_id == REDUCE_LEFT) {
-      uint32_t last    = stack.last();
-      heads[last]      = idx;
-      children[3][idx] = children[2][idx];
-      children[2][idx] = last;
-      children[0][idx] ++;
-      tags[last]       = t_id;
-      sch.loss(gold_heads[last] != heads[last] ? 2 : (gold_tags[last] != t_id) ? 1.f : 0.f);
-        assert(! stack.empty());
-        stack.pop();
-        return idx;
-    }
-    THROW("transition_hybrid failed");
-  }
-  
-  void extract_features(Search::search& sch, uint32_t idx,  vector<example*> &ec) {
-    vw& all = sch.get_vw_pointer_unsafe();
-    task_data *data = sch.get_task_data<task_data>();
-    reset_ex(data->ex);
-    size_t mask = sch.get_mask();
-    uint32_t multiplier = all.wpp << all.reg.stride_shift;
-    v_array<uint32_t> &stack = data->stack, &tags = data->tags, *children = data->children, &temp=data->temp;
-    example **ec_buf = data->ec_buf;
-    example &ex = *(data->ex);
+void extract_features(Search::search& sch, uint32_t idx,  vector<example*> &ec) {
+  vw& all = sch.get_vw_pointer_unsafe();
+  task_data *data = sch.get_task_data<task_data>();
+  reset_ex(data->ex);
+  size_t mask = sch.get_mask();
+  uint32_t multiplier = all.wpp << all.reg.stride_shift;
+  v_array<uint32_t> &stack = data->stack, &tags = data->tags, *children = data->children, &temp=data->temp;
+  example **ec_buf = data->ec_buf;
+  example &ex = *(data->ex);
 
-    size_t n = ec.size();
-    bool empty = stack.empty();
-    size_t last = empty ? 0 : stack.last();
+  size_t n = ec.size();
+  bool empty = stack.empty();
+  size_t last = empty ? 0 : stack.last();
 
-    for(size_t i=0; i<13; i++)
-      ec_buf[i] = nullptr;
+  for(size_t i=0; i<13; i++)
+    ec_buf[i] = nullptr;
 
-    // feature based on the top three examples in stack ec_buf[0]: s1, ec_buf[1]: s2, ec_buf[2]: s3
-    for(size_t i=0; i<3; i++)
-      ec_buf[i] = (stack.size()>i && *(stack.end-(i+1))!=0) ? ec[*(stack.end-(i+1))-1] : 0;
+  // feature based on the top three examples in stack ec_buf[0]: s1, ec_buf[1]: s2, ec_buf[2]: s3
+  for(size_t i=0; i<3; i++)
+    ec_buf[i] = (stack.size()>i && *(stack.end-(i+1))!=0) ? ec[*(stack.end-(i+1))-1] : 0;
 
-    // features based on examples in string buffer ec_buf[3]: b1, ec_buf[4]: b2, ec_buf[5]: b3
-    for(size_t i=3; i<6; i++)
-      ec_buf[i] = (idx+(i-3)-1 < n) ? ec[idx+i-3-1] : 0;
+  // features based on examples in string buffer ec_buf[3]: b1, ec_buf[4]: b2, ec_buf[5]: b3
+  for(size_t i=3; i<6; i++)
+    ec_buf[i] = (idx+(i-3)-1 < n) ? ec[idx+i-3-1] : 0;
 
-    // features based on the leftmost and the rightmost children of the top element stack ec_buf[6]: sl1, ec_buf[7]: sl2, ec_buf[8]: sr1, ec_buf[9]: sr2;
-    for(size_t i=6; i<10; i++)
-      if (!empty && last != 0&& children[i-4][last]!=0)
-        ec_buf[i] = ec[children[i-4][last]-1];
+  // features based on the leftmost and the rightmost children of the top element stack ec_buf[6]: sl1, ec_buf[7]: sl2, ec_buf[8]: sr1, ec_buf[9]: sr2;
+  for(size_t i=6; i<10; i++)
+    if (!empty && last != 0&& children[i-4][last]!=0)
+      ec_buf[i] = ec[children[i-4][last]-1];
 
-    // features based on leftmost children of the top element in bufer ec_buf[10]: bl1, ec_buf[11]: bl2
-    for(size_t i=10; i<12; i++)
-      ec_buf[i] = (idx <=n && children[i-8][idx]!=0) ? ec[children[i-8][idx]-1] : 0;
-    ec_buf[12] = (stack.size()>1 && *(stack.end-2)!=0 && children[2][*(stack.end-2)]!=0) ? ec[children[2][*(stack.end-2)]-1] : 0;
+  // features based on leftmost children of the top element in bufer ec_buf[10]: bl1, ec_buf[11]: bl2
+  for(size_t i=10; i<12; i++)
+    ec_buf[i] = (idx <=n && children[i-8][idx]!=0) ? ec[children[i-8][idx]-1] : 0;
+  ec_buf[12] = (stack.size()>1 && *(stack.end-2)!=0 && children[2][*(stack.end-2)]!=0) ? ec[children[2][*(stack.end-2)]-1] : 0;
 
-    // unigram features
-    for(size_t i=0; i<13; i++) {
-      uint32_t additional_offset = (uint32_t)(i*offset_const);
-      if (!ec_buf[i])
-        add_feature(ex, (uint32_t) 438129041 + additional_offset, (unsigned char)((i+1)+'A'), mask, multiplier);
-      else
-        add_all_features(ex, *ec_buf[i], 'A'+i+1, mask, multiplier, additional_offset, false);
-          }
-
-    // Other features
-    temp.resize(10,true);
-    temp[0] = empty ? 0: (idx >n? 1: 2+min(5, idx - last));
-    temp[1] = empty? 1: 1+min(5, children[0][last]);
-    temp[2] = empty? 1: 1+min(5, children[1][last]);
-    temp[3] = idx>n? 1: 1+min(5 , children[0][idx]);
-    for(size_t i=4; i<8; i++)
-      temp[i] = (!empty && children[i-2][last]!=0)?tags[children[i-2][last]]:15;
-    for(size_t i=8; i<10; i++)
-      temp[i] = (idx <=n && children[i-6][idx]!=0)? tags[children[i-6][idx]] : 15;	
-
-    uint32_t additional_offset = val_namespace*offset_const; 
-    for(uint32_t j=0; j< 10;j++) {
-      additional_offset += j* 1023;
-      add_feature(ex, temp[j]+ additional_offset , val_namespace, mask, multiplier);
-    }
-    
-    size_t count=0;        
-    for (unsigned char* ns = data->ex->indices.begin; ns != data->ex->indices.end; ns++) {
-      data->ex->sum_feat_sq[(int)*ns] = (float) data->ex->atomics[(int)*ns].size();
-      count+= data->ex->atomics[(int)*ns].size();
-    }
-
-    size_t new_count;
-    float new_weight;
-    INTERACTIONS::eval_count_of_generated_ft(all, *data->ex, new_count, new_weight);
-
-    data->ex->num_features = count + new_count;
-    data->ex->total_sum_feat_sq = (float) count + new_weight;
+  // unigram features
+  for(size_t i=0; i<13; i++) {
+    uint32_t additional_offset = (uint32_t)(i*offset_const);
+    if (!ec_buf[i])
+      add_feature(ex, (uint32_t) 438129041 + additional_offset, (unsigned char)((i+1)+'A'), mask, multiplier);
+    else
+      add_all_features(ex, *ec_buf[i], 'A'+i+1, mask, multiplier, additional_offset, false);
   }
 
-  void get_valid_actions(v_array<uint32_t> & valid_action, uint32_t idx, uint32_t n, uint32_t stack_depth, uint32_t state) {
-    valid_action.erase();
-    if(idx<=n) // SHIFT
-      valid_action.push_back( SHIFT );
-    if(stack_depth >=2) // RIGHT
-      valid_action.push_back( REDUCE_RIGHT );
-    if(stack_depth >=1 && state!=0 && idx<=n) // LEFT
-      valid_action.push_back( REDUCE_LEFT );
+  // Other features
+  temp.resize(10,true);
+  temp[0] = empty ? 0: (idx >n? 1: 2+min(5, idx - last));
+  temp[1] = empty? 1: 1+min(5, children[0][last]);
+  temp[2] = empty? 1: 1+min(5, children[1][last]);
+  temp[3] = idx>n? 1: 1+min(5 , children[0][idx]);
+  for(size_t i=4; i<8; i++)
+    temp[i] = (!empty && children[i-2][last]!=0)?tags[children[i-2][last]]:15;
+  for(size_t i=8; i<10; i++)
+    temp[i] = (idx <=n && children[i-6][idx]!=0)? tags[children[i-6][idx]] : 15;
+
+  uint32_t additional_offset = val_namespace*offset_const;
+  for(uint32_t j=0; j< 10; j++) {
+    additional_offset += j* 1023;
+    add_feature(ex, temp[j]+ additional_offset , val_namespace, mask, multiplier);
   }
 
-  bool is_valid(uint32_t action, v_array<uint32_t> valid_actions) {
-    for(size_t i=0; i< valid_actions.size(); i++)
-      if(valid_actions[i] == action)
-        return true;
-    return false;
+  size_t count=0;
+  for (unsigned char* ns = data->ex->indices.begin; ns != data->ex->indices.end; ns++) {
+    data->ex->sum_feat_sq[(int)*ns] = (float) data->ex->atomics[(int)*ns].size();
+    count+= data->ex->atomics[(int)*ns].size();
   }
 
-  void get_gold_actions(Search::search &sch, uint32_t idx, uint32_t n, v_array<action>& gold_actions){
-    gold_actions.erase();
-    task_data *data = sch.get_task_data<task_data>();
-    v_array<uint32_t> &action_loss = data->action_loss, &stack = data->stack, &gold_heads=data->gold_heads, &valid_actions=data->valid_actions;
-    size_t size = stack.size();
-    uint32_t last = (size==0) ? 0 : stack.last();
+  size_t new_count;
+  float new_weight;
+  INTERACTIONS::eval_count_of_generated_ft(all, *data->ex, new_count, new_weight);
 
-    if (is_valid(1,valid_actions) &&( stack.empty() || gold_heads[idx] == last)) {
-      gold_actions.push_back(1);
-      return;
-    }
-    
-    if (is_valid(3,valid_actions) && gold_heads[last] == idx) {
-      gold_actions.push_back(3);
-      return;
-    }
+  data->ex->num_features = count + new_count;
+  data->ex->total_sum_feat_sq = (float) count + new_weight;
+}
 
-    for(uint32_t i = 1; i<= 3; i++)
-      action_loss[i] = (is_valid(i,valid_actions))?0:100;
+void get_valid_actions(v_array<uint32_t> & valid_action, uint32_t idx, uint32_t n, uint32_t stack_depth, uint32_t state) {
+  valid_action.erase();
+  if(idx<=n) // SHIFT
+    valid_action.push_back( SHIFT );
+  if(stack_depth >=2) // RIGHT
+    valid_action.push_back( REDUCE_RIGHT );
+  if(stack_depth >=1 && state!=0 && idx<=n) // LEFT
+    valid_action.push_back( REDUCE_LEFT );
+}
 
-    for(uint32_t i = 0; i<size-1; i++)
-      if(idx <=n && (gold_heads[stack[i]] == idx || gold_heads[idx] == stack[i]))
-        action_loss[1] += 1;
-    if(size>0 && gold_heads[last] == idx)
+bool is_valid(uint32_t action, v_array<uint32_t> valid_actions) {
+  for(size_t i=0; i< valid_actions.size(); i++)
+    if(valid_actions[i] == action)
+      return true;
+  return false;
+}
+
+void get_gold_actions(Search::search &sch, uint32_t idx, uint32_t n, v_array<action>& gold_actions) {
+  gold_actions.erase();
+  task_data *data = sch.get_task_data<task_data>();
+  v_array<uint32_t> &action_loss = data->action_loss, &stack = data->stack, &gold_heads=data->gold_heads, &valid_actions=data->valid_actions;
+  size_t size = stack.size();
+  uint32_t last = (size==0) ? 0 : stack.last();
+
+  if (is_valid(1,valid_actions) &&( stack.empty() || gold_heads[idx] == last)) {
+    gold_actions.push_back(1);
+    return;
+  }
+
+  if (is_valid(3,valid_actions) && gold_heads[last] == idx) {
+    gold_actions.push_back(3);
+    return;
+  }
+
+  for(uint32_t i = 1; i<= 3; i++)
+    action_loss[i] = (is_valid(i,valid_actions))?0:100;
+
+  for(uint32_t i = 0; i<size-1; i++)
+    if(idx <=n && (gold_heads[stack[i]] == idx || gold_heads[idx] == stack[i]))
       action_loss[1] += 1;
+  if(size>0 && gold_heads[last] == idx)
+    action_loss[1] += 1;
 
-    for(uint32_t i = idx+1; i<=n; i++)
-      if(gold_heads[i] == last|| gold_heads[last] == i)
-        action_loss[3] +=1;
-    if(size>0  && idx <=n && gold_heads[idx] == last)
+  for(uint32_t i = idx+1; i<=n; i++)
+    if(gold_heads[i] == last|| gold_heads[last] == i)
       action_loss[3] +=1;
-    if(size>=2 && gold_heads[last] == stack[size-2])
-      action_loss[3] += 1;
+  if(size>0  && idx <=n && gold_heads[idx] == last)
+    action_loss[3] +=1;
+  if(size>=2 && gold_heads[last] == stack[size-2])
+    action_loss[3] += 1;
 
-    if(gold_heads[last] >=idx)
+  if(gold_heads[last] >=idx)
+    action_loss[2] +=1;
+  for(uint32_t i = idx; i<=n; i++)
+    if(gold_heads[i] == last)
       action_loss[2] +=1;
-    for(uint32_t i = idx; i<=n; i++)
-      if(gold_heads[i] == last)
-        action_loss[2] +=1;
 
-    // return the best actions
-    size_t best_action = 1;
-    size_t count = 0;
-    for(size_t i=1; i<=3; i++)
-      if(action_loss[i] < action_loss[best_action]) {
-        best_action= i;
-        count = 1;
-        gold_actions.erase();
-        gold_actions.push_back(i);
-      } else if (action_loss[i] == action_loss[best_action]) {
-        count++;
-        gold_actions.push_back(i);
-      }
+  // return the best actions
+  size_t best_action = 1;
+  size_t count = 0;
+  for(size_t i=1; i<=3; i++)
+    if(action_loss[i] < action_loss[best_action]) {
+      best_action= i;
+      count = 1;
+      gold_actions.erase();
+      gold_actions.push_back(i);
+    } else if (action_loss[i] == action_loss[best_action]) {
+      count++;
+      gold_actions.push_back(i);
+    }
+}
+
+void setup(Search::search& sch, vector<example*>& ec) {
+  task_data *data = sch.get_task_data<task_data>();
+  v_array<uint32_t> &gold_heads=data->gold_heads, &heads=data->heads, &gold_tags=data->gold_tags, &tags=data->tags;
+  uint32_t n = (uint32_t) ec.size();
+  heads.resize(n+1, true);
+  tags.resize(n+1, true);
+  gold_heads.erase();
+  gold_heads.push_back(0);
+  gold_tags.erase();
+  gold_tags.push_back(0);
+  for (size_t i=0; i<n; i++) {
+    v_array<COST_SENSITIVE::wclass>& costs = ec[i]->l.cs.costs;
+    uint32_t head,tag;
+    if (data->old_style_labels) {
+      uint32_t label = costs[0].class_index;
+      head = (label & 255) -1;
+      tag  = label >> 8;
+    } else {
+      head = (costs.size() == 0) ? 0 : costs[0].class_index;
+      tag  = (costs.size() <= 1) ? data->root_label : costs[1].class_index;
+    }
+    if (tag > data->num_label)
+      THROW("invalid label " << tag << " which is > num actions=" << data->num_label);
+
+    gold_heads.push_back(head);
+    gold_tags.push_back(tag);
+    heads[i+1] = 0;
+    tags[i+1] = -1;
+  }
+  for(size_t i=0; i<6; i++)
+    data->children[i].resize(n+1, true);
+}
+
+void run(Search::search& sch, vector<example*>& ec) {
+  task_data *data = sch.get_task_data<task_data>();
+  v_array<uint32_t> &stack=data->stack, &gold_heads=data->gold_heads, &valid_actions=data->valid_actions, &heads=data->heads, &gold_tags=data->gold_tags, &tags=data->tags;
+  uint32_t n = (uint32_t) ec.size();
+
+  stack.erase();
+  stack.push_back((data->root_label==0)?0:1);
+  for(size_t i=0; i<6; i++)
+    for(size_t j=0; j<n+1; j++)
+      data->children[i][j] = 0;
+
+  v_array<action> gold_actions = v_init<action>();
+  int count=1;
+  uint32_t idx = ((data->root_label==0)?1:2);
+  while(stack.size()>1 || idx <= n) {
+    if(sch.predictNeedsExample())
+      extract_features(sch, idx, ec);
+
+    get_valid_actions(valid_actions, idx, n, (uint32_t) stack.size(), stack.empty() ? 0 : stack.last());
+    get_gold_actions(sch, idx, n, gold_actions);
+
+    // Predict the next action {SHIFT, REDUCE_LEFT, REDUCE_RIGHT}
+    uint32_t a_id= Search::predictor(sch, (ptag) count)
+                   .set_input(*(data->ex))
+                   .set_oracle(gold_actions)
+                   .set_allowed(valid_actions)
+                   .set_condition_range(count-1, sch.get_history_length(), 'p')
+                   .set_learner_id(0)
+                   .predict();
+    count++;
+
+    uint32_t t_id = 0; // gold_tags[stack.last()]; // 0;
+    if (a_id != SHIFT) {
+      uint32_t gold_label = gold_tags[stack.last()];
+      t_id = Search::predictor(sch, (ptag) count)
+             .set_input(*(data->ex))
+             .set_oracle(gold_label)
+             .set_condition_range(count-1, sch.get_history_length(), 'p')
+             .set_learner_id(a_id-1)
+             .predict();
+    }
+    count++;
+    idx = transition_hybrid(sch, a_id, idx, t_id);
   }
 
-  void setup(Search::search& sch, vector<example*>& ec) {
-    task_data *data = sch.get_task_data<task_data>();
-    v_array<uint32_t> &gold_heads=data->gold_heads, &heads=data->heads, &gold_tags=data->gold_tags, &tags=data->tags;
-    uint32_t n = (uint32_t) ec.size();
-    heads.resize(n+1, true);
-    tags.resize(n+1, true);
-    gold_heads.erase();
-    gold_heads.push_back(0);
-    gold_tags.erase();
-    gold_tags.push_back(0);
-    for (size_t i=0; i<n; i++) {
-      v_array<COST_SENSITIVE::wclass>& costs = ec[i]->l.cs.costs;
-      uint32_t head,tag;
-      if (data->old_style_labels) {
-        uint32_t label = costs[0].class_index;
-        head = (label & 255) -1;
-        tag  = label >> 8;
-      } else {
-        head = (costs.size() == 0) ? 0 : costs[0].class_index;
-        tag  = (costs.size() <= 1) ? data->root_label : costs[1].class_index;
-      }
-	  if (tag > data->num_label)
-	    THROW("invalid label " << tag << " which is > num actions=" << data->num_label);
-
-      gold_heads.push_back(head);
-      gold_tags.push_back(tag);
-      heads[i+1] = 0;
-      tags[i+1] = -1;
-    }
-    for(size_t i=0; i<6; i++)
-      data->children[i].resize(n+1, true);
-  }    
-  
-  void run(Search::search& sch, vector<example*>& ec) {
-    task_data *data = sch.get_task_data<task_data>();
-    v_array<uint32_t> &stack=data->stack, &gold_heads=data->gold_heads, &valid_actions=data->valid_actions, &heads=data->heads, &gold_tags=data->gold_tags, &tags=data->tags;
-    uint32_t n = (uint32_t) ec.size();
-
-    stack.erase();
-    stack.push_back((data->root_label==0)?0:1);
-    for(size_t i=0; i<6; i++)
-      for(size_t j=0; j<n+1; j++)
-        data->children[i][j] = 0;
-    
-    v_array<action> gold_actions = v_init<action>();
-    int count=1;
-    uint32_t idx = ((data->root_label==0)?1:2);
-    while(stack.size()>1 || idx <= n){
-      if(sch.predictNeedsExample())
-        extract_features(sch, idx, ec);
-      
-      get_valid_actions(valid_actions, idx, n, (uint32_t) stack.size(), stack.empty() ? 0 : stack.last());      
-      get_gold_actions(sch, idx, n, gold_actions);
-
-      // Predict the next action {SHIFT, REDUCE_LEFT, REDUCE_RIGHT}
-      uint32_t a_id= Search::predictor(sch, (ptag) count)
-                              .set_input(*(data->ex))
-                              .set_oracle(gold_actions)
-                              .set_allowed(valid_actions)
-                              .set_condition_range(count-1, sch.get_history_length(), 'p')
-                              .set_learner_id(0)
-                              .predict();
-      count++;
-      
-      uint32_t t_id = 0; // gold_tags[stack.last()]; // 0;
-      if (a_id != SHIFT) {
-        uint32_t gold_label = gold_tags[stack.last()];
-        t_id = Search::predictor(sch, (ptag) count)
-                        .set_input(*(data->ex))
-                        .set_oracle(gold_label)
-                        .set_condition_range(count-1, sch.get_history_length(), 'p')
-                        .set_learner_id(a_id-1)
-                        .predict();
-      }
-      count++;
-      idx = transition_hybrid(sch, a_id, idx, t_id);
-    }
-
-    heads[stack.last()] = 0;
-    tags[stack.last()] = (uint32_t)data->root_label;
-    sch.loss((gold_heads[stack.last()] != heads[stack.last()]));
-    if (sch.output().good())
-      for(size_t i=1; i<=n; i++)
-        sch.output() << (heads[i])<<":"<<tags[i] << endl;
-  }
+  heads[stack.last()] = 0;
+  tags[stack.last()] = (uint32_t)data->root_label;
+  sch.loss((gold_heads[stack.last()] != heads[stack.last()]));
+  if (sch.output().good())
+    for(size_t i=1; i<=n; i++)
+      sch.output() << (heads[i])<<":"<<tags[i] << endl;
+}
 }

--- a/vowpalwabbit/search_dep_parser.h
+++ b/vowpalwabbit/search_dep_parser.h
@@ -7,9 +7,9 @@ license as described in the file LICENSE.
 #include "search.h"
 
 namespace DepParserTask {
-  void initialize(Search::search&, size_t&, po::variables_map&);
-  void finish(Search::search&);
-  void run(Search::search&, vector<example*>&);
-  void setup(Search::search&, vector<example*>&);
-  extern Search::search_task task;
+void initialize(Search::search&, size_t&, po::variables_map&);
+void finish(Search::search&);
+void run(Search::search&, vector<example*>&);
+void setup(Search::search&, vector<example*>&);
+extern Search::search_task task;
 }

--- a/vowpalwabbit/search_entityrelationtask.cc
+++ b/vowpalwabbit/search_entityrelationtask.cc
@@ -9,354 +9,356 @@
 #define R_NONE 10 // label for NONE relation
 #define LABEL_SKIP 11 // label for SKIP
 
-namespace EntityRelationTask { Search::search_task task = { "entity_relation", run, initialize, finish, nullptr, nullptr };  }
+namespace EntityRelationTask {
+Search::search_task task = { "entity_relation", run, initialize, finish, nullptr, nullptr };
+}
 
 
 namespace EntityRelationTask {
-  using namespace Search;
-  namespace CS = COST_SENSITIVE;
+using namespace Search;
+namespace CS = COST_SENSITIVE;
 
-  void update_example_indicies(bool audit, example* ec, uint32_t mult_amount, uint32_t plus_amount);
+void update_example_indicies(bool audit, example* ec, uint32_t mult_amount, uint32_t plus_amount);
 
-  struct task_data {
-    float relation_none_cost;
-    float entity_cost;
-    float relation_cost;
-    float skip_cost;
-    bool constraints;
-    bool allow_skip;
-    v_array<uint32_t> y_allowed_entity;
-    v_array<uint32_t> y_allowed_relation;
-    size_t search_order;
-    example* ldf_entity;
-    example* ldf_relation;
-  };
+struct task_data {
+  float relation_none_cost;
+  float entity_cost;
+  float relation_cost;
+  float skip_cost;
+  bool constraints;
+  bool allow_skip;
+  v_array<uint32_t> y_allowed_entity;
+  v_array<uint32_t> y_allowed_relation;
+  size_t search_order;
+  example* ldf_entity;
+  example* ldf_relation;
+};
 
 
-  void initialize(Search::search& sch, size_t& /*num_actions*/, po::variables_map& vm) {
-    vw& all = sch.get_vw_pointer_unsafe();
-    task_data * my_task_data = new task_data();
-    sch.set_task_data<task_data>(my_task_data);
-		
-	new_options(all, "Entity Relation Options")		
-        ("relation_cost", po::value<float>(&(my_task_data->relation_cost))->default_value(1.0), "Relation Cost")
-        ("entity_cost", po::value<float>(&(my_task_data->entity_cost))->default_value(1.0), "Entity Cost")
-        ("constraints", "Use Constraints")
-        ("relation_none_cost", po::value<float>(&(my_task_data->relation_none_cost))->default_value(0.5), "None Relation Cost")
-        ("skip_cost", po::value<float>(&(my_task_data->skip_cost))->default_value(0.01f), "Skip Cost (only used when search_order = skip")
-        ("search_order", po::value<size_t>(&(my_task_data->search_order))->default_value(0), "Search Order 0: EntityFirst 1: Mix 2: Skip 3: EntityFirst(LDF)" );
-	add_options(all);
+void initialize(Search::search& sch, size_t& /*num_actions*/, po::variables_map& vm) {
+  vw& all = sch.get_vw_pointer_unsafe();
+  task_data * my_task_data = new task_data();
+  sch.set_task_data<task_data>(my_task_data);
 
-	check_option<size_t>(my_task_data->search_order, all, vm, "search_order", false, size_equal,
-                         "warning: you specified a different value for --search_order than the one loaded from regressor. proceeding with loaded value: ", "");
-	check_option<float>(my_task_data->relation_cost, all, vm, "relation_cost", false, float_equal,
-                         "warning: you specified a different value for --relation_cost than the one loaded from regressor. proceeding with loaded value: ", "");
-	check_option<float>(my_task_data->entity_cost, all, vm, "entity_cost", false, float_equal,
-                         "warning: you specified a different value for --entity_cost than the one loaded from regressor. proceeding with loaded value: ", "");
-	check_option<float>(my_task_data->relation_none_cost, all, vm, "relation_none_cost", false, float_equal,
-                         "warning: you specified a different value for --relation_none_cost than the one loaded from regressor. proceeding with loaded value: ", "");
-	check_option<float>(my_task_data->skip_cost, all, vm, "skip_cost", false, float_equal,
-                         "warning: you specified a different value for --skip_cost than the one loaded from regressor. proceeding with loaded value: ", "");
-    check_option(my_task_data->constraints, all, vm, "constraints", false,
-                         "warning: you specified a different value for --constraints than the one loaded from regressor. proceeding with loaded value: ");
+  new_options(all, "Entity Relation Options")
+  ("relation_cost", po::value<float>(&(my_task_data->relation_cost))->default_value(1.0), "Relation Cost")
+  ("entity_cost", po::value<float>(&(my_task_data->entity_cost))->default_value(1.0), "Entity Cost")
+  ("constraints", "Use Constraints")
+  ("relation_none_cost", po::value<float>(&(my_task_data->relation_none_cost))->default_value(0.5), "None Relation Cost")
+  ("skip_cost", po::value<float>(&(my_task_data->skip_cost))->default_value(0.01f), "Skip Cost (only used when search_order = skip")
+  ("search_order", po::value<size_t>(&(my_task_data->search_order))->default_value(0), "Search Order 0: EntityFirst 1: Mix 2: Skip 3: EntityFirst(LDF)" );
+  add_options(all);
 
-    // setup entity and relation labels
-    // Entity label 1:E_Other 2:E_Peop 3:E_Org 4:E_Loc
-    // Relation label 5:R_Live_in 6:R_OrgBased_in 7:R_Located_in 8:R_Work_For 9:R_Kill 10:R_None
-    my_task_data->constraints = vm.count("constraints") > 0;
+  check_option<size_t>(my_task_data->search_order, all, vm, "search_order", false, size_equal,
+                       "warning: you specified a different value for --search_order than the one loaded from regressor. proceeding with loaded value: ", "");
+  check_option<float>(my_task_data->relation_cost, all, vm, "relation_cost", false, float_equal,
+                      "warning: you specified a different value for --relation_cost than the one loaded from regressor. proceeding with loaded value: ", "");
+  check_option<float>(my_task_data->entity_cost, all, vm, "entity_cost", false, float_equal,
+                      "warning: you specified a different value for --entity_cost than the one loaded from regressor. proceeding with loaded value: ", "");
+  check_option<float>(my_task_data->relation_none_cost, all, vm, "relation_none_cost", false, float_equal,
+                      "warning: you specified a different value for --relation_none_cost than the one loaded from regressor. proceeding with loaded value: ", "");
+  check_option<float>(my_task_data->skip_cost, all, vm, "skip_cost", false, float_equal,
+                      "warning: you specified a different value for --skip_cost than the one loaded from regressor. proceeding with loaded value: ", "");
+  check_option(my_task_data->constraints, all, vm, "constraints", false,
+               "warning: you specified a different value for --constraints than the one loaded from regressor. proceeding with loaded value: ");
 
-    for(int i=1; i<5; i++)
-      my_task_data->y_allowed_entity.push_back(i);
+  // setup entity and relation labels
+  // Entity label 1:E_Other 2:E_Peop 3:E_Org 4:E_Loc
+  // Relation label 5:R_Live_in 6:R_OrgBased_in 7:R_Located_in 8:R_Work_For 9:R_Kill 10:R_None
+  my_task_data->constraints = vm.count("constraints") > 0;
 
-    for(int i=5; i<11; i++)
-      my_task_data->y_allowed_relation.push_back(i);
+  for(int i=1; i<5; i++)
+    my_task_data->y_allowed_entity.push_back(i);
 
-    my_task_data->allow_skip = false;
+  for(int i=5; i<11; i++)
+    my_task_data->y_allowed_relation.push_back(i);
 
-    if(my_task_data->search_order != 3 && my_task_data->search_order != 4 ) {
-      sch.set_options(0);
-    } else {
-      example* ldf_examples = VW::alloc_examples(sizeof(CS::label), 10);
-      CS::wclass default_wclass = { 0., 0, 0., 0. };
-      for (size_t a=0; a<10; a++) {
-        ldf_examples[a].l.cs.costs.push_back(default_wclass);
-      }
-      my_task_data->ldf_entity = ldf_examples;
-      my_task_data->ldf_relation = ldf_examples+4;
-      sch.set_options(Search::IS_LDF);
+  my_task_data->allow_skip = false;
+
+  if(my_task_data->search_order != 3 && my_task_data->search_order != 4 ) {
+    sch.set_options(0);
+  } else {
+    example* ldf_examples = VW::alloc_examples(sizeof(CS::label), 10);
+    CS::wclass default_wclass = { 0., 0, 0., 0. };
+    for (size_t a=0; a<10; a++) {
+      ldf_examples[a].l.cs.costs.push_back(default_wclass);
     }
-   
-    sch.set_num_learners(2);
-    if(my_task_data->search_order == 4)
-      sch.set_num_learners(3);
-
+    my_task_data->ldf_entity = ldf_examples;
+    my_task_data->ldf_relation = ldf_examples+4;
+    sch.set_options(Search::IS_LDF);
   }
 
-  void finish(Search::search& sch) {
-    task_data * my_task_data = sch.get_task_data<task_data>();
-    my_task_data->y_allowed_entity.delete_v();
-    my_task_data->y_allowed_relation.delete_v();
-    if(my_task_data->search_order == 3) {
-      for (size_t a=0; a<10; a++)
-        VW::dealloc_example(CS::cs_label.delete_label, my_task_data->ldf_entity[a]);
-      free(my_task_data->ldf_entity);
-    }
-    delete my_task_data;
-  }    // if we had task data, we'd want to free it here
+  sch.set_num_learners(2);
+  if(my_task_data->search_order == 4)
+    sch.set_num_learners(3);
 
-  bool check_constraints(int ent1_id, int ent2_id, int rel_id){
-    int valid_ent1_id [] = {2,3,4,2,2}; // encode the valid entity-relation combinations 
-    int valid_ent2_id [] = {4,4,4,3,2};
-    if(rel_id - 5 == 5)
-      return true;
-    if(valid_ent1_id[rel_id-5] == ent1_id && valid_ent2_id[rel_id-5] == ent2_id)
-      return true;
-    return false;
+}
+
+void finish(Search::search& sch) {
+  task_data * my_task_data = sch.get_task_data<task_data>();
+  my_task_data->y_allowed_entity.delete_v();
+  my_task_data->y_allowed_relation.delete_v();
+  if(my_task_data->search_order == 3) {
+    for (size_t a=0; a<10; a++)
+      VW::dealloc_example(CS::cs_label.delete_label, my_task_data->ldf_entity[a]);
+    free(my_task_data->ldf_entity);
   }
+  delete my_task_data;
+}    // if we had task data, we'd want to free it here
 
-  void decode_tag(v_array<char> tag, char& type, int& id1, int& id2){
-    string s1;
-    string s2;
-    type = tag[0];
-    uint32_t idx = 2;
-    while(idx < tag.size() && tag[idx] != '_' && tag[idx] != '\0'){
-      s1.push_back(tag[idx]);                  
-      idx++;
-    }
-    id1 = atoi(s1.c_str());
+bool check_constraints(int ent1_id, int ent2_id, int rel_id) {
+  int valid_ent1_id [] = {2,3,4,2,2}; // encode the valid entity-relation combinations
+  int valid_ent2_id [] = {4,4,4,3,2};
+  if(rel_id - 5 == 5)
+    return true;
+  if(valid_ent1_id[rel_id-5] == ent1_id && valid_ent2_id[rel_id-5] == ent2_id)
+    return true;
+  return false;
+}
+
+void decode_tag(v_array<char> tag, char& type, int& id1, int& id2) {
+  string s1;
+  string s2;
+  type = tag[0];
+  uint32_t idx = 2;
+  while(idx < tag.size() && tag[idx] != '_' && tag[idx] != '\0') {
+    s1.push_back(tag[idx]);
     idx++;
-    assert(type == 'R');
-    while(idx < tag.size() && tag[idx] != '_' && tag[idx] != '\0'){
-      s2.push_back(tag[idx]);                  
-      idx++;
-    }
-    id2 = atoi(s2.c_str());
   }
-  
-  size_t predict_entity(Search::search&sch, example* ex, v_array<size_t>& /*predictions*/, ptag my_tag, bool isLdf=false){
-	  	
-    task_data* my_task_data = sch.get_task_data<task_data>();
-    size_t prediction;
-    if(my_task_data->allow_skip){
-      v_array<uint32_t> star_labels = v_init<uint32_t>();
-      star_labels.push_back(ex->l.multi.label);
-      star_labels.push_back(LABEL_SKIP);
-      my_task_data->y_allowed_entity.push_back(LABEL_SKIP);
-      prediction = Search::predictor(sch, my_tag).set_input(*ex).set_oracle(star_labels).set_allowed(my_task_data->y_allowed_entity).set_learner_id(1).predict();
-      my_task_data->y_allowed_entity.pop();
+  id1 = atoi(s1.c_str());
+  idx++;
+  assert(type == 'R');
+  while(idx < tag.size() && tag[idx] != '_' && tag[idx] != '\0') {
+    s2.push_back(tag[idx]);
+    idx++;
+  }
+  id2 = atoi(s2.c_str());
+}
+
+size_t predict_entity(Search::search&sch, example* ex, v_array<size_t>& /*predictions*/, ptag my_tag, bool isLdf=false) {
+
+  task_data* my_task_data = sch.get_task_data<task_data>();
+  size_t prediction;
+  if(my_task_data->allow_skip) {
+    v_array<uint32_t> star_labels = v_init<uint32_t>();
+    star_labels.push_back(ex->l.multi.label);
+    star_labels.push_back(LABEL_SKIP);
+    my_task_data->y_allowed_entity.push_back(LABEL_SKIP);
+    prediction = Search::predictor(sch, my_tag).set_input(*ex).set_oracle(star_labels).set_allowed(my_task_data->y_allowed_entity).set_learner_id(1).predict();
+    my_task_data->y_allowed_entity.pop();
+  } else {
+    if(isLdf) {
+      for(size_t a=0; a<4; a++) {
+        VW::copy_example_data(false, &my_task_data->ldf_entity[a], ex);
+        update_example_indicies(true, &my_task_data->ldf_entity[a], 28904713, 4832917 * (uint32_t)(a+1));
+        CS::label& lab = my_task_data->ldf_entity[a].l.cs;
+        lab.costs[0].x = 0.f;
+        lab.costs[0].class_index = (uint32_t)a;
+        lab.costs[0].partial_prediction = 0.f;
+        lab.costs[0].wap_value = 0.f;
+      }
+      prediction = Search::predictor(sch, my_tag).set_input(my_task_data->ldf_entity, 4).set_oracle(ex->l.multi.label-1).set_learner_id(1).predict() + 1;
     } else {
-      if(isLdf) {
-        for(size_t a=0; a<4; a++){
-          VW::copy_example_data(false, &my_task_data->ldf_entity[a], ex);
-          update_example_indicies(true, &my_task_data->ldf_entity[a], 28904713, 4832917 * (uint32_t)(a+1));
-          CS::label& lab = my_task_data->ldf_entity[a].l.cs;
-          lab.costs[0].x = 0.f;
-          lab.costs[0].class_index = (uint32_t)a;
-          lab.costs[0].partial_prediction = 0.f;
-          lab.costs[0].wap_value = 0.f;
+      prediction = Search::predictor(sch, my_tag).set_input(*ex).set_oracle(ex->l.multi.label).set_allowed(my_task_data->y_allowed_entity).set_learner_id(0).predict();
+    }
+  }
+
+  // record loss
+  float loss = 0.0;
+  if(prediction == LABEL_SKIP) {
+    loss = my_task_data->skip_cost;
+  } else if(prediction !=  ex->l.multi.label)
+    loss= my_task_data->entity_cost;
+  sch.loss(loss);
+  return prediction;
+}
+size_t predict_relation(Search::search&sch, example* ex, v_array<size_t>& predictions, ptag my_tag, bool isLdf=false) {
+  char type;
+  int id1, id2;
+  task_data* my_task_data = sch.get_task_data<task_data>();
+  uint32_t hist[2];
+  decode_tag(ex->tag, type, id1, id2);
+  v_array<uint32_t> constrained_relation_labels = v_init<uint32_t>();
+  if(my_task_data->constraints && predictions[id1]!=0 &&predictions[id2]!=0) {
+    hist[0] = (uint32_t)predictions[id1];
+    hist[1] = (uint32_t)predictions[id2];
+  } else {
+    hist[0] = 0;
+    hist[1] = 0;
+  }
+  for(size_t j=0; j< my_task_data->y_allowed_relation.size(); j++) {
+    if(!my_task_data->constraints || hist[0] == 0  || check_constraints(hist[0], hist[1], my_task_data->y_allowed_relation[j])) {
+      constrained_relation_labels.push_back(my_task_data->y_allowed_relation[j]);
+    }
+  }
+
+  size_t prediction;
+  if(my_task_data->allow_skip) {
+    v_array<uint32_t> star_labels = v_init<uint32_t>();
+    star_labels.push_back(ex->l.multi.label);
+    star_labels.push_back(LABEL_SKIP);
+    constrained_relation_labels.push_back(LABEL_SKIP);
+    prediction = Search::predictor(sch, my_tag).set_input(*ex).set_oracle(star_labels).set_allowed(constrained_relation_labels).set_learner_id(2).add_condition(id1, 'a').add_condition(id2, 'b').predict();
+    constrained_relation_labels.pop();
+  } else {
+    if(isLdf) {
+      int correct_label = 0; // if correct label is not in the set, use the first one
+      for(size_t a=0; a<constrained_relation_labels.size(); a++) {
+        VW::copy_example_data(false, &my_task_data->ldf_relation[a], ex);
+        update_example_indicies(true, &my_task_data->ldf_relation[a], 28904713, 4832917* (uint32_t)(constrained_relation_labels[a]));
+        CS::label& lab = my_task_data->ldf_relation[a].l.cs;
+        lab.costs[0].x = 0.f;
+        lab.costs[0].class_index = (uint32_t)constrained_relation_labels[a];
+        lab.costs[0].partial_prediction = 0.f;
+        lab.costs[0].wap_value = 0.f;
+        if(constrained_relation_labels[a] == ex->l.multi.label) {
+          correct_label = (int)a;
         }
-        prediction = Search::predictor(sch, my_tag).set_input(my_task_data->ldf_entity, 4).set_oracle(ex->l.multi.label-1).set_learner_id(1).predict() + 1;
-      } else {
-        prediction = Search::predictor(sch, my_tag).set_input(*ex).set_oracle(ex->l.multi.label).set_allowed(my_task_data->y_allowed_entity).set_learner_id(0).predict();
       }
-    }
-
-    // record loss
-    float loss = 0.0;
-    if(prediction == LABEL_SKIP){
-      loss = my_task_data->skip_cost;
-    } else if(prediction !=  ex->l.multi.label)
-      loss= my_task_data->entity_cost;
-    sch.loss(loss);
-    return prediction;
-  }
-  size_t predict_relation(Search::search&sch, example* ex, v_array<size_t>& predictions, ptag my_tag, bool isLdf=false){
-    char type; 
-    int id1, id2;
-    task_data* my_task_data = sch.get_task_data<task_data>();
-    uint32_t hist[2];
-    decode_tag(ex->tag, type, id1, id2);
-    v_array<uint32_t> constrained_relation_labels = v_init<uint32_t>();
-    if(my_task_data->constraints && predictions[id1]!=0 &&predictions[id2]!=0){
-      hist[0] = (uint32_t)predictions[id1];
-      hist[1] = (uint32_t)predictions[id2];
+      size_t pred_pos = Search::predictor(sch, my_tag).set_input(my_task_data->ldf_relation, constrained_relation_labels.size()).set_oracle(correct_label).set_learner_id(2).predict();
+      prediction = constrained_relation_labels[pred_pos];
     } else {
-      hist[0] = 0;
-      hist[1] = 0;
+      prediction = Search::predictor(sch, my_tag).set_input(*ex).set_oracle(ex->l.multi.label).set_allowed(constrained_relation_labels).set_learner_id(1).predict();
     }
-    for(size_t j=0; j< my_task_data->y_allowed_relation.size(); j++){
-      if(!my_task_data->constraints || hist[0] == 0  || check_constraints(hist[0], hist[1], my_task_data->y_allowed_relation[j])){
-        constrained_relation_labels.push_back(my_task_data->y_allowed_relation[j]);
-      }
-    }
-
-    size_t prediction;
-    if(my_task_data->allow_skip){
-      v_array<uint32_t> star_labels = v_init<uint32_t>();
-      star_labels.push_back(ex->l.multi.label);
-      star_labels.push_back(LABEL_SKIP);
-      constrained_relation_labels.push_back(LABEL_SKIP);
-      prediction = Search::predictor(sch, my_tag).set_input(*ex).set_oracle(star_labels).set_allowed(constrained_relation_labels).set_learner_id(2).add_condition(id1, 'a').add_condition(id2, 'b').predict();
-      constrained_relation_labels.pop();
-    } else {
-      if(isLdf) {
-        int correct_label = 0; // if correct label is not in the set, use the first one 
-        for(size_t a=0; a<constrained_relation_labels.size(); a++){
-          VW::copy_example_data(false, &my_task_data->ldf_relation[a], ex);
-          update_example_indicies(true, &my_task_data->ldf_relation[a], 28904713, 4832917* (uint32_t)(constrained_relation_labels[a]));
-          CS::label& lab = my_task_data->ldf_relation[a].l.cs;
-          lab.costs[0].x = 0.f;
-          lab.costs[0].class_index = (uint32_t)constrained_relation_labels[a];
-          lab.costs[0].partial_prediction = 0.f;
-          lab.costs[0].wap_value = 0.f;
-          if(constrained_relation_labels[a] == ex->l.multi.label){
-            correct_label = (int)a;
-          }
-        }
-        size_t pred_pos = Search::predictor(sch, my_tag).set_input(my_task_data->ldf_relation, constrained_relation_labels.size()).set_oracle(correct_label).set_learner_id(2).predict();
-        prediction = constrained_relation_labels[pred_pos];
-      } else {
-        prediction = Search::predictor(sch, my_tag).set_input(*ex).set_oracle(ex->l.multi.label).set_allowed(constrained_relation_labels).set_learner_id(1).predict();
-      }
-    }
-
-    float loss = 0.0;
-    if(prediction == LABEL_SKIP){
-      loss = my_task_data->skip_cost;
-    } else if(prediction !=  ex->l.multi.label) {
-      if(ex->l.multi.label == R_NONE){
-        loss = my_task_data->relation_none_cost;
-      } else {
-        loss= my_task_data->relation_cost;
-      }
-    }
-    sch.loss(loss);
-    return prediction;
   }
 
-  void entity_first_decoding(Search::search& sch, vector<example*> ec, v_array<size_t>& predictions, bool isLdf=false) {
-    // ec.size = #entity + #entity*(#entity-1)/2
-    size_t n_ent = (size_t)(sqrt(ec.size()*8+1)-1)/2;
+  float loss = 0.0;
+  if(prediction == LABEL_SKIP) {
+    loss = my_task_data->skip_cost;
+  } else if(prediction !=  ex->l.multi.label) {
+    if(ex->l.multi.label == R_NONE) {
+      loss = my_task_data->relation_none_cost;
+    } else {
+      loss= my_task_data->relation_cost;
+    }
+  }
+  sch.loss(loss);
+  return prediction;
+}
+
+void entity_first_decoding(Search::search& sch, vector<example*> ec, v_array<size_t>& predictions, bool isLdf=false) {
+  // ec.size = #entity + #entity*(#entity-1)/2
+  size_t n_ent = (size_t)(sqrt(ec.size()*8+1)-1)/2;
+  // Do entity recognition first
+  for (size_t i=0; i<ec.size(); i++) {
+    if(i< n_ent)
+      predictions[i] = predict_entity(sch, ec[i], predictions, (ptag)i, isLdf);
+    else
+      predictions[i] = predict_relation(sch, ec[i], predictions, (ptag)i, isLdf);
+  }
+}
+
+void er_mixed_decoding(Search::search& sch, vector<example*> ec, v_array<size_t>& predictions) {
+  // ec.size = #entity + #entity*(#entity-1)/2
+  size_t n_ent = (size_t)(sqrt(ec.size()*8+1)-1)/2;
+  for(size_t t=0; t<ec.size(); t++) {
     // Do entity recognition first
-    for (size_t i=0; i<ec.size(); i++) {
-      if(i< n_ent)
-        predictions[i] = predict_entity(sch, ec[i], predictions, (ptag)i, isLdf);
-      else
-        predictions[i] = predict_relation(sch, ec[i], predictions, (ptag)i, isLdf);
-    }
-  }
-
-  void er_mixed_decoding(Search::search& sch, vector<example*> ec, v_array<size_t>& predictions) {
-    // ec.size = #entity + #entity*(#entity-1)/2
-    size_t n_ent = (size_t)(sqrt(ec.size()*8+1)-1)/2;
-    for(size_t t=0; t<ec.size(); t++){
-      // Do entity recognition first
-      size_t count = 0;
-      for (size_t i=0; i<n_ent; i++) {
-        if(count ==t){
-          predictions[i] = predict_entity(sch, ec[i], predictions, (ptag)i);
+    size_t count = 0;
+    for (size_t i=0; i<n_ent; i++) {
+      if(count ==t) {
+        predictions[i] = predict_entity(sch, ec[i], predictions, (ptag)i);
+        break;
+      }
+      count++;
+      for(size_t j=0; j<i; j++) {
+        if(count ==t) {
+          uint32_t rel_index = (uint32_t) (n_ent + (2*n_ent-j-1)*j/2 + i-j-1);
+          predictions[rel_index] = predict_relation(sch, ec[rel_index], predictions, rel_index);
           break;
         }
         count++;
-        for(size_t j=0; j<i; j++) {
-          if(count ==t){
-            uint32_t rel_index = (uint32_t) (n_ent + (2*n_ent-j-1)*j/2 + i-j-1);
-            predictions[rel_index] = predict_relation(sch, ec[rel_index], predictions, rel_index);
-            break;
-          }
-          count++;
-        }
       }
     }
   }
+}
 
-  void er_allow_skip_decoding(Search::search& sch, vector<example*> ec, v_array<size_t>& predictions) {
-    task_data* my_task_data = sch.get_task_data<task_data>();
-    // ec.size = #entity + #entity*(#entity-1)/2
-    size_t n_ent = (size_t)(sqrt(ec.size()*8+1)-1)/2;
+void er_allow_skip_decoding(Search::search& sch, vector<example*> ec, v_array<size_t>& predictions) {
+  task_data* my_task_data = sch.get_task_data<task_data>();
+  // ec.size = #entity + #entity*(#entity-1)/2
+  size_t n_ent = (size_t)(sqrt(ec.size()*8+1)-1)/2;
 
-    bool must_predict = false;
-    size_t n_predicts = 0;
-    size_t p_n_predicts = 0;
-    my_task_data->allow_skip = true;
-             
-    // loop until all the entity and relation types are predicted
-    for(size_t t=0; ; t++){
-      uint32_t i = (uint32_t) t % ec.size();
-      if(n_predicts == ec.size())
-        break;
-      
-      if(predictions[i] == 0){
-        if(must_predict) {
-          my_task_data->allow_skip = false;
-        }
-        size_t prediction = 0;
-        if(i < n_ent) {// do entity recognition
-          prediction = predict_entity(sch, ec[i], predictions, i);
-        } else { // do relation recognition
-          prediction = predict_relation(sch, ec[i], predictions, i);
-        }
+  bool must_predict = false;
+  size_t n_predicts = 0;
+  size_t p_n_predicts = 0;
+  my_task_data->allow_skip = true;
 
-        if(prediction != LABEL_SKIP){
-          predictions[i] = prediction;
-          n_predicts++;
-        }
+  // loop until all the entity and relation types are predicted
+  for(size_t t=0; ; t++) {
+    uint32_t i = (uint32_t) t % ec.size();
+    if(n_predicts == ec.size())
+      break;
 
-        if(must_predict) {
-          my_task_data->allow_skip = true;
-          must_predict = false;
-        }
-      } 
+    if(predictions[i] == 0) {
+      if(must_predict) {
+        my_task_data->allow_skip = false;
+      }
+      size_t prediction = 0;
+      if(i < n_ent) {// do entity recognition
+        prediction = predict_entity(sch, ec[i], predictions, i);
+      } else { // do relation recognition
+        prediction = predict_relation(sch, ec[i], predictions, i);
+      }
 
-      if(i == ec.size()-1) {
-        if(n_predicts == p_n_predicts){
-          must_predict = true;
-        }
-        p_n_predicts = n_predicts;
+      if(prediction != LABEL_SKIP) {
+        predictions[i] = prediction;
+        n_predicts++;
+      }
+
+      if(must_predict) {
+        my_task_data->allow_skip = true;
+        must_predict = false;
       }
     }
-  }
- 
-  void run(Search::search& sch, vector<example*>& ec) {
-    task_data* my_task_data = sch.get_task_data<task_data>();
-    
-    v_array<size_t> predictions = v_init<size_t>();
-    for(size_t i=0; i<ec.size(); i++){
-      predictions.push_back(0);
-    }
-        
-    switch(my_task_data->search_order) {
-      case 0:
-        entity_first_decoding(sch, ec, predictions, false);
-        break;
-      case 1:
-        er_mixed_decoding(sch, ec, predictions);
-        break;
-      case 2:
-        er_allow_skip_decoding(sch, ec, predictions);
-        break;
-      case 3:
-        entity_first_decoding(sch, ec, predictions, true); //LDF = true
-        break;
-      default:
-        cerr << "search order " << my_task_data->search_order << "is undefined." << endl;
-    }
 
-    
-    for(size_t i=0; i<ec.size(); i++){
-      if (sch.output().good())
-        sch.output() << predictions[i] << ' ';
+    if(i == ec.size()-1) {
+      if(n_predicts == p_n_predicts) {
+        must_predict = true;
+      }
+      p_n_predicts = n_predicts;
     }
   }
-  // this is totally bogus for the example -- you'd never actually do this!
-  void update_example_indicies(bool audit, example* ec, uint32_t mult_amount, uint32_t plus_amount) {
+}
+
+void run(Search::search& sch, vector<example*>& ec) {
+  task_data* my_task_data = sch.get_task_data<task_data>();
+
+  v_array<size_t> predictions = v_init<size_t>();
+  for(size_t i=0; i<ec.size(); i++) {
+    predictions.push_back(0);
+  }
+
+  switch(my_task_data->search_order) {
+  case 0:
+    entity_first_decoding(sch, ec, predictions, false);
+    break;
+  case 1:
+    er_mixed_decoding(sch, ec, predictions);
+    break;
+  case 2:
+    er_allow_skip_decoding(sch, ec, predictions);
+    break;
+  case 3:
+    entity_first_decoding(sch, ec, predictions, true); //LDF = true
+    break;
+  default:
+    cerr << "search order " << my_task_data->search_order << "is undefined." << endl;
+  }
+
+
+  for(size_t i=0; i<ec.size(); i++) {
+    if (sch.output().good())
+      sch.output() << predictions[i] << ' ';
+  }
+}
+// this is totally bogus for the example -- you'd never actually do this!
+void update_example_indicies(bool audit, example* ec, uint32_t mult_amount, uint32_t plus_amount) {
+  for (unsigned char* i = ec->indices.begin; i != ec->indices.end; i++)
+    for (feature* f = ec->atomics[*i].begin; f != ec->atomics[*i].end; ++f)
+      f->weight_index = ((f->weight_index * mult_amount) + plus_amount);
+  if (audit)
     for (unsigned char* i = ec->indices.begin; i != ec->indices.end; i++)
-      for (feature* f = ec->atomics[*i].begin; f != ec->atomics[*i].end; ++f)
-        f->weight_index = ((f->weight_index * mult_amount) + plus_amount);
-    if (audit)
-      for (unsigned char* i = ec->indices.begin; i != ec->indices.end; i++) 
-        if (ec->audit_features[*i].begin != ec->audit_features[*i].end)
-          for (audit_data *f = ec->audit_features[*i].begin; f != ec->audit_features[*i].end; ++f)
-            f->weight_index = ((f->weight_index * mult_amount) + plus_amount);
-  }
+      if (ec->audit_features[*i].begin != ec->audit_features[*i].end)
+        for (audit_data *f = ec->audit_features[*i].begin; f != ec->audit_features[*i].end; ++f)
+          f->weight_index = ((f->weight_index * mult_amount) + plus_amount);
+}
 }

--- a/vowpalwabbit/search_entityrelationtask.h
+++ b/vowpalwabbit/search_entityrelationtask.h
@@ -7,8 +7,8 @@ license as described in the file LICENSE.
 #include "search.h"
 
 namespace EntityRelationTask {
-  void initialize(Search::search&, size_t&, po::variables_map&);
-  void finish(Search::search&);
-  void run(Search::search&, vector<example*>&);
-  extern Search::search_task task;
+void initialize(Search::search&, size_t&, po::variables_map&);
+void finish(Search::search&);
+void run(Search::search&, vector<example*>&);
+extern Search::search_task task;
 }

--- a/vowpalwabbit/search_graph.cc
+++ b/vowpalwabbit/search_graph.cc
@@ -57,352 +57,371 @@ instance "n1 n2 n3 0 n4 | ..." is the same as "n1 n2 n3 n4 | ...", but
 */
 
 namespace GraphTask {
-  Search::search_task task = { "graph", run, initialize, finish, setup, takedown };
+Search::search_task task = { "graph", run, initialize, finish, setup, takedown };
 
-  struct task_data {
-    // global data
-    size_t num_loops;
-    size_t K;  // number of labels, *NOT* including the +1 for 'unlabeled'
-    size_t numN; // number of neighbor predictions (equals K+1 for undirected, or 2*(K+1) for directed)
-    bool   use_structure;
-    bool   separate_learners;
-    bool   directed;
+struct task_data {
+  // global data
+  size_t num_loops;
+  size_t K;  // number of labels, *NOT* including the +1 for 'unlabeled'
+  size_t numN; // number of neighbor predictions (equals K+1 for undirected, or 2*(K+1) for directed)
+  bool   use_structure;
+  bool   separate_learners;
+  bool   directed;
 
-    // for adding new features
-    size_t mask; // all->reg.weight_mask
-    size_t multiplier;   // all.wpp << all.reg.stride_shift
-    size_t ss; // stride_shift
-    size_t wpp;
-    
-    // per-example data
-    uint32_t N;  // number of nodes
-    uint32_t E;  // number of edges
-    vector< vector<size_t> > adj;  // adj[n] is a vector of *edge example ids* that contain n
-    vector<uint32_t> bfs;   // order of nodes to process
-    vector<size_t>   pred;  // predictions
-    example*cur_node;       // pointer to the current node for add_edge_features_fn
-    float* neighbor_predictions;  // prediction on this neighbor for add_edge_features_fn
-    weight* weight_vector;
-    uint32_t* confusion_matrix;
-    float* true_counts;
-    float true_counts_total;
-  };
+  // for adding new features
+  size_t mask; // all->reg.weight_mask
+  size_t multiplier;   // all.wpp << all.reg.stride_shift
+  size_t ss; // stride_shift
+  size_t wpp;
 
-  inline bool example_is_test(polylabel&l) { return l.cs.costs.size() == 0; }
-  
-  void initialize(Search::search& sch, size_t& num_actions, po::variables_map& vm) {
-    task_data * D = new task_data();
-    po::options_description sspan_opts("search graphtask options");
-    sspan_opts.add_options()("search_graph_num_loops", po::value<size_t>(), "how many loops to run [def: 2]");
-    sspan_opts.add_options()("search_graph_no_structure", "turn off edge features");
-    sspan_opts.add_options()("search_graph_separate_learners", "use a different learner for each pass");
-    sspan_opts.add_options()("search_graph_directed", "construct features based on directed graph semantics");
-    sch.add_program_options(vm, sspan_opts);
+  // per-example data
+  uint32_t N;  // number of nodes
+  uint32_t E;  // number of edges
+  vector< vector<size_t> > adj;  // adj[n] is a vector of *edge example ids* that contain n
+  vector<uint32_t> bfs;   // order of nodes to process
+  vector<size_t>   pred;  // predictions
+  example*cur_node;       // pointer to the current node for add_edge_features_fn
+  float* neighbor_predictions;  // prediction on this neighbor for add_edge_features_fn
+  weight* weight_vector;
+  uint32_t* confusion_matrix;
+  float* true_counts;
+  float true_counts_total;
+};
 
-    D->num_loops = 2;
-    D->use_structure = true;
-    D->directed = false;
-    if (vm.count("search_graph_num_loops"))      D->num_loops = vm["search_graph_num_loops"].as<size_t>();
-    if (vm.count("search_graph_no_structure"))   D->use_structure = false;
-    if (vm.count("search_graph_separate_learners")) D->separate_learners = true;
-    if (vm.count("search_graph_directed"))       D->directed = true;
+inline bool example_is_test(polylabel&l) {
+  return l.cs.costs.size() == 0;
+}
 
-    if (D->num_loops <= 1) { D->num_loops = 1; D->separate_learners = false; }
-    
-    D->K = num_actions;
-    D->numN = (D->directed+1) * (D->K+1);
-    cerr << "K=" << D->K << ", numN=" << D->numN << endl;
-    D->neighbor_predictions = calloc_or_die<float>(D->numN);
+void initialize(Search::search& sch, size_t& num_actions, po::variables_map& vm) {
+  task_data * D = new task_data();
+  po::options_description sspan_opts("search graphtask options");
+  sspan_opts.add_options()("search_graph_num_loops", po::value<size_t>(), "how many loops to run [def: 2]");
+  sspan_opts.add_options()("search_graph_no_structure", "turn off edge features");
+  sspan_opts.add_options()("search_graph_separate_learners", "use a different learner for each pass");
+  sspan_opts.add_options()("search_graph_directed", "construct features based on directed graph semantics");
+  sch.add_program_options(vm, sspan_opts);
 
-    D->confusion_matrix = calloc_or_die<uint32_t>( (D->K+1)*(D->K+1) );
-    D->true_counts = calloc_or_die<float>(D->K+1);
-    D->true_counts_total = (float)(D->K+1);
-    for (size_t k=0; k<=D->K; k++) D->true_counts[k] = 1.;
-    
-    if (D->separate_learners) sch.set_num_learners(D->num_loops);
-    
-    sch.set_task_data<task_data>(D);
-    sch.set_options( 0 ); // Search::AUTO_HAMMING_LOSS
-    sch.set_label_parser( COST_SENSITIVE::cs_label, example_is_test );
+  D->num_loops = 2;
+  D->use_structure = true;
+  D->directed = false;
+  if (vm.count("search_graph_num_loops"))      D->num_loops = vm["search_graph_num_loops"].as<size_t>();
+  if (vm.count("search_graph_no_structure"))   D->use_structure = false;
+  if (vm.count("search_graph_separate_learners")) D->separate_learners = true;
+  if (vm.count("search_graph_directed"))       D->directed = true;
+
+  if (D->num_loops <= 1) {
+    D->num_loops = 1;
+    D->separate_learners = false;
   }
 
-  void finish(Search::search& sch) {
-    task_data * D = sch.get_task_data<task_data>();
-    free(D->neighbor_predictions);
-    free(D->confusion_matrix);
-    free(D->true_counts);
-    delete D;
-  }
-  
-  inline bool example_is_edge(example*e) { return e->l.cs.costs.size() > 1; }
+  D->K = num_actions;
+  D->numN = (D->directed+1) * (D->K+1);
+  cerr << "K=" << D->K << ", numN=" << D->numN << endl;
+  D->neighbor_predictions = calloc_or_die<float>(D->numN);
 
-  void run_bfs(task_data &D, vector<example*>& ec) {
-    D.bfs.clear();
-    vector<bool> touched;
-    for (size_t n=0; n<D.N; n++) touched.push_back(false);
+  D->confusion_matrix = calloc_or_die<uint32_t>( (D->K+1)*(D->K+1) );
+  D->true_counts = calloc_or_die<float>(D->K+1);
+  D->true_counts_total = (float)(D->K+1);
+  for (size_t k=0; k<=D->K; k++) D->true_counts[k] = 1.;
 
-    touched[0] = true;
-    D.bfs.push_back(0);
+  if (D->separate_learners) sch.set_num_learners(D->num_loops);
 
-    size_t i = 0;
-    while (D.bfs.size() < D.N) {
-      while (i < D.bfs.size()) {
-        uint32_t n = D.bfs[i];
-        for (size_t id : D.adj[n])
-          for (size_t j=0; j<ec[id]->l.cs.costs.size(); j++) {
-            uint32_t m = ec[id]->l.cs.costs[j].class_index;
-            if ((m > 0) && (!touched[m-1])) {
-              D.bfs.push_back(m-1);
-              touched[m-1] = true;
-            }
+  sch.set_task_data<task_data>(D);
+  sch.set_options( 0 ); // Search::AUTO_HAMMING_LOSS
+  sch.set_label_parser( COST_SENSITIVE::cs_label, example_is_test );
+}
+
+void finish(Search::search& sch) {
+  task_data * D = sch.get_task_data<task_data>();
+  free(D->neighbor_predictions);
+  free(D->confusion_matrix);
+  free(D->true_counts);
+  delete D;
+}
+
+inline bool example_is_edge(example*e) {
+  return e->l.cs.costs.size() > 1;
+}
+
+void run_bfs(task_data &D, vector<example*>& ec) {
+  D.bfs.clear();
+  vector<bool> touched;
+  for (size_t n=0; n<D.N; n++) touched.push_back(false);
+
+  touched[0] = true;
+  D.bfs.push_back(0);
+
+  size_t i = 0;
+  while (D.bfs.size() < D.N) {
+    while (i < D.bfs.size()) {
+      uint32_t n = D.bfs[i];
+for (size_t id : D.adj[n])
+        for (size_t j=0; j<ec[id]->l.cs.costs.size(); j++) {
+          uint32_t m = ec[id]->l.cs.costs[j].class_index;
+          if ((m > 0) && (!touched[m-1])) {
+            D.bfs.push_back(m-1);
+            touched[m-1] = true;
           }
-        i++;
-      }
-
-      if (D.bfs.size() < D.N)
-        // we finished a SCC, need to find another
-        for (uint32_t n=0; n<D.N; n++)
-          if (! touched[n]) {
-            touched[n] = true;
-            D.bfs.push_back(n);
-            break;
-          }
+        }
+      i++;
     }
+
+    if (D.bfs.size() < D.N)
+      // we finished a SCC, need to find another
+      for (uint32_t n=0; n<D.N; n++)
+        if (! touched[n]) {
+          touched[n] = true;
+          D.bfs.push_back(n);
+          break;
+        }
   }
-  
-  void setup(Search::search& sch, vector<example*>& ec) {
-    task_data& D = *sch.get_task_data<task_data>();
+}
 
-    D.mask = sch.get_vw_pointer_unsafe().reg.weight_mask;
-    D.wpp  = sch.get_vw_pointer_unsafe().wpp;
-    D.ss   = sch.get_vw_pointer_unsafe().reg.stride_shift;
-    D.multiplier = D.wpp << D.ss;
-    D.weight_vector = sch.get_vw_pointer_unsafe().reg.weight_vector;
-    
-    D.N = 0;
-    D.E = 0;
-    for (size_t i=0; i<ec.size(); i++)
-      if (example_is_edge(ec[i]))
-        D.E++;
-      else { // it's a node!
-        if (D.E > 0)
-	  THROW("error: got a node after getting edges!");
+void setup(Search::search& sch, vector<example*>& ec) {
+  task_data& D = *sch.get_task_data<task_data>();
 
-        D.N++;
-        if (ec[i]->l.cs.costs.size() > 0) {
-          D.true_counts[ec[i]->l.cs.costs[0].class_index] += 1.;
-          D.true_counts_total += 1.;
-      }
-      }
+  D.mask = sch.get_vw_pointer_unsafe().reg.weight_mask;
+  D.wpp  = sch.get_vw_pointer_unsafe().wpp;
+  D.ss   = sch.get_vw_pointer_unsafe().reg.stride_shift;
+  D.multiplier = D.wpp << D.ss;
+  D.weight_vector = sch.get_vw_pointer_unsafe().reg.weight_vector;
 
-    if ((D.N == 0) && (D.E > 0)) 
-      THROW("error: got edges without any nodes (perhaps ring_size is too small?)!");
+  D.N = 0;
+  D.E = 0;
+  for (size_t i=0; i<ec.size(); i++)
+    if (example_is_edge(ec[i]))
+      D.E++;
+    else { // it's a node!
+      if (D.E > 0)
+        THROW("error: got a node after getting edges!");
 
-    D.adj = vector<vector<size_t>>(D.N, vector<size_t>(0));
-
-    for (size_t i=D.N; i<ec.size(); i++) {
-      for (size_t n=0; n<ec[i]->l.cs.costs.size(); n++) {
-        if (ec[i]->l.cs.costs[n].class_index > D.N)
-	  THROW("error: edge source points to too large of a node id: " << (ec[i]->l.cs.costs[n].class_index) << " > " << D.N);
-      }
-      for (size_t n=0; n<ec[i]->l.cs.costs.size(); n++) {
-        size_t nn = ec[i]->l.cs.costs[n].class_index;
-        if ((nn > 0) && (((D.adj[nn-1].size() == 0) || (D.adj[nn-1][D.adj[nn-1].size()-1] != i)))) // don't allow dups
-          D.adj[nn-1].push_back(i);
+      D.N++;
+      if (ec[i]->l.cs.costs.size() > 0) {
+        D.true_counts[ec[i]->l.cs.costs[0].class_index] += 1.;
+        D.true_counts_total += 1.;
       }
     }
 
-    run_bfs(D, ec);
+  if ((D.N == 0) && (D.E > 0))
+    THROW("error: got edges without any nodes (perhaps ring_size is too small?)!");
 
-    D.pred.clear();
-    for (size_t n=0; n<D.N; n++)
-      D.pred.push_back( D.K+1 );
-  }
+  D.adj = vector<vector<size_t>>(D.N, vector<size_t>(0));
 
-  void takedown(Search::search& sch, vector<example*>& /*ec*/) {
-    task_data& D = *sch.get_task_data<task_data>();
-    D.bfs.clear();
-    D.pred.clear();
-    for (auto x : D.adj) x.clear();
-    D.adj.clear();
-  }
-
-  void add_edge_features_group_fn(task_data&D, float fv, uint32_t fx) {
-    example*node = D.cur_node;
-    uint32_t fx2 = fx / D.multiplier;
-    for (size_t k=0; k<D.numN; k++) {
-      if (D.neighbor_predictions[k] == 0.) continue;
-      float fv2 = fv * D.neighbor_predictions[k];
-      feature f = { fv2, (uint32_t)(( fx2 + 348919043 * k ) * D.multiplier) & (uint32_t)D.mask };
-      node->atomics[neighbor_namespace].push_back(f);
-      node->sum_feat_sq[neighbor_namespace] += f.x * f.x;
+  for (size_t i=D.N; i<ec.size(); i++) {
+    for (size_t n=0; n<ec[i]->l.cs.costs.size(); n++) {
+      if (ec[i]->l.cs.costs[n].class_index > D.N)
+        THROW("error: edge source points to too large of a node id: " << (ec[i]->l.cs.costs[n].class_index) << " > " << D.N);
     }
-    // TODO: audit
+    for (size_t n=0; n<ec[i]->l.cs.costs.size(); n++) {
+      size_t nn = ec[i]->l.cs.costs[n].class_index;
+      if ((nn > 0) && (((D.adj[nn-1].size() == 0) || (D.adj[nn-1][D.adj[nn-1].size()-1] != i)))) // don't allow dups
+        D.adj[nn-1].push_back(i);
+    }
   }
 
-  void add_edge_features_single_fn(task_data&D, float fv, uint32_t fx) {
-    example*node = D.cur_node;
-    uint32_t fx2 = fx / D.multiplier;
-    size_t k = (size_t) D.neighbor_predictions[0];
-    feature f = { fv, (uint32_t)(( fx2 + 348919043 * k ) * D.multiplier) & (uint32_t)D.mask };
+  run_bfs(D, ec);
+
+  D.pred.clear();
+  for (size_t n=0; n<D.N; n++)
+    D.pred.push_back( D.K+1 );
+}
+
+void takedown(Search::search& sch, vector<example*>& /*ec*/) {
+  task_data& D = *sch.get_task_data<task_data>();
+  D.bfs.clear();
+  D.pred.clear();
+for (auto x : D.adj) x.clear();
+  D.adj.clear();
+}
+
+void add_edge_features_group_fn(task_data&D, float fv, uint32_t fx) {
+  example*node = D.cur_node;
+  uint32_t fx2 = fx / D.multiplier;
+  for (size_t k=0; k<D.numN; k++) {
+    if (D.neighbor_predictions[k] == 0.) continue;
+    float fv2 = fv * D.neighbor_predictions[k];
+    feature f = { fv2, (uint32_t)(( fx2 + 348919043 * k ) * D.multiplier) & (uint32_t)D.mask };
     node->atomics[neighbor_namespace].push_back(f);
     node->sum_feat_sq[neighbor_namespace] += f.x * f.x;
-    // TODO: audit
   }
-  
-  void add_edge_features(Search::search&sch, task_data&D, uint32_t n, vector<example*>&ec) {
-    D.cur_node = ec[n];
+  // TODO: audit
+}
 
-    for (size_t i : D.adj[n]) {
-      for (size_t k=0; k<D.numN; k++) D.neighbor_predictions[k] = 0.;
+void add_edge_features_single_fn(task_data&D, float fv, uint32_t fx) {
+  example*node = D.cur_node;
+  uint32_t fx2 = fx / D.multiplier;
+  size_t k = (size_t) D.neighbor_predictions[0];
+  feature f = { fv, (uint32_t)(( fx2 + 348919043 * k ) * D.multiplier) & (uint32_t)D.mask };
+  node->atomics[neighbor_namespace].push_back(f);
+  node->sum_feat_sq[neighbor_namespace] += f.x * f.x;
+  // TODO: audit
+}
 
-      float pred_total = 0.;
-      uint32_t last_pred = 0;
-      if (D.use_structure) {
-        bool n_in_sink = true;
-        if (D.directed)
-          for (size_t j=0; j<ec[i]->l.cs.costs.size()-1; j++) {
-            size_t m = ec[i]->l.cs.costs[j].class_index;
-            if (m == 0) break;
-            if (m-1 == n) { n_in_sink = false; break; }
-          }
+void add_edge_features(Search::search&sch, task_data&D, uint32_t n, vector<example*>&ec) {
+  D.cur_node = ec[n];
 
-        bool m_in_sink = false;
-        for (size_t j=0; j<ec[i]->l.cs.costs.size(); j++) {
+for (size_t i : D.adj[n]) {
+    for (size_t k=0; k<D.numN; k++) D.neighbor_predictions[k] = 0.;
+
+    float pred_total = 0.;
+    uint32_t last_pred = 0;
+    if (D.use_structure) {
+      bool n_in_sink = true;
+      if (D.directed)
+        for (size_t j=0; j<ec[i]->l.cs.costs.size()-1; j++) {
           size_t m = ec[i]->l.cs.costs[j].class_index;
-          if (m == 0) { m_in_sink = true; continue; }
-          if (j == ec[i]->l.cs.costs.size()-1) m_in_sink = true;
-          m--;
-          if (m == n) continue;
-          size_t other_side = (D.directed && (n_in_sink != m_in_sink)) ? (D.K+1) : 0;
-          D.neighbor_predictions[ D.pred[m]-1 + other_side ] += 1.;
-          pred_total += 1.;
-          last_pred = D.pred[m]-1 + other_side;
+          if (m == 0) break;
+          if (m-1 == n) {
+            n_in_sink = false;
+            break;
+          }
         }
-      } else {
-        D.neighbor_predictions[0] += 1.;
+
+      bool m_in_sink = false;
+      for (size_t j=0; j<ec[i]->l.cs.costs.size(); j++) {
+        size_t m = ec[i]->l.cs.costs[j].class_index;
+        if (m == 0) {
+          m_in_sink = true;
+          continue;
+        }
+        if (j == ec[i]->l.cs.costs.size()-1) m_in_sink = true;
+        m--;
+        if (m == n) continue;
+        size_t other_side = (D.directed && (n_in_sink != m_in_sink)) ? (D.K+1) : 0;
+        D.neighbor_predictions[ D.pred[m]-1 + other_side ] += 1.;
         pred_total += 1.;
-        last_pred = 0;
+        last_pred = D.pred[m]-1 + other_side;
       }
-
-      if (pred_total == 0.) continue;
-      //cerr << n << ':' << i << " -> ["; for (size_t k=0; k<D.numN; k++) cerr << ' ' << D.neighbor_predictions[k]; cerr << " ]" << endl;
-      for (size_t k=0; k<D.numN; k++) D.neighbor_predictions[k] /= pred_total;
-      example&edge = *ec[i];
-      
-      if (pred_total <= 1.) {  // single edge
-        D.neighbor_predictions[0] = (float)last_pred;
-        GD::foreach_feature<task_data,uint32_t,add_edge_features_single_fn>(sch.get_vw_pointer_unsafe(), edge, D);
-      } else // lots of edges
-        GD::foreach_feature<task_data,uint32_t,add_edge_features_group_fn>(sch.get_vw_pointer_unsafe(), edge, D);
+    } else {
+      D.neighbor_predictions[0] += 1.;
+      pred_total += 1.;
+      last_pred = 0;
     }
-    ec[n]->indices.push_back(neighbor_namespace);
-    ec[n]->total_sum_feat_sq += ec[n]->sum_feat_sq[neighbor_namespace];
-    ec[n]->num_features += ec[n]->atomics[neighbor_namespace].size();
 
-    vw& all = sch.get_vw_pointer_unsafe();
-    for (vector<string>::iterator i = all.pairs.begin(); i != all.pairs.end();i++) {
-      int i0 = (int)(*i)[0];
-      int i1 = (int)(*i)[1];
-      if ((i0 == (int)neighbor_namespace) || (i1 == (int)neighbor_namespace)) {
-        ec[n]->num_features      += ec[n]->atomics[i0].size() * ec[n]->atomics[i1].size();
-        ec[n]->total_sum_feat_sq += ec[n]->sum_feat_sq[i0]*ec[n]->sum_feat_sq[i1];
-      }
+    if (pred_total == 0.) continue;
+    //cerr << n << ':' << i << " -> ["; for (size_t k=0; k<D.numN; k++) cerr << ' ' << D.neighbor_predictions[k]; cerr << " ]" << endl;
+    for (size_t k=0; k<D.numN; k++) D.neighbor_predictions[k] /= pred_total;
+    example&edge = *ec[i];
+
+    if (pred_total <= 1.) {  // single edge
+      D.neighbor_predictions[0] = (float)last_pred;
+      GD::foreach_feature<task_data,uint32_t,add_edge_features_single_fn>(sch.get_vw_pointer_unsafe(), edge, D);
+    } else // lots of edges
+      GD::foreach_feature<task_data,uint32_t,add_edge_features_group_fn>(sch.get_vw_pointer_unsafe(), edge, D);
+  }
+  ec[n]->indices.push_back(neighbor_namespace);
+  ec[n]->total_sum_feat_sq += ec[n]->sum_feat_sq[neighbor_namespace];
+  ec[n]->num_features += ec[n]->atomics[neighbor_namespace].size();
+
+  vw& all = sch.get_vw_pointer_unsafe();
+  for (vector<string>::iterator i = all.pairs.begin(); i != all.pairs.end(); i++) {
+    int i0 = (int)(*i)[0];
+    int i1 = (int)(*i)[1];
+    if ((i0 == (int)neighbor_namespace) || (i1 == (int)neighbor_namespace)) {
+      ec[n]->num_features      += ec[n]->atomics[i0].size() * ec[n]->atomics[i1].size();
+      ec[n]->total_sum_feat_sq += ec[n]->sum_feat_sq[i0]*ec[n]->sum_feat_sq[i1];
     }
-    
   }
-  
-  void del_edge_features(task_data&/*D*/, uint32_t n, vector<example*>&ec) {
-    ec[n]->indices.pop();
-    ec[n]->total_sum_feat_sq -= ec[n]->sum_feat_sq[neighbor_namespace];
-    ec[n]->num_features -= ec[n]->atomics[neighbor_namespace].size();
-    ec[n]->atomics[neighbor_namespace].erase();
-    ec[n]->sum_feat_sq[neighbor_namespace] = 0.;
-  }
-  
+
+}
+
+void del_edge_features(task_data&/*D*/, uint32_t n, vector<example*>&ec) {
+  ec[n]->indices.pop();
+  ec[n]->total_sum_feat_sq -= ec[n]->sum_feat_sq[neighbor_namespace];
+  ec[n]->num_features -= ec[n]->atomics[neighbor_namespace].size();
+  ec[n]->atomics[neighbor_namespace].erase();
+  ec[n]->sum_feat_sq[neighbor_namespace] = 0.;
+}
+
 #define IDX(i,j) ( (i) * (D.K+1) + j )
 
-  float macro_f(task_data& D) {
-    float total_f1 = 0.;
-    float count_f1 = 0.;
-    for (size_t k=1; k<=D.K; k++) {
-      float trueC = 0.;
-      float predC = 0.;
-      for (size_t j=1; j<=D.K; j++) {
-        trueC += (float)D.confusion_matrix[ IDX(k,j) ];
-        predC += (float)D.confusion_matrix[ IDX(j,k) ];
-      }
-      if (trueC == 0) continue;
-      float correctC = D.confusion_matrix[ IDX(k,k) ];
-      count_f1++;
-      if (correctC > 0) {
-        float pre = correctC / predC;
-        float rec = correctC / trueC;
-        total_f1 += 2 * pre * rec / (pre + rec);
-      }
+float macro_f(task_data& D) {
+  float total_f1 = 0.;
+  float count_f1 = 0.;
+  for (size_t k=1; k<=D.K; k++) {
+    float trueC = 0.;
+    float predC = 0.;
+    for (size_t j=1; j<=D.K; j++) {
+      trueC += (float)D.confusion_matrix[ IDX(k,j) ];
+      predC += (float)D.confusion_matrix[ IDX(j,k) ];
     }
-    return total_f1 / count_f1;
+    if (trueC == 0) continue;
+    float correctC = D.confusion_matrix[ IDX(k,k) ];
+    count_f1++;
+    if (correctC > 0) {
+      float pre = correctC / predC;
+      float rec = correctC / trueC;
+      total_f1 += 2 * pre * rec / (pre + rec);
+    }
   }
-  
-  void run(Search::search& sch, vector<example*>& ec) {
-    task_data& D = *sch.get_task_data<task_data>();
-    float loss_val = 0.5 / (float)D.num_loops;
-    for (size_t n=0; n<D.N; n++) D.pred[n] = D.K+1;
-    
-    for (size_t loop=0; loop<D.num_loops; loop++) {
-      bool last_loop = loop == (D.num_loops-1);
-      int start = 0; int end = D.N; int step = 1;
-      if (loop % 2 == 1) { start = D.N-1; end=-1; step = -1; } // go inward on odd loops
-      for (int n_id = start; n_id != end; n_id += step) {
-        uint32_t n = D.bfs[n_id];
-        uint32_t k = (ec[n]->l.cs.costs.size() > 0) ? ec[n]->l.cs.costs[0].class_index : 0;
+  return total_f1 / count_f1;
+}
 
-        bool add_features = /* D.use_structure && */ sch.predictNeedsExample();
-        //add_features = false;
+void run(Search::search& sch, vector<example*>& ec) {
+  task_data& D = *sch.get_task_data<task_data>();
+  float loss_val = 0.5 / (float)D.num_loops;
+  for (size_t n=0; n<D.N; n++) D.pred[n] = D.K+1;
 
-        if (add_features) add_edge_features(sch, D, n, ec);
-        Search::predictor P = Search::predictor(sch, n+1);
-        P.set_input(*ec[n]);
-        if (false && (k > 0)) {
-          float min_count = 1e12;
-          for (size_t k2=1; k2<=D.K; k2++)
-            min_count = min(min_count, D.true_counts[k2]);
-          float w = min_count / D.true_counts[k];
-          //float w = D.true_counts_total / D.true_counts[k] / (float)(D.K);
-          P.set_weight( w );
-          //cerr << "w = " << D.true_counts_total / D.true_counts[k] / (float)(D.K) << endl;
-          //P.set_weight( D.true_counts_total / D.true_counts[k] / (float)(D.K) );
-        }
-        if (D.separate_learners) P.set_learner_id(loop);
-        if (k > 0) // for test examples
-          P.set_oracle(k);
-        // add all the conditioning
-        for (size_t i=0; i<D.adj[n].size(); i++) {
-          for (size_t j=0; j<ec[i]->l.cs.costs.size(); j++) {
-            uint32_t m = ec[i]->l.cs.costs[j].class_index;
-            if (m == 0) continue;
-            m--;
-            if (m == n) continue;
-            P.add_condition(m+1, 'e');
-          }
-        }
-
-        // make the prediction
-        D.pred[n] = P.predict();
-        if (ec[n]->l.cs.costs.size() > 0) // for test examples
-          sch.loss((ec[n]->l.cs.costs[0].class_index == D.pred[n]) ? 0. : (last_loop ? 0.5 : loss_val));
-        
-        if (add_features) del_edge_features(D, n, ec);
-      }
+  for (size_t loop=0; loop<D.num_loops; loop++) {
+    bool last_loop = loop == (D.num_loops-1);
+    int start = 0;
+    int end = D.N;
+    int step = 1;
+    if (loop % 2 == 1) {
+      start = D.N-1;  // go inward on odd loops
+      end=-1;
+      step = -1;
     }
+    for (int n_id = start; n_id != end; n_id += step) {
+      uint32_t n = D.bfs[n_id];
+      uint32_t k = (ec[n]->l.cs.costs.size() > 0) ? ec[n]->l.cs.costs[0].class_index : 0;
 
+      bool add_features = /* D.use_structure && */ sch.predictNeedsExample();
+      //add_features = false;
+
+      if (add_features) add_edge_features(sch, D, n, ec);
+      Search::predictor P = Search::predictor(sch, n+1);
+      P.set_input(*ec[n]);
+      if (false && (k > 0)) {
+        float min_count = 1e12;
+        for (size_t k2=1; k2<=D.K; k2++)
+          min_count = min(min_count, D.true_counts[k2]);
+        float w = min_count / D.true_counts[k];
+        //float w = D.true_counts_total / D.true_counts[k] / (float)(D.K);
+        P.set_weight( w );
+        //cerr << "w = " << D.true_counts_total / D.true_counts[k] / (float)(D.K) << endl;
+        //P.set_weight( D.true_counts_total / D.true_counts[k] / (float)(D.K) );
+      }
+      if (D.separate_learners) P.set_learner_id(loop);
+      if (k > 0) // for test examples
+        P.set_oracle(k);
+      // add all the conditioning
+      for (size_t i=0; i<D.adj[n].size(); i++) {
+        for (size_t j=0; j<ec[i]->l.cs.costs.size(); j++) {
+          uint32_t m = ec[i]->l.cs.costs[j].class_index;
+          if (m == 0) continue;
+          m--;
+          if (m == n) continue;
+          P.add_condition(m+1, 'e');
+        }
+      }
+
+      // make the prediction
+      D.pred[n] = P.predict();
+      if (ec[n]->l.cs.costs.size() > 0) // for test examples
+        sch.loss((ec[n]->l.cs.costs[0].class_index == D.pred[n]) ? 0. : (last_loop ? 0.5 : loss_val));
+
+      if (add_features) del_edge_features(D, n, ec);
+    }
+  }
+
+  for (uint32_t n=0; n<D.N; n++)
+    D.confusion_matrix[ IDX( ec[n]->l.cs.costs[0].class_index, D.pred[n] ) ] ++;
+  sch.loss( 1. - macro_f(D) );
+
+  if (sch.output().good())
     for (uint32_t n=0; n<D.N; n++)
-      D.confusion_matrix[ IDX( ec[n]->l.cs.costs[0].class_index, D.pred[n] ) ] ++;
-    sch.loss( 1. - macro_f(D) );
-    
-    if (sch.output().good())
-      for (uint32_t n=0; n<D.N; n++)
-        sch.output() << D.pred[n] << ' ';
-  }
+      sch.output() << D.pred[n] << ' ';
+}
 }
 

--- a/vowpalwabbit/search_graph.h
+++ b/vowpalwabbit/search_graph.h
@@ -7,10 +7,10 @@ license as described in the file LICENSE.
 #include "search.h"
 
 namespace GraphTask {
-  void initialize(Search::search&, size_t&, po::variables_map&);
-  void finish(Search::search&);
-  void setup(Search::search&, vector<example*>&);
-  void run(Search::search&, vector<example*>&);
-  void takedown(Search::search&, vector<example*>&);
-  extern Search::search_task task;
+void initialize(Search::search&, size_t&, po::variables_map&);
+void finish(Search::search&);
+void setup(Search::search&, vector<example*>&);
+void run(Search::search&, vector<example*>&);
+void takedown(Search::search&, vector<example*>&);
+extern Search::search_task task;
 }

--- a/vowpalwabbit/search_hooktask.cc
+++ b/vowpalwabbit/search_hooktask.cc
@@ -8,51 +8,51 @@ license as described in the file LICENSE.
 // this is used for the C++ library and python library hook; hopefully
 // it can be used for any foreign library too!
 namespace HookTask {
-  Search::search_task task = { "hook", run, initialize, finish, run_setup, run_takedown  };
+Search::search_task task = { "hook", run, initialize, finish, run_setup, run_takedown  };
 
-  void initialize(Search::search& sch, size_t& num_actions, po::variables_map& vm) {
-    task_data *td = new task_data;
-    td->run_f = nullptr;
-    td->run_setup_f = nullptr;
-    td->run_takedown_f = nullptr;
-    td->run_object = nullptr;
-    td->setup_object = nullptr;
-    td->takedown_object = nullptr;
-    td->delete_run_object = nullptr;
-    td->delete_extra_data = nullptr;
-    td->var_map = new po::variables_map(vm);
-    td->num_actions = num_actions;
-    sch.set_task_data<task_data>(td);
-  }
+void initialize(Search::search& sch, size_t& num_actions, po::variables_map& vm) {
+  task_data *td = new task_data;
+  td->run_f = nullptr;
+  td->run_setup_f = nullptr;
+  td->run_takedown_f = nullptr;
+  td->run_object = nullptr;
+  td->setup_object = nullptr;
+  td->takedown_object = nullptr;
+  td->delete_run_object = nullptr;
+  td->delete_extra_data = nullptr;
+  td->var_map = new po::variables_map(vm);
+  td->num_actions = num_actions;
+  sch.set_task_data<task_data>(td);
+}
 
-  void finish(Search::search& sch) {
-    task_data *td = sch.get_task_data<task_data>();
-    if (td->delete_run_object) {
-      if (td->run_object) td->delete_run_object(td->run_object);
-      if (td->setup_object) td->delete_run_object(td->setup_object);
-      if (td->takedown_object) td->delete_run_object(td->takedown_object);
-    }
-    if (td->delete_extra_data) td->delete_extra_data(*td);
-    delete td->var_map;
-    delete td;
+void finish(Search::search& sch) {
+  task_data *td = sch.get_task_data<task_data>();
+  if (td->delete_run_object) {
+    if (td->run_object) td->delete_run_object(td->run_object);
+    if (td->setup_object) td->delete_run_object(td->setup_object);
+    if (td->takedown_object) td->delete_run_object(td->takedown_object);
   }
+  if (td->delete_extra_data) td->delete_extra_data(*td);
+  delete td->var_map;
+  delete td;
+}
 
-  void run(Search::search& sch, vector<example*>& /*ec*/) {
-    task_data *td = sch.get_task_data<task_data>();
-    if (td->run_f)
-      td->run_f(sch);
-    else
-      cerr << "warning: HookTask::structured_predict called before hook is set" << endl;
-  }
+void run(Search::search& sch, vector<example*>& /*ec*/) {
+  task_data *td = sch.get_task_data<task_data>();
+  if (td->run_f)
+    td->run_f(sch);
+  else
+    cerr << "warning: HookTask::structured_predict called before hook is set" << endl;
+}
 
-  void run_setup(Search::search& sch, vector<example*>& /*ec*/) {
-    task_data *td = sch.get_task_data<task_data>();
-    if (td->run_setup_f) td->run_setup_f(sch);
-  }
+void run_setup(Search::search& sch, vector<example*>& /*ec*/) {
+  task_data *td = sch.get_task_data<task_data>();
+  if (td->run_setup_f) td->run_setup_f(sch);
+}
 
-  void run_takedown(Search::search& sch, vector<example*>& /*ec*/) {
-    task_data *td = sch.get_task_data<task_data>();
-    if (td->run_takedown_f) td->run_takedown_f(sch);
-  }
+void run_takedown(Search::search& sch, vector<example*>& /*ec*/) {
+  task_data *td = sch.get_task_data<task_data>();
+  if (td->run_takedown_f) td->run_takedown_f(sch);
+}
 }
 

--- a/vowpalwabbit/search_hooktask.h
+++ b/vowpalwabbit/search_hooktask.h
@@ -7,25 +7,25 @@ license as described in the file LICENSE.
 #include "search.h"
 
 namespace HookTask {
-  void initialize(Search::search&, size_t&, po::variables_map&);
-  void finish(Search::search&);
-  void run(Search::search&, vector<example*>&);
-  void run_setup(Search::search&, vector<example*>&);
-  void run_takedown(Search::search&, vector<example*>&);
-  extern Search::search_task task;
+void initialize(Search::search&, size_t&, po::variables_map&);
+void finish(Search::search&);
+void run(Search::search&, vector<example*>&);
+void run_setup(Search::search&, vector<example*>&);
+void run_takedown(Search::search&, vector<example*>&);
+extern Search::search_task task;
 
-  struct task_data {
-    void (*run_f)(Search::search&);
-    void (*run_setup_f)(Search::search&);
-    void (*run_takedown_f)(Search::search&);
-    void *run_object;                  // for python this will really be a (py::object*), but we don't want basic VW to have to know about hook
-    void *setup_object;                // for python this will really be a (py::object*), but we don't want basic VW to have to know about hook
-    void *takedown_object;             // for python this will really be a (py::object*), but we don't want basic VW to have to know about hook
-    void (*delete_run_object)(void*);  // we can't delete run_object on our own because we don't know its size, so provide a hook
-    void (*delete_extra_data)(task_data&);  // ditto for extra_data and extra_data2
-    po::variables_map* var_map;        // so that hook can access command line variables
-    const void* extra_data;            // any extra data that might be needed
-    const void* extra_data2;           // any (more) extra data that might be needed
-    size_t num_actions;                // cache for easy access
-  };
+struct task_data {
+  void (*run_f)(Search::search&);
+  void (*run_setup_f)(Search::search&);
+  void (*run_takedown_f)(Search::search&);
+  void *run_object;                  // for python this will really be a (py::object*), but we don't want basic VW to have to know about hook
+  void *setup_object;                // for python this will really be a (py::object*), but we don't want basic VW to have to know about hook
+  void *takedown_object;             // for python this will really be a (py::object*), but we don't want basic VW to have to know about hook
+  void (*delete_run_object)(void*);  // we can't delete run_object on our own because we don't know its size, so provide a hook
+  void (*delete_extra_data)(task_data&);  // ditto for extra_data and extra_data2
+  po::variables_map* var_map;        // so that hook can access command line variables
+  const void* extra_data;            // any extra data that might be needed
+  const void* extra_data2;           // any (more) extra data that might be needed
+  size_t num_actions;                // cache for easy access
+};
 }

--- a/vowpalwabbit/search_meta.cc
+++ b/vowpalwabbit/search_meta.cc
@@ -11,215 +11,224 @@ license as described in the file LICENSE.
 #include "search.h"
 
 namespace DebugMT {
-  void run(Search::search& sch, vector<example*>& ec);
-  Search::search_metatask metatask = { "debug", run, nullptr, nullptr, nullptr, nullptr };
+void run(Search::search& sch, vector<example*>& ec);
+Search::search_metatask metatask = { "debug", run, nullptr, nullptr, nullptr, nullptr };
 
-  void run(Search::search& sch, vector<example*>& ec) {
-    sch.base_task(ec)
-        .foreach_action(
-            [](Search::search& /*sch*/, size_t t, float min_cost, action a, bool taken, float a_cost) -> void {
-              cerr << "==DebugMT== foreach_action(t=" << t << ", min_cost=" << min_cost << ", a=" << a << ", taken=" << taken << ", a_cost=" << a_cost << ")" << endl;
-            })
+void run(Search::search& sch, vector<example*>& ec) {
+  sch.base_task(ec)
+  .foreach_action(
+  [](Search::search& /*sch*/, size_t t, float min_cost, action a, bool taken, float a_cost) -> void {
+    cerr << "==DebugMT== foreach_action(t=" << t << ", min_cost=" << min_cost << ", a=" << a << ", taken=" << taken << ", a_cost=" << a_cost << ")" << endl;
+  })
 
-        .post_prediction(
-            [](Search::search& /*sch*/, size_t t, action a, float a_cost) -> void {
-              cerr << "==DebugMT== post_prediction(t=" << t << ", a=" << a << ", a_cost=" << a_cost << ")" << endl;
-            })
+  .post_prediction(
+  [](Search::search& /*sch*/, size_t t, action a, float a_cost) -> void {
+    cerr << "==DebugMT== post_prediction(t=" << t << ", a=" << a << ", a_cost=" << a_cost << ")" << endl;
+  })
 
-        .maybe_override_prediction(
-            [](Search::search& /*sch*/, size_t t, action& a, float& a_cost) -> bool {
-              cerr << "==DebugMT== maybe_override_prediction(t=" << t << ", a=" << a << ", a_cost=" << a_cost << ")" << endl;
-              return false;
-            })
+  .maybe_override_prediction(
+  [](Search::search& /*sch*/, size_t t, action& a, float& a_cost) -> bool {
+    cerr << "==DebugMT== maybe_override_prediction(t=" << t << ", a=" << a << ", a_cost=" << a_cost << ")" << endl;
+    return false;
+  })
 
-        .final_run()
-        
-        .Run();
-  }
+  .final_run()
+
+  .Run();
+}
 }
 
 namespace SelectiveBranchingMT {
-  void run(Search::search& sch, vector<example*>& ec);
-  void initialize(Search::search& sch, size_t& num_actions, po::variables_map& vm);
-  void finish(Search::search& sch);
-  Search::search_metatask metatask = { "selective_branching", run, initialize, finish, nullptr, nullptr };
-  
-  typedef pair<action,float>  act_score;
-  typedef v_array<act_score>  path;
-  typedef pair< float, path > branch;
+void run(Search::search& sch, vector<example*>& ec);
+void initialize(Search::search& sch, size_t& num_actions, po::variables_map& vm);
+void finish(Search::search& sch);
+Search::search_metatask metatask = { "selective_branching", run, initialize, finish, nullptr, nullptr };
 
-  std::ostream& operator<<(std::ostream& os, const std::pair<unsigned int,float>& v) { os << v.first << '_' << v.second; return os; }
-  
-  struct task_data {
-    size_t max_branches, kbest;
-    v_array< branch > branches;
-    v_array< pair<branch,string*> > final;
-    path trajectory;
-    float total_cost;
-    size_t cur_branch;
-    string*output_string;
-    stringstream*kbest_out;
-    task_data(size_t mb, size_t kb) : max_branches(mb), kbest(kb) {
-      branches   = v_init<branch>();
-      final      = v_init< pair<branch,string*> >();
-      trajectory = v_init<act_score>();
-      output_string = nullptr;
-      kbest_out     = nullptr;
-    }
-    ~task_data() {
-      branches.delete_v();
-      final.delete_v();
-      trajectory.delete_v();
-      if (output_string) delete output_string;
-      if (kbest_out) delete kbest_out;
-    }
-  };
-  
-  void initialize(Search::search& sch, size_t& /*num_actions*/, po::variables_map& vm) {
-    size_t max_branches = 2;
-    size_t kbest = 0;
-    po::options_description opts("selective branching options");
-    opts.add_options()
-        ("search_max_branch", po::value<size_t>(&max_branches)->default_value(2), "maximum number of branches to consider")
-        ("search_kbest",      po::value<size_t>(&kbest)->default_value(0), "number of best items to output (0=just like non-selectional-branching, default)");
-    sch.add_program_options(vm, opts);
-    
-    task_data* d = new task_data(max_branches, kbest);
-    sch.set_metatask_data(d);
+typedef pair<action,float>  act_score;
+typedef v_array<act_score>  path;
+typedef pair< float, path > branch;
+
+std::ostream& operator<<(std::ostream& os, const std::pair<unsigned int,float>& v) {
+  os << v.first << '_' << v.second;
+  return os;
+}
+
+struct task_data {
+  size_t max_branches, kbest;
+  v_array< branch > branches;
+  v_array< pair<branch,string*> > final;
+  path trajectory;
+  float total_cost;
+  size_t cur_branch;
+  string*output_string;
+  stringstream*kbest_out;
+  task_data(size_t mb, size_t kb) : max_branches(mb), kbest(kb) {
+    branches   = v_init<branch>();
+    final      = v_init< pair<branch,string*> >();
+    trajectory = v_init<act_score>();
+    output_string = nullptr;
+    kbest_out     = nullptr;
+  }
+  ~task_data() {
+    branches.delete_v();
+    final.delete_v();
+    trajectory.delete_v();
+    if (output_string) delete output_string;
+    if (kbest_out) delete kbest_out;
+  }
+};
+
+void initialize(Search::search& sch, size_t& /*num_actions*/, po::variables_map& vm) {
+  size_t max_branches = 2;
+  size_t kbest = 0;
+  po::options_description opts("selective branching options");
+  opts.add_options()
+  ("search_max_branch", po::value<size_t>(&max_branches)->default_value(2), "maximum number of branches to consider")
+  ("search_kbest",      po::value<size_t>(&kbest)->default_value(0), "number of best items to output (0=just like non-selectional-branching, default)");
+  sch.add_program_options(vm, opts);
+
+  task_data* d = new task_data(max_branches, kbest);
+  sch.set_metatask_data(d);
+}
+
+void finish(Search::search& sch) {
+  delete sch.get_metatask_data<task_data>();
+}
+
+void run(Search::search& sch, vector<example*>& ec) {
+  task_data& d = *sch.get_metatask_data<task_data>();
+
+  // generate an initial trajectory, but record possible branches
+  d.branches.erase();
+  d.final.erase();
+  d.trajectory.erase();
+  d.total_cost = 0.;
+  d.output_string = nullptr;
+
+  cdbg << "*** INITIAL PASS ***" << endl;
+  sch.base_task(ec)
+  .foreach_action(
+  [](Search::search& sch, size_t t, float min_cost, action a, bool taken, float a_cost) -> void {
+    cdbg << "==DebugMT== foreach_action(t=" << t << ", min_cost=" << min_cost << ", a=" << a << ", taken=" << taken << ", a_cost=" << a_cost << ")" << endl;
+    if (taken) return;  // ignore the taken action
+    task_data& d = *sch.get_metatask_data<task_data>();
+    float delta = a_cost - min_cost;
+    path branch = v_init<act_score>();
+    push_many<act_score>(branch, d.trajectory.begin, d.trajectory.size());
+    branch.push_back( make_pair(a,a_cost) );
+    d.branches.push_back( make_pair(delta, branch) );
+    cdbg << "adding branch: " << delta << " -> " << branch << endl;
+  })
+  .post_prediction(
+  [](Search::search& sch, size_t /*t*/, action a, float a_cost) -> void {
+    task_data& d = *sch.get_metatask_data<task_data>();
+    d.trajectory.push_back( make_pair(a,a_cost) );
+    d.total_cost += a_cost;
+  })
+  .with_output_string(
+  [](Search::search& sch, stringstream& output) -> void {
+    sch.get_metatask_data<task_data>()->output_string = new string(output.str());
+  })
+  .Run();
+
+  // the last item the trajectory stack is complete and therefore not a branch
+  //if (! d.branches.empty())
+  //  d.branches.pop().second.delete_v();
+
+  { // construct the final trajectory
+    path original_final = v_init<act_score>();
+    copy_array(original_final, d.trajectory);
+    d.final.push_back( make_pair(make_pair(d.total_cost, original_final), d.output_string) );
   }
 
-  void finish(Search::search& sch) { delete sch.get_metatask_data<task_data>(); }
+  // sort the branches by cost
+  stable_sort(d.branches.begin, d.branches.end,
+              [](const branch& a, const branch& b) -> bool { return a.first < b.first; });
 
-  void run(Search::search& sch, vector<example*>& ec) {
-    task_data& d = *sch.get_metatask_data<task_data>();
-
-    // generate an initial trajectory, but record possible branches
-    d.branches.erase();
-    d.final.erase();
+  // make new predictions
+  for (size_t i=0; i<min(d.max_branches, d.branches.size()); i++) {
+    d.cur_branch = i;
     d.trajectory.erase();
     d.total_cost = 0.;
     d.output_string = nullptr;
 
-    cdbg << "*** INITIAL PASS ***" << endl;
+    cdbg << "*** BRANCH " << i << " *** " << d.branches[i].first << " : " << d.branches[i].second << endl;
     sch.base_task(ec)
-        .foreach_action(
-            [](Search::search& sch, size_t t, float min_cost, action a, bool taken, float a_cost) -> void {
-              cdbg << "==DebugMT== foreach_action(t=" << t << ", min_cost=" << min_cost << ", a=" << a << ", taken=" << taken << ", a_cost=" << a_cost << ")" << endl;
-              if (taken) return;  // ignore the taken action
-              task_data& d = *sch.get_metatask_data<task_data>();
-              float delta = a_cost - min_cost;
-              path branch = v_init<act_score>();
-              push_many<act_score>(branch, d.trajectory.begin, d.trajectory.size());
-              branch.push_back( make_pair(a,a_cost) );
-              d.branches.push_back( make_pair(delta, branch) );
-              cdbg << "adding branch: " << delta << " -> " << branch << endl;
-            })
-        .post_prediction(
-            [](Search::search& sch, size_t /*t*/, action a, float a_cost) -> void {
-              task_data& d = *sch.get_metatask_data<task_data>();
-              d.trajectory.push_back( make_pair(a,a_cost) );
-              d.total_cost += a_cost;
-            })
-        .with_output_string(
-            [](Search::search& sch, stringstream& output) -> void {
-              sch.get_metatask_data<task_data>()->output_string = new string(output.str());
-            })
-        .Run();
+    .foreach_action([](Search::search& /*sch*/, size_t /*t*/, float /*min_cost*/, action /*a*/, bool /*taken*/, float /*a_cost*/) -> void {})
+    .maybe_override_prediction(
+    [](Search::search& sch, size_t t, action& a, float& a_cost) -> bool {
+      task_data& d = *sch.get_metatask_data<task_data>();
+      path& path = d.branches[d.cur_branch].second;
+      if (t >= path.size()) return false;
+      a = path[t].first;
+      a_cost = path[t].second;
+      return true;
+    })
+    .post_prediction(
+    [](Search::search& sch, size_t /*t*/, action a, float a_cost) -> void {
+      task_data& d = *sch.get_metatask_data<task_data>();
+      d.trajectory.push_back( make_pair(a,a_cost) );
+      d.total_cost += a_cost;
+    })
+    .with_output_string(
+    [](Search::search& sch, stringstream& output) -> void {
+      sch.get_metatask_data<task_data>()->output_string = new string(output.str());
+    })
+    .Run();
 
-    // the last item the trajectory stack is complete and therefore not a branch
-    //if (! d.branches.empty())
-    //  d.branches.pop().second.delete_v();
-    
     { // construct the final trajectory
-      path original_final = v_init<act_score>();
-      copy_array(original_final, d.trajectory);
-      d.final.push_back( make_pair(make_pair(d.total_cost, original_final), d.output_string) );
+      path this_final = v_init<act_score>();
+      copy_array(this_final, d.trajectory);
+      d.final.push_back( make_pair(make_pair(d.total_cost, this_final), d.output_string) );
     }
-
-    // sort the branches by cost
-    stable_sort(d.branches.begin, d.branches.end,
-                [](const branch& a, const branch& b) -> bool { return a.first < b.first; });
-
-    // make new predictions
-    for (size_t i=0; i<min(d.max_branches, d.branches.size()); i++) {
-      d.cur_branch = i;
-      d.trajectory.erase();
-      d.total_cost = 0.;
-      d.output_string = nullptr;
-      
-      cdbg << "*** BRANCH " << i << " *** " << d.branches[i].first << " : " << d.branches[i].second << endl;
-      sch.base_task(ec)
-          .foreach_action([](Search::search& /*sch*/, size_t /*t*/, float /*min_cost*/, action /*a*/, bool /*taken*/, float /*a_cost*/) -> void {})
-          .maybe_override_prediction(
-              [](Search::search& sch, size_t t, action& a, float& a_cost) -> bool {
-                task_data& d = *sch.get_metatask_data<task_data>();
-                path& path = d.branches[d.cur_branch].second;
-                if (t >= path.size()) return false;
-                a = path[t].first;
-                a_cost = path[t].second;
-                return true;
-              })
-          .post_prediction(
-              [](Search::search& sch, size_t /*t*/, action a, float a_cost) -> void {
-                task_data& d = *sch.get_metatask_data<task_data>();
-                d.trajectory.push_back( make_pair(a,a_cost) );
-                d.total_cost += a_cost;
-              })
-          .with_output_string(
-              [](Search::search& sch, stringstream& output) -> void {
-                sch.get_metatask_data<task_data>()->output_string = new string(output.str());
-              })
-          .Run();
-
-      { // construct the final trajectory
-        path this_final = v_init<act_score>();
-        copy_array(this_final, d.trajectory);
-        d.final.push_back( make_pair(make_pair(d.total_cost, this_final), d.output_string) );
-      }
-    }
-
-    // sort the finals by cost
-    stable_sort(d.final.begin, d.final.end,
-                [](const pair<branch,string*>& a, const pair<branch,string*>& b) -> bool { return a.first.first < b.first.first; });
-    
-    d.kbest_out = nullptr;
-    if (d.output_string && (d.kbest > 0)) {
-      d.kbest_out = new stringstream();
-      for (size_t i=0; i<min(d.final.size(), d.kbest); i++)
-        (*d.kbest_out) << *d.final[i].second << "\t" << d.final[i].first.first << endl;
-    }
-    
-    // run the final selected trajectory
-    cdbg << "*** FINAL ***" << endl;
-    d.cur_branch = 0;
-    d.output_string = nullptr;
-    sch.base_task(ec)
-        .foreach_action([](Search::search& /*sch*/, size_t /*t*/, float /*min_cost*/, action /*a*/, bool /*taken*/, float /*a_cost*/) -> void {})
-        .maybe_override_prediction(
-            [](Search::search& sch, size_t t, action& a, float& a_cost) -> bool {
-              task_data& d = *sch.get_metatask_data<task_data>();
-              path& path = d.final[d.cur_branch].first.second;
-              if ((t >= path.size()) || (path[t].first == (action)-1)) return false;
-              a = path[t].first;
-              a_cost = path[t].second;
-              return true;
-            })
-        .with_output_string(
-            [](Search::search& sch, stringstream& output) -> void {
-              task_data& d = *sch.get_metatask_data<task_data>();
-              if (d.kbest_out) {
-                output.str("");
-                output << d.kbest_out->str();
-              }
-            })
-        .final_run()
-        .Run();
-
-    // clean up memory
-    for (size_t i=0; i<d.branches.size(); i++) d.branches[i].second.delete_v();
-    d.branches.erase();
-    for (size_t i=0; i<d.final.size(); i++) { d.final[i].first.second.delete_v(); delete d.final[i].second; }
-    d.final.erase();
-    if (d.kbest_out) delete d.kbest_out; d.kbest_out = nullptr;
   }
+
+  // sort the finals by cost
+  stable_sort(d.final.begin, d.final.end,
+              [](const pair<branch,string*>& a, const pair<branch,string*>& b) -> bool { return a.first.first < b.first.first; });
+
+  d.kbest_out = nullptr;
+  if (d.output_string && (d.kbest > 0)) {
+    d.kbest_out = new stringstream();
+    for (size_t i=0; i<min(d.final.size(), d.kbest); i++)
+      (*d.kbest_out) << *d.final[i].second << "\t" << d.final[i].first.first << endl;
+  }
+
+  // run the final selected trajectory
+  cdbg << "*** FINAL ***" << endl;
+  d.cur_branch = 0;
+  d.output_string = nullptr;
+  sch.base_task(ec)
+  .foreach_action([](Search::search& /*sch*/, size_t /*t*/, float /*min_cost*/, action /*a*/, bool /*taken*/, float /*a_cost*/) -> void {})
+  .maybe_override_prediction(
+  [](Search::search& sch, size_t t, action& a, float& a_cost) -> bool {
+    task_data& d = *sch.get_metatask_data<task_data>();
+    path& path = d.final[d.cur_branch].first.second;
+    if ((t >= path.size()) || (path[t].first == (action)-1)) return false;
+    a = path[t].first;
+    a_cost = path[t].second;
+    return true;
+  })
+  .with_output_string(
+  [](Search::search& sch, stringstream& output) -> void {
+    task_data& d = *sch.get_metatask_data<task_data>();
+    if (d.kbest_out) {
+      output.str("");
+      output << d.kbest_out->str();
+    }
+  })
+  .final_run()
+  .Run();
+
+  // clean up memory
+  for (size_t i=0; i<d.branches.size(); i++) d.branches[i].second.delete_v();
+  d.branches.erase();
+  for (size_t i=0; i<d.final.size(); i++) {
+    d.final[i].first.second.delete_v();
+    delete d.final[i].second;
+  }
+  d.final.erase();
+  if (d.kbest_out) delete d.kbest_out;
+  d.kbest_out = nullptr;
+}
 }

--- a/vowpalwabbit/search_multiclasstask.cc
+++ b/vowpalwabbit/search_multiclasstask.cc
@@ -5,51 +5,53 @@ license as described in the file LICENSE.
  */
 #include "search_multiclasstask.h"
 
-namespace MulticlassTask { Search::search_task task = { "multiclasstask", run, initialize, finish, nullptr, nullptr };  }
+namespace MulticlassTask {
+Search::search_task task = { "multiclasstask", run, initialize, finish, nullptr, nullptr };
+}
 
 namespace MulticlassTask {
 
-  struct task_data {
-    size_t max_label;
-    size_t num_level;
-    v_array<uint32_t> y_allowed;
-  };
+struct task_data {
+  size_t max_label;
+  size_t num_level;
+  v_array<uint32_t> y_allowed;
+};
 
-  void initialize(Search::search& sch, size_t& num_actions, po::variables_map& /*vm*/) {
-    task_data * my_task_data = new task_data();
-    sch.set_options( 0 );
-    sch.set_num_learners(num_actions);
-    my_task_data->max_label = num_actions;
-	my_task_data->num_level = (size_t)ceil(log(num_actions) /log(2));
-	my_task_data->y_allowed.push_back(1);
-	my_task_data->y_allowed.push_back(2);
-    sch.set_task_data(my_task_data);
+void initialize(Search::search& sch, size_t& num_actions, po::variables_map& /*vm*/) {
+  task_data * my_task_data = new task_data();
+  sch.set_options( 0 );
+  sch.set_num_learners(num_actions);
+  my_task_data->max_label = num_actions;
+  my_task_data->num_level = (size_t)ceil(log(num_actions) /log(2));
+  my_task_data->y_allowed.push_back(1);
+  my_task_data->y_allowed.push_back(2);
+  sch.set_task_data(my_task_data);
+}
+
+void finish(Search::search& sch) {
+  task_data * my_task_data = sch.get_task_data<task_data>();
+  my_task_data->y_allowed.delete_v();
+  delete my_task_data;
+}
+
+void run(Search::search& sch, vector<example*>& ec) {
+  task_data * my_task_data = sch.get_task_data<task_data>();
+  size_t gold_label = ec[0]->l.multi.label;
+  size_t label = 0;
+  size_t learner_id = 0;
+
+  for(size_t i=0; i<my_task_data->num_level; i++) {
+    size_t mask = 1<<(my_task_data->num_level-i-1);
+    size_t y_allowed_size = (label+mask +1 <= my_task_data->max_label)?2:1;
+    action oracle = (((gold_label-1)&mask)>0)+1;
+    size_t prediction = sch.predict(*ec[0], 0, &oracle, 1, nullptr, nullptr, my_task_data->y_allowed.begin, y_allowed_size, learner_id); // TODO: do we really need y_allowed?
+    learner_id= (learner_id << 1) + prediction;
+    if(prediction == 2)
+      label += mask;
   }
-
-  void finish(Search::search& sch) {   
-    task_data * my_task_data = sch.get_task_data<task_data>();
-	my_task_data->y_allowed.delete_v();
-	delete my_task_data;
-  }
-
-  void run(Search::search& sch, vector<example*>& ec) {
-    task_data * my_task_data = sch.get_task_data<task_data>();
-    size_t gold_label = ec[0]->l.multi.label;
-    size_t label = 0;
-    size_t learner_id = 0;
-
-	for(size_t i=0; i<my_task_data->num_level;i++){
-	  size_t mask = 1<<(my_task_data->num_level-i-1);
-	  size_t y_allowed_size = (label+mask +1 <= my_task_data->max_label)?2:1;
-      action oracle = (((gold_label-1)&mask)>0)+1;
-      size_t prediction = sch.predict(*ec[0], 0, &oracle, 1, nullptr, nullptr, my_task_data->y_allowed.begin, y_allowed_size, learner_id); // TODO: do we really need y_allowed?
-      learner_id= (learner_id << 1) + prediction;
-	  if(prediction == 2)
-	      label += mask;
-	}
-    label+=1;
-    sch.loss(!(label == gold_label));
-    if (sch.output().good())
-        sch.output() << label << ' ';
-  }
+  label+=1;
+  sch.loss(!(label == gold_label));
+  if (sch.output().good())
+    sch.output() << label << ' ';
+}
 }

--- a/vowpalwabbit/search_multiclasstask.h
+++ b/vowpalwabbit/search_multiclasstask.h
@@ -7,8 +7,8 @@ license as described in the file LICENSE.
 #include "search.h"
 
 namespace MulticlassTask {
-  void initialize(Search::search&, size_t&, po::variables_map&);
-  void finish(Search::search&);
-  void run(Search::search&, vector<example*>&);
-  extern Search::search_task task;
+void initialize(Search::search&, size_t&, po::variables_map&);
+void finish(Search::search&);
+void run(Search::search&, vector<example*>&);
+extern Search::search_task task;
 }

--- a/vowpalwabbit/search_sequencetask.cc
+++ b/vowpalwabbit/search_sequencetask.cc
@@ -6,33 +6,41 @@ license as described in the file LICENSE.
 #include "search_sequencetask.h"
 #include "vw.h"
 
-namespace SequenceTask         { Search::search_task task = { "sequence",          run, initialize, nullptr,   nullptr,  nullptr     }; }
-namespace SequenceSpanTask     { Search::search_task task = { "sequencespan",      run, initialize, finish, setup, takedown }; }
-namespace ArgmaxTask           { Search::search_task task = { "argmax",            run, initialize, nullptr,   nullptr,  nullptr     }; }
-namespace SequenceTask_DemoLDF { Search::search_task task = { "sequence_demoldf",  run, initialize, finish, nullptr,  nullptr     }; }
+namespace SequenceTask         {
+Search::search_task task = { "sequence",          run, initialize, nullptr,   nullptr,  nullptr     };
+}
+namespace SequenceSpanTask     {
+Search::search_task task = { "sequencespan",      run, initialize, finish, setup, takedown };
+}
+namespace ArgmaxTask           {
+Search::search_task task = { "argmax",            run, initialize, nullptr,   nullptr,  nullptr     };
+}
+namespace SequenceTask_DemoLDF {
+Search::search_task task = { "sequence_demoldf",  run, initialize, finish, nullptr,  nullptr     };
+}
 
 namespace SequenceTask {
-  void initialize(Search::search& sch, size_t& /*num_actions*/, po::variables_map& /*vm*/) {
-    sch.set_options( Search::AUTO_CONDITION_FEATURES  |    // automatically add history features to our examples, please
-                     Search::AUTO_HAMMING_LOSS        |    // please just use hamming loss on individual predictions -- we won't declare loss
-                     Search::EXAMPLES_DONT_CHANGE     |    // we don't do any internal example munging
-                     0);
-  }
+void initialize(Search::search& sch, size_t& /*num_actions*/, po::variables_map& /*vm*/) {
+  sch.set_options( Search::AUTO_CONDITION_FEATURES  |    // automatically add history features to our examples, please
+                   Search::AUTO_HAMMING_LOSS        |    // please just use hamming loss on individual predictions -- we won't declare loss
+                   Search::EXAMPLES_DONT_CHANGE     |    // we don't do any internal example munging
+                   0);
+}
 
-  void run(Search::search& sch, vector<example*>& ec) {
-    for (size_t i=0; i<ec.size(); i++) {
-      action oracle     = ec[i]->l.multi.label;
-      size_t prediction = Search::predictor(sch, (ptag)i+1).set_input(*ec[i]).set_oracle(oracle).set_condition_range((ptag)i, sch.get_history_length(), 'p').predict();
+void run(Search::search& sch, vector<example*>& ec) {
+  for (size_t i=0; i<ec.size(); i++) {
+    action oracle     = ec[i]->l.multi.label;
+    size_t prediction = Search::predictor(sch, (ptag)i+1).set_input(*ec[i]).set_oracle(oracle).set_condition_range((ptag)i, sch.get_history_length(), 'p').predict();
 
-      if (sch.output().good())
-        sch.output() << sch.pretty_label(prediction) << ' ';
-    }
+    if (sch.output().good())
+      sch.output() << sch.pretty_label(prediction) << ' ';
   }
+}
 }
 
 
 namespace SequenceSpanTask {
-  enum EncodingType { BIO, BILOU };
+enum EncodingType { BIO, BILOU };
 // the format for the BIO encoding is:
 //     label     description
 //     1         "O" (out)
@@ -58,275 +66,281 @@ namespace SequenceSpanTask {
 //     m%4=2 -> m, m+1                                  in-X to { in-X, last-X }              4, 8, 12, 16, ...
 //     m%4=3 -> 1; 2, 6, 10, ...; 3, 7, 11, ...         last-X to { out, unit-Y, begin-Y }    5, 9, 13, 17, ...
 
-  inline action bilou_to_bio(action y) {
-    return y / 2 + 1;  // out -> out, {unit,begin} -> begin; {in,last} -> in
-  }
+inline action bilou_to_bio(action y) {
+  return y / 2 + 1;  // out -> out, {unit,begin} -> begin; {in,last} -> in
+}
 
-  void convert_bio_to_bilou(vector<example*> ec) {
-    for (size_t n=0; n<ec.size(); n++) {
-      MULTICLASS::label_t& ylab = ec[n]->l.multi;
-      action y = ylab.label;
-      action nexty = (n == ec.size()-1) ? 0 : ec[n+1]->l.multi.label;
-      if (y == 1) { // do nothing
-      } else if (y % 2 == 0) { // this is a begin-X
-        if (nexty != y + 1) // should be unit
-          ylab.label = (y/2 - 1) * 4 + 2;  // from 2 to 2, 4 to 6, 6 to 10, etc.
-        else // should be begin-X
-          ylab.label = (y/2 - 1) * 4 + 3;  // from 2 to 3, 4 to 7, 6 to 11, etc.
-      } else if (y % 2 == 1) { // this is an in-X
-        if (nexty != y) // should be last
-          ylab.label = (y-1) * 2 + 1;  // from 3 to 5, 5 to 9, 7 to 13, etc.
-        else // should be in-X
-          ylab.label = (y-1) * 2;      // from 3 to 4, 5 to 8, 7 to 12, etc.
-      }
-      assert( y == bilou_to_bio(ylab.label) );
+void convert_bio_to_bilou(vector<example*> ec) {
+  for (size_t n=0; n<ec.size(); n++) {
+    MULTICLASS::label_t& ylab = ec[n]->l.multi;
+    action y = ylab.label;
+    action nexty = (n == ec.size()-1) ? 0 : ec[n+1]->l.multi.label;
+    if (y == 1) { // do nothing
+    } else if (y % 2 == 0) { // this is a begin-X
+      if (nexty != y + 1) // should be unit
+        ylab.label = (y/2 - 1) * 4 + 2;  // from 2 to 2, 4 to 6, 6 to 10, etc.
+      else // should be begin-X
+        ylab.label = (y/2 - 1) * 4 + 3;  // from 2 to 3, 4 to 7, 6 to 11, etc.
+    } else if (y % 2 == 1) { // this is an in-X
+      if (nexty != y) // should be last
+        ylab.label = (y-1) * 2 + 1;  // from 3 to 5, 5 to 9, 7 to 13, etc.
+      else // should be in-X
+        ylab.label = (y-1) * 2;      // from 3 to 4, 5 to 8, 7 to 12, etc.
     }
-  }
-
-  struct task_data {
-    EncodingType encoding;
-    v_array<action> allowed_actions;
-    v_array<action> only_two_allowed;  // used for BILOU encoding
-    size_t multipass;
-  };
-
-  void initialize(Search::search& sch, size_t& num_actions, po::variables_map& vm) {
-    task_data * D = new task_data();
-    po::options_description sspan_opts("search sequencespan options");
-    sspan_opts.add_options()("search_span_bilou", "switch to (internal) BILOU encoding instead of BIO encoding");
-    sspan_opts.add_options()("search_span_multipass", po::value<size_t>(&(D->multipass))->default_value(1), "do multiple passes");
-    sch.add_program_options(vm, sspan_opts);
-
-    if (vm.count("search_span_bilou")) {
-      cerr << "switching to BILOU encoding for sequence span labeling" << endl;
-      D->encoding = BILOU;
-      num_actions = num_actions * 2 - 1;
-    } else
-      D->encoding = BIO;
-    
-    
-    D->allowed_actions.erase();
-
-    if (D->encoding == BIO) {
-      D->allowed_actions.push_back(1);
-      for (action l=2; l<num_actions; l+=2)
-        D->allowed_actions.push_back(l);
-      D->allowed_actions.push_back(1);  // push back an extra 1 that we can overwrite later if we want
-    } else if (D->encoding == BILOU) {
-      D->allowed_actions.push_back(1);
-      for (action l=2; l<num_actions; l+=4) {
-        D->allowed_actions.push_back(l);
-        D->allowed_actions.push_back(l+1);
-      }
-      D->only_two_allowed.push_back(0);
-      D->only_two_allowed.push_back(0);
-    }
-
-    sch.set_task_data<task_data>(D);
-    sch.set_options( Search::AUTO_CONDITION_FEATURES  |    // automatically add history features to our examples, please
-                     Search::AUTO_HAMMING_LOSS        |    // please just use hamming loss on individual predictions -- we won't declare loss
-                     Search::EXAMPLES_DONT_CHANGE     |    // we don't do any internal example munging
-                     0);
-    sch.set_num_learners(D->multipass);
-  }
-
-  void finish(Search::search& sch) {
-    task_data* D = sch.get_task_data<task_data>();
-    D->allowed_actions.delete_v();
-    D->only_two_allowed.delete_v();
-    delete D;
-  }
-
-  void setup(Search::search& sch, vector<example*>& ec) {
-    task_data& D = *sch.get_task_data<task_data>();
-    if (D.encoding == BILOU)
-      convert_bio_to_bilou(ec);
-  }
-
-  void takedown(Search::search& sch, vector<example*>& ec) {
-    task_data& D = *sch.get_task_data<task_data>();
-
-    if (D.encoding == BILOU)
-      for (size_t n=0; n<ec.size(); n++) {
-        MULTICLASS::label_t ylab = ec[n]->l.multi;
-        ylab.label = bilou_to_bio(ylab.label);
-      }
-  }
-  
-  void run(Search::search& sch, vector<example*>& ec) {
-    task_data& D = *sch.get_task_data<task_data>();
-    v_array<action> * y_allowed = &(D.allowed_actions);
-
-    for (size_t pass=1; pass<=D.multipass; pass++) {
-      action last_prediction = 1;
-      for (size_t i=0; i<ec.size(); i++) {
-        action oracle = ec[i]->l.multi.label;
-        size_t len = y_allowed->size();
-        Search::predictor P(sch, (ptag)i+1);
-        P.set_learner_id(pass-1);
-        if (D.encoding == BIO) {
-          if      (last_prediction == 1)       P.set_allowed(y_allowed->begin, len-1);
-          else if (last_prediction % 2 == 0) { (*y_allowed)[len-1] = last_prediction+1; P.set_allowed(*y_allowed); }
-          else                               { (*y_allowed)[len-1] = last_prediction;   P.set_allowed(*y_allowed); }
-          if ((oracle > 1) && (oracle % 2 == 1) && (last_prediction != oracle) && (last_prediction != oracle-1))
-            oracle = 1; // if we are supposed to I-X, but last wasn't B-X or I-X, then say O
-        } else if (D.encoding == BILOU) {
-          if ((last_prediction == 1) || ((last_prediction-2) % 4 == 0) || ((last_prediction-2) % 4 == 3)) { // O or unit-X or last-X
-            P.set_allowed(D.allowed_actions);
-            // we cannot allow in-X or last-X next
-            if ((oracle > 1) && (((oracle-2) % 4 == 2) || ((oracle-2) % 4 == 3)))
-              oracle = 1;
-          } else { // begin-X or in-X
-            action other = ((last_prediction-2) % 4 == 1) ? (last_prediction+2) : last_prediction;
-            P.set_allowed(last_prediction+1);
-            P.add_allowed(other);
-            if ((oracle != last_prediction+1) && (oracle != other))
-              oracle = other;
-          }
-        }
-        P.set_input(*ec[i]);
-        P.set_condition_range((ptag)i, sch.get_history_length(), 'p');
-        if (pass > 1) P.add_condition_range((ptag)(i+1+sch.get_history_length()), sch.get_history_length()+1, 'a');
-        P.set_oracle(oracle);
-        last_prediction = P.predict();
-      
-        if ((pass == D.multipass) && sch.output().good())
-          sch.output() << ((D.encoding == BIO) ? last_prediction : bilou_to_bio(last_prediction)) << ' ';
-      }
-    }
+    assert( y == bilou_to_bio(ylab.label) );
   }
 }
 
-namespace ArgmaxTask {
-  struct task_data {
-    float false_negative_cost;
-    float negative_weight;
-    bool predict_max;
-  };
+struct task_data {
+  EncodingType encoding;
+  v_array<action> allowed_actions;
+  v_array<action> only_two_allowed;  // used for BILOU encoding
+  size_t multipass;
+};
 
-  void initialize(Search::search& sch, size_t& /*num_actions*/, po::variables_map& vm) {
-    task_data* D = new task_data();
-    
-    po::options_description argmax_opts("argmax options");
-    argmax_opts.add_options()
-      ("cost", po::value<float>(&(D->false_negative_cost))->default_value(10.0), "False Negative Cost")
-      ("negative_weight", po::value<float>(&(D->negative_weight))->default_value(1), "Relative weight of negative examples")
-      ("max", "Disable structure: just predict the max");
-    sch.add_program_options(vm, argmax_opts);
+void initialize(Search::search& sch, size_t& num_actions, po::variables_map& vm) {
+  task_data * D = new task_data();
+  po::options_description sspan_opts("search sequencespan options");
+  sspan_opts.add_options()("search_span_bilou", "switch to (internal) BILOU encoding instead of BIO encoding");
+  sspan_opts.add_options()("search_span_multipass", po::value<size_t>(&(D->multipass))->default_value(1), "do multiple passes");
+  sch.add_program_options(vm, sspan_opts);
 
-    D->predict_max = vm.count("max") > 0;
+  if (vm.count("search_span_bilou")) {
+    cerr << "switching to BILOU encoding for sequence span labeling" << endl;
+    D->encoding = BILOU;
+    num_actions = num_actions * 2 - 1;
+  } else
+    D->encoding = BIO;
 
-    sch.set_task_data(D);
 
-    if (D->predict_max)
-      sch.set_options( Search::EXAMPLES_DONT_CHANGE );   // we don't do any internal example munging
-    else
-      sch.set_options( Search::AUTO_CONDITION_FEATURES |    // automatically add history features to our examples, please
-                       Search::EXAMPLES_DONT_CHANGE );   // we don't do any internal example munging
-  }
+  D->allowed_actions.erase();
 
-  void run(Search::search& sch, vector<example*>& ec) {
-    task_data& D = *sch.get_task_data<task_data>();
-    uint32_t max_prediction = 1;
-    uint32_t max_label = 1;
-
-    for(size_t i = 0; i < ec.size(); i++)
-      max_label = max(ec[i]->l.multi.label, max_label);
-        
-    for (ptag i=0; i<ec.size(); i++) {
-      // labels should be 1 or 2, and our output is MAX of all predicted values
-      uint32_t oracle = D.predict_max ? max_label : ec[i]->l.multi.label;
-      uint32_t prediction = sch.predict(*ec[i], i+1, &oracle, 1, &i, "p");
-
-      max_prediction = max(prediction, max_prediction);
+  if (D->encoding == BIO) {
+    D->allowed_actions.push_back(1);
+    for (action l=2; l<num_actions; l+=2)
+      D->allowed_actions.push_back(l);
+    D->allowed_actions.push_back(1);  // push back an extra 1 that we can overwrite later if we want
+  } else if (D->encoding == BILOU) {
+    D->allowed_actions.push_back(1);
+    for (action l=2; l<num_actions; l+=4) {
+      D->allowed_actions.push_back(l);
+      D->allowed_actions.push_back(l+1);
     }
-    float loss = 0.;
-    if (max_label > max_prediction)
-      loss = D.false_negative_cost / D.negative_weight;
-    else if (max_prediction > max_label)
-      loss = 1.;
-    sch.loss(loss);
-
-    if (sch.output().good())
-      sch.output() << max_prediction;
+    D->only_two_allowed.push_back(0);
+    D->only_two_allowed.push_back(0);
   }
+
+  sch.set_task_data<task_data>(D);
+  sch.set_options( Search::AUTO_CONDITION_FEATURES  |    // automatically add history features to our examples, please
+                   Search::AUTO_HAMMING_LOSS        |    // please just use hamming loss on individual predictions -- we won't declare loss
+                   Search::EXAMPLES_DONT_CHANGE     |    // we don't do any internal example munging
+                   0);
+  sch.set_num_learners(D->multipass);
+}
+
+void finish(Search::search& sch) {
+  task_data* D = sch.get_task_data<task_data>();
+  D->allowed_actions.delete_v();
+  D->only_two_allowed.delete_v();
+  delete D;
+}
+
+void setup(Search::search& sch, vector<example*>& ec) {
+  task_data& D = *sch.get_task_data<task_data>();
+  if (D.encoding == BILOU)
+    convert_bio_to_bilou(ec);
+}
+
+void takedown(Search::search& sch, vector<example*>& ec) {
+  task_data& D = *sch.get_task_data<task_data>();
+
+  if (D.encoding == BILOU)
+    for (size_t n=0; n<ec.size(); n++) {
+      MULTICLASS::label_t ylab = ec[n]->l.multi;
+      ylab.label = bilou_to_bio(ylab.label);
+    }
+}
+
+void run(Search::search& sch, vector<example*>& ec) {
+  task_data& D = *sch.get_task_data<task_data>();
+  v_array<action> * y_allowed = &(D.allowed_actions);
+
+  for (size_t pass=1; pass<=D.multipass; pass++) {
+    action last_prediction = 1;
+    for (size_t i=0; i<ec.size(); i++) {
+      action oracle = ec[i]->l.multi.label;
+      size_t len = y_allowed->size();
+      Search::predictor P(sch, (ptag)i+1);
+      P.set_learner_id(pass-1);
+      if (D.encoding == BIO) {
+        if      (last_prediction == 1)       P.set_allowed(y_allowed->begin, len-1);
+        else if (last_prediction % 2 == 0) {
+          (*y_allowed)[len-1] = last_prediction+1;
+          P.set_allowed(*y_allowed);
+        }
+        else                               {
+          (*y_allowed)[len-1] = last_prediction;
+          P.set_allowed(*y_allowed);
+        }
+        if ((oracle > 1) && (oracle % 2 == 1) && (last_prediction != oracle) && (last_prediction != oracle-1))
+          oracle = 1; // if we are supposed to I-X, but last wasn't B-X or I-X, then say O
+      } else if (D.encoding == BILOU) {
+        if ((last_prediction == 1) || ((last_prediction-2) % 4 == 0) || ((last_prediction-2) % 4 == 3)) { // O or unit-X or last-X
+          P.set_allowed(D.allowed_actions);
+          // we cannot allow in-X or last-X next
+          if ((oracle > 1) && (((oracle-2) % 4 == 2) || ((oracle-2) % 4 == 3)))
+            oracle = 1;
+        } else { // begin-X or in-X
+          action other = ((last_prediction-2) % 4 == 1) ? (last_prediction+2) : last_prediction;
+          P.set_allowed(last_prediction+1);
+          P.add_allowed(other);
+          if ((oracle != last_prediction+1) && (oracle != other))
+            oracle = other;
+        }
+      }
+      P.set_input(*ec[i]);
+      P.set_condition_range((ptag)i, sch.get_history_length(), 'p');
+      if (pass > 1) P.add_condition_range((ptag)(i+1+sch.get_history_length()), sch.get_history_length()+1, 'a');
+      P.set_oracle(oracle);
+      last_prediction = P.predict();
+
+      if ((pass == D.multipass) && sch.output().good())
+        sch.output() << ((D.encoding == BIO) ? last_prediction : bilou_to_bio(last_prediction)) << ' ';
+    }
+  }
+}
+}
+
+namespace ArgmaxTask {
+struct task_data {
+  float false_negative_cost;
+  float negative_weight;
+  bool predict_max;
+};
+
+void initialize(Search::search& sch, size_t& /*num_actions*/, po::variables_map& vm) {
+  task_data* D = new task_data();
+
+  po::options_description argmax_opts("argmax options");
+  argmax_opts.add_options()
+  ("cost", po::value<float>(&(D->false_negative_cost))->default_value(10.0), "False Negative Cost")
+  ("negative_weight", po::value<float>(&(D->negative_weight))->default_value(1), "Relative weight of negative examples")
+  ("max", "Disable structure: just predict the max");
+  sch.add_program_options(vm, argmax_opts);
+
+  D->predict_max = vm.count("max") > 0;
+
+  sch.set_task_data(D);
+
+  if (D->predict_max)
+    sch.set_options( Search::EXAMPLES_DONT_CHANGE );   // we don't do any internal example munging
+  else
+    sch.set_options( Search::AUTO_CONDITION_FEATURES |    // automatically add history features to our examples, please
+                     Search::EXAMPLES_DONT_CHANGE );   // we don't do any internal example munging
+}
+
+void run(Search::search& sch, vector<example*>& ec) {
+  task_data& D = *sch.get_task_data<task_data>();
+  uint32_t max_prediction = 1;
+  uint32_t max_label = 1;
+
+  for(size_t i = 0; i < ec.size(); i++)
+    max_label = max(ec[i]->l.multi.label, max_label);
+
+  for (ptag i=0; i<ec.size(); i++) {
+    // labels should be 1 or 2, and our output is MAX of all predicted values
+    uint32_t oracle = D.predict_max ? max_label : ec[i]->l.multi.label;
+    uint32_t prediction = sch.predict(*ec[i], i+1, &oracle, 1, &i, "p");
+
+    max_prediction = max(prediction, max_prediction);
+  }
+  float loss = 0.;
+  if (max_label > max_prediction)
+    loss = D.false_negative_cost / D.negative_weight;
+  else if (max_prediction > max_label)
+    loss = 1.;
+  sch.loss(loss);
+
+  if (sch.output().good())
+    sch.output() << max_prediction;
+}
 }
 
 
 namespace SequenceTask_DemoLDF {  // this is just to debug/show off how to do LDF
-  namespace CS=COST_SENSITIVE;
-  struct task_data {
-    example* ldf_examples;
-    size_t   num_actions;
-  };
-  
-  void initialize(Search::search& sch, size_t& num_actions, po::variables_map& /*vm*/) {
-    CS::wclass default_wclass = { 0., 0, 0., 0. };
+namespace CS=COST_SENSITIVE;
+struct task_data {
+  example* ldf_examples;
+  size_t   num_actions;
+};
 
-    example* ldf_examples = VW::alloc_examples(sizeof(CS::label), num_actions);
-    for (size_t a=0; a<num_actions; a++) {
-      CS::label& lab = ldf_examples[a].l.cs;
-      CS::cs_label.default_label(&lab);
-      lab.costs.push_back(default_wclass);
-    }
+void initialize(Search::search& sch, size_t& num_actions, po::variables_map& /*vm*/) {
+  CS::wclass default_wclass = { 0., 0, 0., 0. };
 
-    task_data* data = &calloc_or_die<task_data>();
-    data->ldf_examples = ldf_examples;
-    data->num_actions  = num_actions;
-
-    sch.set_task_data<task_data>(data);
-    sch.set_options( Search::AUTO_CONDITION_FEATURES |    // automatically add history features to our examples, please
-                     Search::AUTO_HAMMING_LOSS       |    // please just use hamming loss on individual predictions -- we won't declare loss
-                     Search::IS_LDF                  );   // we generate ldf examples
+  example* ldf_examples = VW::alloc_examples(sizeof(CS::label), num_actions);
+  for (size_t a=0; a<num_actions; a++) {
+    CS::label& lab = ldf_examples[a].l.cs;
+    CS::cs_label.default_label(&lab);
+    lab.costs.push_back(default_wclass);
   }
 
-  void finish(Search::search& sch) {
-    task_data *data = sch.get_task_data<task_data>();
-    for (size_t a=0; a<data->num_actions; a++)
-      VW::dealloc_example(CS::cs_label.delete_label, data->ldf_examples[a]);
-    free(data->ldf_examples);
-    free(data);
-  }
+  task_data* data = &calloc_or_die<task_data>();
+  data->ldf_examples = ldf_examples;
+  data->num_actions  = num_actions;
+
+  sch.set_task_data<task_data>(data);
+  sch.set_options( Search::AUTO_CONDITION_FEATURES |    // automatically add history features to our examples, please
+                   Search::AUTO_HAMMING_LOSS       |    // please just use hamming loss on individual predictions -- we won't declare loss
+                   Search::IS_LDF                  );   // we generate ldf examples
+}
+
+void finish(Search::search& sch) {
+  task_data *data = sch.get_task_data<task_data>();
+  for (size_t a=0; a<data->num_actions; a++)
+    VW::dealloc_example(CS::cs_label.delete_label, data->ldf_examples[a]);
+  free(data->ldf_examples);
+  free(data);
+}
 
 
-  // this is totally bogus for the example -- you'd never actually do this!
-  void my_update_example_indicies(Search::search& sch, bool audit, example* ec, uint32_t mult_amount, uint32_t plus_amount) {
-    size_t ss = sch.get_stride_shift();
+// this is totally bogus for the example -- you'd never actually do this!
+void my_update_example_indicies(Search::search& sch, bool audit, example* ec, uint32_t mult_amount, uint32_t plus_amount) {
+  size_t ss = sch.get_stride_shift();
+  for (unsigned char* i = ec->indices.begin; i != ec->indices.end; i++)
+    for (feature* f = ec->atomics[*i].begin; f != ec->atomics[*i].end; ++f)
+      f->weight_index = (((f->weight_index>>ss) * mult_amount) + plus_amount)<<ss;
+  if (audit)
     for (unsigned char* i = ec->indices.begin; i != ec->indices.end; i++)
-      for (feature* f = ec->atomics[*i].begin; f != ec->atomics[*i].end; ++f)
-        f->weight_index = (((f->weight_index>>ss) * mult_amount) + plus_amount)<<ss;
-    if (audit)
-      for (unsigned char* i = ec->indices.begin; i != ec->indices.end; i++) 
-        if (ec->audit_features[*i].begin != ec->audit_features[*i].end)
-          for (audit_data *f = ec->audit_features[*i].begin; f != ec->audit_features[*i].end; ++f)
-            f->weight_index = (((f->weight_index>>ss) * mult_amount) + plus_amount)<<ss;
-  }
-  
-  void run(Search::search& sch, vector<example*>& ec) {
-    task_data *data = sch.get_task_data<task_data>();
-    for (ptag i=0; i<ec.size(); i++) {
-      for (size_t a=0; a<data->num_actions; a++) {
-        if (sch.predictNeedsExample()) { // we can skip this work if `predict` won't actually use the example data
-          VW::copy_example_data(false, &data->ldf_examples[a], ec[i]);  // copy but leave label alone!
-          // now, offset it appropriately for the action id
-          my_update_example_indicies(sch, true, &data->ldf_examples[a], 28904713, 4832917 * (uint32_t)a);
-        }
+      if (ec->audit_features[*i].begin != ec->audit_features[*i].end)
+        for (audit_data *f = ec->audit_features[*i].begin; f != ec->audit_features[*i].end; ++f)
+          f->weight_index = (((f->weight_index>>ss) * mult_amount) + plus_amount)<<ss;
+}
 
-        // regardless of whether the example is needed or not, the class info is needed
-        CS::label& lab = data->ldf_examples[a].l.cs;
-        // need to tell search what the action id is, so that it can add history features correctly!
-        lab.costs[0].x = 0.;
-        lab.costs[0].class_index = (uint32_t)a+1;
-        lab.costs[0].partial_prediction = 0.;
-        lab.costs[0].wap_value = 0.;
+void run(Search::search& sch, vector<example*>& ec) {
+  task_data *data = sch.get_task_data<task_data>();
+  for (ptag i=0; i<ec.size(); i++) {
+    for (size_t a=0; a<data->num_actions; a++) {
+      if (sch.predictNeedsExample()) { // we can skip this work if `predict` won't actually use the example data
+        VW::copy_example_data(false, &data->ldf_examples[a], ec[i]);  // copy but leave label alone!
+        // now, offset it appropriately for the action id
+        my_update_example_indicies(sch, true, &data->ldf_examples[a], 28904713, 4832917 * (uint32_t)a);
       }
 
-      action oracle  = ec[i]->l.multi.label - 1;
-      action pred_id = Search::predictor(sch, i+1).set_input(data->ldf_examples, data->num_actions).set_oracle(oracle).set_condition_range(i, sch.get_history_length(), 'p').predict();
-      action prediction = pred_id + 1;  // or ldf_examples[pred_id]->ld.costs[0].weight_index
-      
-      if (sch.output().good())
-        sch.output() << prediction << ' ';
+      // regardless of whether the example is needed or not, the class info is needed
+      CS::label& lab = data->ldf_examples[a].l.cs;
+      // need to tell search what the action id is, so that it can add history features correctly!
+      lab.costs[0].x = 0.;
+      lab.costs[0].class_index = (uint32_t)a+1;
+      lab.costs[0].partial_prediction = 0.;
+      lab.costs[0].wap_value = 0.;
     }
+
+    action oracle  = ec[i]->l.multi.label - 1;
+    action pred_id = Search::predictor(sch, i+1).set_input(data->ldf_examples, data->num_actions).set_oracle(oracle).set_condition_range(i, sch.get_history_length(), 'p').predict();
+    action prediction = pred_id + 1;  // or ldf_examples[pred_id]->ld.costs[0].weight_index
+
+    if (sch.output().good())
+      sch.output() << prediction << ' ';
   }
+}
 }

--- a/vowpalwabbit/search_sequencetask.h
+++ b/vowpalwabbit/search_sequencetask.h
@@ -7,29 +7,29 @@ license as described in the file LICENSE.
 #include "search.h"
 
 namespace SequenceTask {
-  void initialize(Search::search&, size_t&, po::variables_map&);
-  void run(Search::search&, vector<example*>&);
-  extern Search::search_task task;
+void initialize(Search::search&, size_t&, po::variables_map&);
+void run(Search::search&, vector<example*>&);
+extern Search::search_task task;
 }
 
 namespace SequenceSpanTask {
-  void initialize(Search::search&, size_t&, po::variables_map&);
-  void finish(Search::search&);
-  void run(Search::search&, vector<example*>&);
-  void setup(Search::search&, vector<example*>&);
-  void takedown(Search::search&, vector<example*>&);
-  extern Search::search_task task;
+void initialize(Search::search&, size_t&, po::variables_map&);
+void finish(Search::search&);
+void run(Search::search&, vector<example*>&);
+void setup(Search::search&, vector<example*>&);
+void takedown(Search::search&, vector<example*>&);
+extern Search::search_task task;
 }
 
 namespace ArgmaxTask {
-  void initialize(Search::search&, size_t&, po::variables_map&);
-  void run(Search::search&, vector<example*>&);
-  extern Search::search_task task;
+void initialize(Search::search&, size_t&, po::variables_map&);
+void run(Search::search&, vector<example*>&);
+extern Search::search_task task;
 }
 
 namespace SequenceTask_DemoLDF {
-  void initialize(Search::search&, size_t&, po::variables_map&);
-  void finish(Search::search&);
-  void run(Search::search&, vector<example*>&);
-  extern Search::search_task task;
+void initialize(Search::search&, size_t&, po::variables_map&);
+void finish(Search::search&);
+void run(Search::search&, vector<example*>&);
+extern Search::search_task task;
 }

--- a/vowpalwabbit/sender.cc
+++ b/vowpalwabbit/sender.cc
@@ -39,7 +39,7 @@ void open_sockets(sender& s, string host)
 void send_features(io_buf *b, example& ec, uint32_t mask)
 { // note: subtracting 1 b/c not sending constant
   output_byte(*b,(unsigned char) (ec.indices.size()-1));
-  
+
   for (unsigned char* i = ec.indices.begin; i != ec.indices.end; i++) {
     if (*i == constant_namespace)
       continue;
@@ -51,22 +51,22 @@ void send_features(io_buf *b, example& ec, uint32_t mask)
 void receive_result(sender& s)
 {
   float res, weight;
-  
+
   get_prediction(s.sd,res,weight);
   example& ec = *s.delay_ring[s.received_index++ % s.all->p->ring_size];
   ec.pred.scalar = res;
-  
+
   label_data& ld = ec.l.simple;
   ec.loss = s.all->loss->getLoss(s.all->sd, ec.pred.scalar, ld.label) * ld.weight;
-  
-  return_simple_example(*(s.all), nullptr, ec);  
+
+  return_simple_example(*(s.all), nullptr, ec);
 }
 
 void learn(sender& s, LEARNER::base_learner&, example& ec)
-{ 
+{
   if (s.received_index + s.all->p->ring_size / 2 - 1 == s.sent_index)
     receive_result(s);
-  
+
   s.all->set_minmax(s.all->sd, ec.l.simple.label);
   s.all->p->lp.cache_label(&ec.l, *s.buf);//send label information.
   cache_tag(*s.buf, ec.tag);
@@ -74,7 +74,7 @@ void learn(sender& s, LEARNER::base_learner&, example& ec)
   s.delay_ring[s.sent_index++ % s.all->p->ring_size] = &ec;
 }
 
-void finish_example(vw&, sender&, example&){}
+void finish_example(vw&, sender&, example&) {}
 
 void end_examples(sender& s)
 { //close our outputs to signal finishing.
@@ -83,8 +83,8 @@ void end_examples(sender& s)
   shutdown(s.buf->files[0],SHUT_WR);
 }
 
-void finish(sender& s) 
-{ 
+void finish(sender& s)
+{
   s.buf->files.delete_v();
   s.buf->space.delete_v();
   free(s.delay_ring);
@@ -95,21 +95,21 @@ LEARNER::base_learner* sender_setup(vw& all)
 {
   if (missing_option<string, true>(all, "sendto", "send examples to <host>"))
     return nullptr;
-  
+
   sender& s = calloc_or_die<sender>();
   s.sd = -1;
   if (all.vm.count("sendto"))
-    {      
-      string host = all.vm["sendto"].as< string >();
-      open_sockets(s, host);
-    }
-  
+  {
+    string host = all.vm["sendto"].as< string >();
+    open_sockets(s, host);
+  }
+
   s.all = &all;
   s.delay_ring = calloc_or_die<example*>(all.p->ring_size);
-  
+
   LEARNER::learner<sender>& l = init_learner(&s, learn, 1);
   l.set_finish(finish);
-  l.set_finish_example(finish_example); 
+  l.set_finish_example(finish_example);
   l.set_end_examples(end_examples);
   return make_base(l);
 }

--- a/vowpalwabbit/simple_label.cc
+++ b/vowpalwabbit/simple_label.cc
@@ -27,7 +27,7 @@ size_t read_cached_simple_label(shared_data* sd, void* v, io_buf& cache)
   label_data* ld = (label_data*) v;
   char *c;
   size_t total = sizeof(ld->label)+sizeof(ld->weight)+sizeof(ld->initial);
-  if (buf_read(cache, c, total) < total) 
+  if (buf_read(cache, c, total) < total)
     return 0;
   c = bufread_simple_label(sd, ld,c);
 
@@ -92,7 +92,7 @@ void parse_simple_label(parser*, shared_data*, void* v, v_array<substring>& word
     break;
   default:
     cout << "Error: " << words.size() << " is too many tokens for a simple label: ";
-    for(unsigned int i=0; i<words.size(); ++i) 
+    for(unsigned int i=0; i<words.size(); ++i)
       print_substring(words[i]);
     cout << endl;
   }
@@ -100,18 +100,19 @@ void parse_simple_label(parser*, shared_data*, void* v, v_array<substring>& word
 }
 
 label_parser simple_label = {default_simple_label, parse_simple_label,
-				   cache_simple_label, read_cached_simple_label, 
-				   delete_simple_label, get_weight,  
-                                   nullptr,
-				   sizeof(label_data)};
+                             cache_simple_label, read_cached_simple_label,
+                             delete_simple_label, get_weight,
+                             nullptr,
+                             sizeof(label_data)
+                            };
 
 void print_update(vw& all, example& ec)
 {
   if (all.sd->weighted_examples >= all.sd->dump_interval && !all.quiet && !all.bfgs)
-    {
-      all.sd->print_update(all.holdout_set_off, all.current_pass, ec.l.simple.label, ec.pred.scalar, 
-			   ec.num_features, all.progress_add, all.progress_arg);
-    }
+  {
+    all.sd->print_update(all.holdout_set_off, all.current_pass, ec.l.simple.label, ec.pred.scalar,
+                         ec.num_features, all.progress_add, all.progress_arg);
+  }
 }
 
 void output_and_account_example(vw& all, example& ec)
@@ -125,13 +126,13 @@ void output_and_account_example(vw& all, example& ec)
 
   all.print(all.raw_prediction, ec.partial_prediction, -1, ec.tag);
   for (size_t i = 0; i<all.final_prediction_sink.size(); i++)
-    {
-      int f = (int)all.final_prediction_sink[i];
-      if (all.lda > 0)
-	print_lda_result(all, f,ec.topic_predictions.begin,0.,ec.tag);
-      else
-	all.print(f, ec.pred.scalar, 0, ec.tag);
-    }
+  {
+    int f = (int)all.final_prediction_sink[i];
+    if (all.lda > 0)
+      print_lda_result(all, f,ec.topic_predictions.begin,0.,ec.tag);
+    else
+      all.print(f, ec.pred.scalar, 0, ec.tag);
+  }
 
   print_update(all, ec);
 }
@@ -161,5 +162,5 @@ bool summarize_holdout_set(vw& all, size_t& no_win_counter)
 
   if ((thisLoss != FLT_MAX) || (isfinite(all.sd->holdout_best_loss))) // it's only a loss if we're not infinite when the previous one wasn't infinite
     no_win_counter++;
-  return false;          
-} 
+  return false;
+}

--- a/vowpalwabbit/stagewise_poly.cc
+++ b/vowpalwabbit/stagewise_poly.cc
@@ -11,700 +11,700 @@
 using namespace std;
 using namespace LEARNER;
 
-  static const uint32_t parent_bit = 1;
-  static const uint32_t cycle_bit = 2;
-  static const uint32_t tree_atomics = 134;
-  static const float tolerance = 1e-9f;
-  static const uint32_t indicator_bit = 128;
-  static const uint32_t default_depth = 127;
+static const uint32_t parent_bit = 1;
+static const uint32_t cycle_bit = 2;
+static const uint32_t tree_atomics = 134;
+static const float tolerance = 1e-9f;
+static const uint32_t indicator_bit = 128;
+static const uint32_t default_depth = 127;
 
-  struct sort_data {
-    float wval;
-    uint32_t wid;
-  };
+struct sort_data {
+  float wval;
+  uint32_t wid;
+};
 
-  struct stagewise_poly
-  {
-    vw *all; // many uses, unmodular reduction
+struct stagewise_poly
+{
+  vw *all; // many uses, unmodular reduction
 
-    float sched_exponent;
-    uint32_t batch_sz;
-    bool batch_sz_double;
+  float sched_exponent;
+  uint32_t batch_sz;
+  bool batch_sz_double;
 
-    sort_data *sd;
-    uint32_t sd_len;
-    uint8_t *depthsbits; //interleaved array storing depth information and parent/cycle bits
+  sort_data *sd;
+  uint32_t sd_len;
+  uint8_t *depthsbits; //interleaved array storing depth information and parent/cycle bits
 
-    uint64_t sum_sparsity; //of synthetic example
-    uint64_t sum_input_sparsity; //of input example
-    uint64_t num_examples;
-    //following three are for parallel (see end_pass())
-    uint64_t sum_sparsity_sync;
-    uint64_t sum_input_sparsity_sync;
-    uint64_t num_examples_sync;
+  uint64_t sum_sparsity; //of synthetic example
+  uint64_t sum_input_sparsity; //of input example
+  uint64_t num_examples;
+  //following three are for parallel (see end_pass())
+  uint64_t sum_sparsity_sync;
+  uint64_t sum_input_sparsity_sync;
+  uint64_t num_examples_sync;
 
-    example synth_ec;
-    //following is bookkeeping in synth_ec creation (dfs)
-    feature synth_rec_f;
-    example *original_ec;
-    uint32_t cur_depth;
-    bool training;
-    uint64_t last_example_counter;
-    size_t numpasses;
-    uint32_t next_batch_sz;
-    bool update_support;
+  example synth_ec;
+  //following is bookkeeping in synth_ec creation (dfs)
+  feature synth_rec_f;
+  example *original_ec;
+  uint32_t cur_depth;
+  bool training;
+  uint64_t last_example_counter;
+  size_t numpasses;
+  uint32_t next_batch_sz;
+  bool update_support;
 
 #ifdef DEBUG
-    uint32_t max_depth;
-    uint32_t depths[100000];
+  uint32_t max_depth;
+  uint32_t depths[100000];
 #endif //DEBUG
 
 #ifdef MAGIC_ARGUMENT
-    float magic_argument;
+  float magic_argument;
 #endif //MAGIC_ARGUMENT
-  };
+};
 
 
-  inline uint32_t stride_shift(const stagewise_poly &poly, uint32_t idx)
-  {
-    return idx << poly.all->reg.stride_shift;
-  }
+inline uint32_t stride_shift(const stagewise_poly &poly, uint32_t idx)
+{
+  return idx << poly.all->reg.stride_shift;
+}
 
-  inline uint32_t stride_un_shift(const stagewise_poly &poly, uint32_t idx)
-  {
-    return idx >> poly.all->reg.stride_shift;
-  }
+inline uint32_t stride_un_shift(const stagewise_poly &poly, uint32_t idx)
+{
+  return idx >> poly.all->reg.stride_shift;
+}
 
-  inline uint32_t do_ft_offset(const stagewise_poly &poly, uint32_t idx)
-  {
-    //cout << poly.synth_ec.ft_offset << "  " << poly.original_ec->ft_offset << endl;
-    assert(!poly.original_ec || poly.synth_ec.ft_offset == poly.original_ec->ft_offset);
-    return idx + poly.synth_ec.ft_offset;
-  }
+inline uint32_t do_ft_offset(const stagewise_poly &poly, uint32_t idx)
+{
+  //cout << poly.synth_ec.ft_offset << "  " << poly.original_ec->ft_offset << endl;
+  assert(!poly.original_ec || poly.synth_ec.ft_offset == poly.original_ec->ft_offset);
+  return idx + poly.synth_ec.ft_offset;
+}
 
-  inline uint32_t un_ft_offset(const stagewise_poly &poly, uint32_t idx)
-  {
-    assert(!poly.original_ec || poly.synth_ec.ft_offset == poly.original_ec->ft_offset);
-    if (poly.synth_ec.ft_offset == 0)
-      return idx;
-    else {
-      while (idx < poly.synth_ec.ft_offset) {
-        idx += (uint32_t) poly.all->length() << poly.all->reg.stride_shift;
-      }
-      return idx - poly.synth_ec.ft_offset;
+inline uint32_t un_ft_offset(const stagewise_poly &poly, uint32_t idx)
+{
+  assert(!poly.original_ec || poly.synth_ec.ft_offset == poly.original_ec->ft_offset);
+  if (poly.synth_ec.ft_offset == 0)
+    return idx;
+  else {
+    while (idx < poly.synth_ec.ft_offset) {
+      idx += (uint32_t) poly.all->length() << poly.all->reg.stride_shift;
     }
+    return idx - poly.synth_ec.ft_offset;
   }
+}
 
-  inline uint32_t wid_mask(const stagewise_poly &poly, uint32_t wid)
-  {
-    return wid & poly.all->reg.weight_mask;
+inline uint32_t wid_mask(const stagewise_poly &poly, uint32_t wid)
+{
+  return wid & poly.all->reg.weight_mask;
+}
+
+inline uint32_t wid_mask_un_shifted(const stagewise_poly &poly, uint32_t wid)
+{
+  return stride_un_shift(poly, wid & poly.all->reg.weight_mask);
+}
+
+inline uint32_t constant_feat(const stagewise_poly &poly)
+{
+  return stride_shift(poly, constant * poly.all->wpp);
+}
+
+inline uint32_t constant_feat_masked(const stagewise_poly &poly)
+{
+  return wid_mask(poly, constant_feat(poly));
+}
+
+
+inline uint32_t depthsbits_sizeof(const stagewise_poly &poly)
+{
+  return (uint32_t)(2 * poly.all->length() * sizeof(uint8_t));
+}
+
+void depthsbits_create(stagewise_poly &poly)
+{
+  poly.depthsbits = calloc_or_die<uint8_t>(2 * poly.all->length());
+  for (uint32_t i = 0; i < poly.all->length() * 2; i += 2) {
+    poly.depthsbits[i] = default_depth;
+    poly.depthsbits[i+1] = indicator_bit;
   }
+}
 
-  inline uint32_t wid_mask_un_shifted(const stagewise_poly &poly, uint32_t wid)
-  {
-    return stride_un_shift(poly, wid & poly.all->reg.weight_mask);
-  }
+void depthsbits_destroy(stagewise_poly &poly)
+{
+  free(poly.depthsbits);
+}
 
-  inline uint32_t constant_feat(const stagewise_poly &poly)
-  {
-    return stride_shift(poly, constant * poly.all->wpp);
-  }
+inline bool parent_get(const stagewise_poly &poly, uint32_t wid)
+{
+  assert(wid % stride_shift(poly, 1) == 0);
+  assert(do_ft_offset(poly, wid) % stride_shift(poly, 1) == 0);
+  return poly.depthsbits[wid_mask_un_shifted(poly, do_ft_offset(poly, wid)) * 2 + 1] & parent_bit;
+}
 
-  inline uint32_t constant_feat_masked(const stagewise_poly &poly)
-  {
-    return wid_mask(poly, constant_feat(poly));
-  }
+inline void parent_toggle(stagewise_poly &poly, uint32_t wid)
+{
+  assert(wid % stride_shift(poly, 1) == 0);
+  assert(do_ft_offset(poly, wid) % stride_shift(poly, 1) == 0);
+  poly.depthsbits[wid_mask_un_shifted(poly, do_ft_offset(poly, wid)) * 2 + 1] ^= parent_bit;
+}
 
+inline bool cycle_get(const stagewise_poly &poly, uint32_t wid)
+{
+  //note: intentionally leaving out ft_offset.
+  assert(wid % stride_shift(poly, 1) == 0);
+  if ((poly.depthsbits[wid_mask_un_shifted(poly, wid) * 2 + 1] & cycle_bit) > 0)
+    return true;
+  else
+    return false;
+}
 
-  inline uint32_t depthsbits_sizeof(const stagewise_poly &poly)
-  {
-    return (uint32_t)(2 * poly.all->length() * sizeof(uint8_t));
-  }
+inline void cycle_toggle(stagewise_poly &poly, uint32_t wid)
+{
+  //note: intentionally leaving out ft_offset.
+  assert(wid % stride_shift(poly, 1) == 0);
+  poly.depthsbits[wid_mask_un_shifted(poly, wid) * 2 + 1] ^= cycle_bit;
+}
 
-  void depthsbits_create(stagewise_poly &poly)
-  {
-    poly.depthsbits = calloc_or_die<uint8_t>(2 * poly.all->length());
-    for (uint32_t i = 0; i < poly.all->length() * 2; i += 2) {
-      poly.depthsbits[i] = default_depth;
-      poly.depthsbits[i+1] = indicator_bit;
-    }
-  }
+inline uint8_t min_depths_get(const stagewise_poly &poly, uint32_t wid)
+{
+  assert(wid % stride_shift(poly, 1) == 0);
+  assert(do_ft_offset(poly, wid) % stride_shift(poly, 1) == 0);
+  return poly.depthsbits[stride_un_shift(poly, do_ft_offset(poly, wid)) * 2];
+}
 
-  void depthsbits_destroy(stagewise_poly &poly)
-  {
-    free(poly.depthsbits);
-  }
-
-  inline bool parent_get(const stagewise_poly &poly, uint32_t wid)
-  {
-    assert(wid % stride_shift(poly, 1) == 0);
-    assert(do_ft_offset(poly, wid) % stride_shift(poly, 1) == 0);
-    return poly.depthsbits[wid_mask_un_shifted(poly, do_ft_offset(poly, wid)) * 2 + 1] & parent_bit;
-  }
-
-  inline void parent_toggle(stagewise_poly &poly, uint32_t wid)
-  {
-    assert(wid % stride_shift(poly, 1) == 0);
-    assert(do_ft_offset(poly, wid) % stride_shift(poly, 1) == 0);
-    poly.depthsbits[wid_mask_un_shifted(poly, do_ft_offset(poly, wid)) * 2 + 1] ^= parent_bit;
-  }
-
-  inline bool cycle_get(const stagewise_poly &poly, uint32_t wid)
-  {
-    //note: intentionally leaving out ft_offset.
-    assert(wid % stride_shift(poly, 1) == 0);
-	if ((poly.depthsbits[wid_mask_un_shifted(poly, wid) * 2 + 1] & cycle_bit) > 0)
-		return true;
-	else
-		return false;
-  }
-
-  inline void cycle_toggle(stagewise_poly &poly, uint32_t wid)
-  {
-    //note: intentionally leaving out ft_offset.
-    assert(wid % stride_shift(poly, 1) == 0);
-    poly.depthsbits[wid_mask_un_shifted(poly, wid) * 2 + 1] ^= cycle_bit;
-  }
-
-  inline uint8_t min_depths_get(const stagewise_poly &poly, uint32_t wid)
-  {
-    assert(wid % stride_shift(poly, 1) == 0);
-    assert(do_ft_offset(poly, wid) % stride_shift(poly, 1) == 0);
-    return poly.depthsbits[stride_un_shift(poly, do_ft_offset(poly, wid)) * 2];
-  }
-
-  inline void min_depths_set(stagewise_poly &poly, uint32_t wid, uint8_t depth)
-  {
-    assert(wid % stride_shift(poly, 1) == 0);
-    assert(do_ft_offset(poly, wid) % stride_shift(poly, 1) == 0);
-    poly.depthsbits[stride_un_shift(poly, do_ft_offset(poly, wid)) * 2] = depth;
-  }
+inline void min_depths_set(stagewise_poly &poly, uint32_t wid, uint8_t depth)
+{
+  assert(wid % stride_shift(poly, 1) == 0);
+  assert(do_ft_offset(poly, wid) % stride_shift(poly, 1) == 0);
+  poly.depthsbits[stride_un_shift(poly, do_ft_offset(poly, wid)) * 2] = depth;
+}
 
 #ifndef NDEBUG
-  void sanity_check_state(stagewise_poly &poly)
+void sanity_check_state(stagewise_poly &poly)
+{
+  for (uint32_t i = 0; i != poly.all->length(); ++i)
   {
-    for (uint32_t i = 0; i != poly.all->length(); ++i)
-    {
-      uint32_t wid = stride_shift(poly, i);
+    uint32_t wid = stride_shift(poly, i);
 
-      assert( ! cycle_get(poly,wid) );
+    assert( ! cycle_get(poly,wid) );
 
-      assert( ! (min_depths_get(poly, wid) == default_depth && parent_get(poly, wid)) );
+    assert( ! (min_depths_get(poly, wid) == default_depth && parent_get(poly, wid)) );
 
-      assert( ! (min_depths_get(poly, wid) == default_depth && fabsf(poly.all->reg.weight_vector[wid]) > 0) );
-      //assert( min_depths_get(poly, wid) != default_depth && fabsf(poly.all->reg.weight_vector[wid]) < tolerance );
+    assert( ! (min_depths_get(poly, wid) == default_depth && fabsf(poly.all->reg.weight_vector[wid]) > 0) );
+    //assert( min_depths_get(poly, wid) != default_depth && fabsf(poly.all->reg.weight_vector[wid]) < tolerance );
 
-      assert( ! (poly.depthsbits[wid_mask_un_shifted(poly, wid) * 2 + 1] & ~(parent_bit + cycle_bit + indicator_bit)) );
-    }
+    assert( ! (poly.depthsbits[wid_mask_un_shifted(poly, wid) * 2 + 1] & ~(parent_bit + cycle_bit + indicator_bit)) );
   }
+}
 #endif //NDEBUG
 
-  //Note.  OUTPUT & INPUT masked.
-  //It is very important that this function is invariant to stride.
-  inline uint32_t child_wid(const stagewise_poly &poly, uint32_t wi_atomic, uint32_t wi_general)
-  {
-    assert(wi_atomic == wid_mask(poly, wi_atomic));
-    assert(wi_general == wid_mask(poly, wi_general));
-    assert((wi_atomic & (stride_shift(poly, 1) - 1)) == 0);
-    assert((wi_general & (stride_shift(poly, 1) - 1)) == 0);
+//Note.  OUTPUT & INPUT masked.
+//It is very important that this function is invariant to stride.
+inline uint32_t child_wid(const stagewise_poly &poly, uint32_t wi_atomic, uint32_t wi_general)
+{
+  assert(wi_atomic == wid_mask(poly, wi_atomic));
+  assert(wi_general == wid_mask(poly, wi_general));
+  assert((wi_atomic & (stride_shift(poly, 1) - 1)) == 0);
+  assert((wi_general & (stride_shift(poly, 1) - 1)) == 0);
 
-    if (wi_atomic == constant_feat_masked(poly))
-      return wi_general;
-    else if (wi_general == constant_feat_masked(poly))
-      return wi_atomic;
-    else {
-      //This is basically the "Fowler–Noll–Vo" hash.  Ideally, the hash would be invariant
-      //to the monomial, whereas this here is sensitive to the path followed, but whatever.
-      //the two main big differences with FNV are: (1) the "*constant" case should also have
-      //a big prime (so the default hash shouldn't be identity on small things, and (2) the
-      //size should not just be a power of 2, but some big prime.
-      return wid_mask(poly, stride_shift(poly, stride_un_shift(poly, wi_atomic)
-            ^ (16777619 * stride_un_shift(poly, wi_general))));
-    }
+  if (wi_atomic == constant_feat_masked(poly))
+    return wi_general;
+  else if (wi_general == constant_feat_masked(poly))
+    return wi_atomic;
+  else {
+    //This is basically the "Fowler–Noll–Vo" hash.  Ideally, the hash would be invariant
+    //to the monomial, whereas this here is sensitive to the path followed, but whatever.
+    //the two main big differences with FNV are: (1) the "*constant" case should also have
+    //a big prime (so the default hash shouldn't be identity on small things, and (2) the
+    //size should not just be a power of 2, but some big prime.
+    return wid_mask(poly, stride_shift(poly, stride_un_shift(poly, wi_atomic)
+                                       ^ (16777619 * stride_un_shift(poly, wi_general))));
   }
+}
 
-  void sort_data_create(stagewise_poly &poly)
-  {
-    poly.sd = nullptr;
-    poly.sd_len = 0;
-  }
+void sort_data_create(stagewise_poly &poly)
+{
+  poly.sd = nullptr;
+  poly.sd_len = 0;
+}
 
-  void sort_data_ensure_sz(stagewise_poly &poly, uint32_t len)
-  {
-    if (poly.sd_len < len) {
-      uint32_t len_candidate = 2 * len;
+void sort_data_ensure_sz(stagewise_poly &poly, uint32_t len)
+{
+  if (poly.sd_len < len) {
+    uint32_t len_candidate = 2 * len;
 #ifdef DEBUG
-      cout << "resizing sort buffer; current size " << poly.sd_len;
+    cout << "resizing sort buffer; current size " << poly.sd_len;
 #endif //DEBUG
-      poly.sd_len = (len_candidate > poly.all->length()) ? (uint32_t)poly.all->length() : len_candidate;
+    poly.sd_len = (len_candidate > poly.all->length()) ? (uint32_t)poly.all->length() : len_candidate;
 #ifdef DEBUG
-      cout << ", new size " << poly.sd_len << endl;
+    cout << ", new size " << poly.sd_len << endl;
 #endif //DEBUG
-      free(poly.sd); //okay for null.
-      poly.sd = calloc_or_die<sort_data>(poly.sd_len);
-    }
-    assert(len <= poly.sd_len);
+    free(poly.sd); //okay for null.
+    poly.sd = calloc_or_die<sort_data>(poly.sd_len);
   }
+  assert(len <= poly.sd_len);
+}
 
-  void sort_data_destroy(stagewise_poly &poly)
-  {
-    free(poly.sd);
-  }
+void sort_data_destroy(stagewise_poly &poly)
+{
+  free(poly.sd);
+}
 
 #ifdef DEBUG
-  int sort_data_compar(const void *a_v, const void *b_v)
-  {
-    return 2 * ( ((sort_data *) a_v)->wval < ((sort_data *) b_v)->wval ) - 1;
-  }
+int sort_data_compar(const void *a_v, const void *b_v)
+{
+  return 2 * ( ((sort_data *) a_v)->wval < ((sort_data *) b_v)->wval ) - 1;
+}
 #endif //DEBUG
 
-  int sort_data_compar_heap(sort_data &a_v, sort_data &b_v)
-  {
-    return (a_v.wval > b_v.wval);
-  }
+int sort_data_compar_heap(sort_data &a_v, sort_data &b_v)
+{
+  return (a_v.wval > b_v.wval);
+}
 
-  /*
-   * Performance note.
-   *
-   * On my laptop (Intel(R) Core(TM) i7-3520M CPU @ 2.90GHz), with compiler
-   * optimizations enabled, this routine takes ~0.001 seconds with -b 18 and
-   * ~0.06 seconds with -b 24.  Since it is intended to run ~8 times in 1-pass
-   * mode and otherwise once per pass, it is considered adequate.
-   *
-   * Another choice (implemented in another version) is to never process the
-   * whole weight vector (e.g., by updating a hash set of nonzero weights after
-   * creating the synthetic example, and only processing that here).  This
-   * choice was implemented in a similar algorithm and performed well.
-   */
-  void sort_data_update_support(stagewise_poly &poly)
-  {
-    assert(poly.num_examples);
+/*
+ * Performance note.
+ *
+ * On my laptop (Intel(R) Core(TM) i7-3520M CPU @ 2.90GHz), with compiler
+ * optimizations enabled, this routine takes ~0.001 seconds with -b 18 and
+ * ~0.06 seconds with -b 24.  Since it is intended to run ~8 times in 1-pass
+ * mode and otherwise once per pass, it is considered adequate.
+ *
+ * Another choice (implemented in another version) is to never process the
+ * whole weight vector (e.g., by updating a hash set of nonzero weights after
+ * creating the synthetic example, and only processing that here).  This
+ * choice was implemented in a similar algorithm and performed well.
+ */
+void sort_data_update_support(stagewise_poly &poly)
+{
+  assert(poly.num_examples);
 
-    //ft_offset affects parent_set / parent_get.  This state must be reset at end.
-    uint32_t pop_ft_offset = poly.original_ec->ft_offset;
-    poly.synth_ec.ft_offset = 0;
-    assert(poly.original_ec);
-    poly.original_ec->ft_offset = 0;
+  //ft_offset affects parent_set / parent_get.  This state must be reset at end.
+  uint32_t pop_ft_offset = poly.original_ec->ft_offset;
+  poly.synth_ec.ft_offset = 0;
+  assert(poly.original_ec);
+  poly.original_ec->ft_offset = 0;
 
-    uint32_t num_new_features = (uint32_t)pow(poly.sum_input_sparsity * 1.0f / poly.num_examples, poly.sched_exponent);
-    num_new_features = (num_new_features > poly.all->length()) ? (uint32_t)poly.all->length() : num_new_features;
-    sort_data_ensure_sz(poly, num_new_features);
+  uint32_t num_new_features = (uint32_t)pow(poly.sum_input_sparsity * 1.0f / poly.num_examples, poly.sched_exponent);
+  num_new_features = (num_new_features > poly.all->length()) ? (uint32_t)poly.all->length() : num_new_features;
+  sort_data_ensure_sz(poly, num_new_features);
 
-    sort_data *heap_end = poly.sd;
-    make_heap(poly.sd, heap_end, sort_data_compar_heap); //redundant
-    for (uint32_t i = 0; i != poly.all->length(); ++i) {
-      uint32_t wid = stride_shift(poly, i);
-      if (!parent_get(poly, wid) && wid != constant_feat_masked(poly)) {
-        float wval = (fabsf(poly.all->reg.weight_vector[wid])
-            * poly.all->reg.weight_vector[poly.all->normalized_idx + (wid)])
-          /*
-           * here's some depth penalization code.  It was found to not improve
-           * statistical performance, and meanwhile it is verified as giving
-           * a nontrivial computational hit, thus commented out.
-           *
-           * - poly.magic_argument
-           * sqrtf(min_depths_get(poly, stride_shift(poly, i)) * 1.0 / poly.num_examples)
-           */
-          ;
-        if (wval > tolerance) {
-          assert(heap_end >= poly.sd);
-          assert(heap_end <= poly.sd + num_new_features);
+  sort_data *heap_end = poly.sd;
+  make_heap(poly.sd, heap_end, sort_data_compar_heap); //redundant
+  for (uint32_t i = 0; i != poly.all->length(); ++i) {
+    uint32_t wid = stride_shift(poly, i);
+    if (!parent_get(poly, wid) && wid != constant_feat_masked(poly)) {
+      float wval = (fabsf(poly.all->reg.weight_vector[wid])
+                    * poly.all->reg.weight_vector[poly.all->normalized_idx + (wid)])
+                   /*
+                    * here's some depth penalization code.  It was found to not improve
+                    * statistical performance, and meanwhile it is verified as giving
+                    * a nontrivial computational hit, thus commented out.
+                    *
+                    * - poly.magic_argument
+                    * sqrtf(min_depths_get(poly, stride_shift(poly, i)) * 1.0 / poly.num_examples)
+                    */
+                   ;
+      if (wval > tolerance) {
+        assert(heap_end >= poly.sd);
+        assert(heap_end <= poly.sd + num_new_features);
 
-          if (heap_end - poly.sd == (int)num_new_features && poly.sd->wval < wval) {
-            pop_heap(poly.sd, heap_end, sort_data_compar_heap);
-            --heap_end;
-          }
+        if (heap_end - poly.sd == (int)num_new_features && poly.sd->wval < wval) {
+          pop_heap(poly.sd, heap_end, sort_data_compar_heap);
+          --heap_end;
+        }
 
-          assert(heap_end >= poly.sd);
-          assert(heap_end < poly.sd + poly.sd_len);
+        assert(heap_end >= poly.sd);
+        assert(heap_end < poly.sd + poly.sd_len);
 
-          if (heap_end - poly.sd < (int)num_new_features) {
-            heap_end->wval = wval;
-            heap_end->wid = wid;
-            ++heap_end;
-            push_heap(poly.sd, heap_end, sort_data_compar_heap);
-          }
+        if (heap_end - poly.sd < (int)num_new_features) {
+          heap_end->wval = wval;
+          heap_end->wid = wid;
+          ++heap_end;
+          push_heap(poly.sd, heap_end, sort_data_compar_heap);
         }
       }
     }
-    num_new_features = (uint32_t) (heap_end - poly.sd);
+  }
+  num_new_features = (uint32_t) (heap_end - poly.sd);
 
 #ifdef DEBUG
-    //eyeballing weights a pain if unsorted.
-    qsort(poly.sd, num_new_features, sizeof(sort_data), sort_data_compar);
+  //eyeballing weights a pain if unsorted.
+  qsort(poly.sd, num_new_features, sizeof(sort_data), sort_data_compar);
 #endif //DEBUG
 
-    for (uint32_t pos = 0; pos < num_new_features && pos < poly.sd_len; ++pos) {
-      assert(!parent_get(poly, poly.sd[pos].wid)
-          && poly.sd[pos].wval > tolerance
-          && poly.sd[pos].wid != constant_feat_masked(poly));
-      parent_toggle(poly, poly.sd[pos].wid);
+  for (uint32_t pos = 0; pos < num_new_features && pos < poly.sd_len; ++pos) {
+    assert(!parent_get(poly, poly.sd[pos].wid)
+           && poly.sd[pos].wval > tolerance
+           && poly.sd[pos].wid != constant_feat_masked(poly));
+    parent_toggle(poly, poly.sd[pos].wid);
 #ifdef DEBUG
-      cout
+    cout
         << "Adding feature " << pos << "/" << num_new_features
         << " || wid " << poly.sd[pos].wid
         << " || sort value " << poly.sd[pos].wval
         << endl;
 #endif //DEBUG
-    }
+  }
 
 #ifdef DEBUG
-    cout << "depths:";
-    for (uint32_t depth = 0; depth <= poly.max_depth && depth < sizeof(poly.depths) / sizeof(*poly.depths); ++depth)
-      cout << "  [" << depth << "] = " << poly.depths[depth];
-    cout << endl;
+  cout << "depths:";
+  for (uint32_t depth = 0; depth <= poly.max_depth && depth < sizeof(poly.depths) / sizeof(*poly.depths); ++depth)
+    cout << "  [" << depth << "] = " << poly.depths[depth];
+  cout << endl;
 
-    cout << "Sanity check after sort... " << flush;
-    sanity_check_state(poly);
-    cout << "done" << endl;
+  cout << "Sanity check after sort... " << flush;
+  sanity_check_state(poly);
+  cout << "done" << endl;
 #endif //DEBUG
 
-    //it's okay that these may have been initially unequal; synth_ec value irrelevant so far.
-    poly.original_ec->ft_offset = pop_ft_offset;
-    poly.synth_ec.ft_offset = pop_ft_offset;
+  //it's okay that these may have been initially unequal; synth_ec value irrelevant so far.
+  poly.original_ec->ft_offset = pop_ft_offset;
+  poly.synth_ec.ft_offset = pop_ft_offset;
+}
+
+void synthetic_reset(stagewise_poly &poly, example &ec)
+{
+  poly.synth_ec.l = ec.l;
+  poly.synth_ec.tag = ec.tag;
+  poly.synth_ec.example_counter = ec.example_counter;
+
+  /**
+   * Some comments on ft_offset.
+   *
+   * The plan is to do the feature mapping dfs with weight indices ignoring
+   * the ft_offset.  This is because ft_offset is then added at the end,
+   * guaranteeing local/strided access on synth_ec.  This might not matter
+   * too much in this implementation (where, e.g., --oaa runs one after the
+   * other, not interleaved), but who knows.
+   *
+   * (The other choice is to basically ignore adjusting for ft_offset when
+   * doing the traversal, which means synth_ec.ft_offset is 0 here...)
+   *
+   * Anyway, so here is how ft_offset matters:
+   *   - synthetic_create_rec must "normalize it out" of the fed weight value
+   *   - parent and min_depths set/get are adjusted for it.
+   *   - cycle set/get are not adjusted for it, since it doesn't matter for them.
+   *   - operations on the whole weight vector (sorting, save_load, all_reduce)
+   *     ignore ft_offset, just treat the thing as a flat vector.
+   **/
+  poly.synth_ec.ft_offset = ec.ft_offset;
+
+  poly.synth_ec.test_only = ec.test_only;
+  poly.synth_ec.end_pass = ec.end_pass;
+  poly.synth_ec.sorted = ec.sorted;
+  poly.synth_ec.in_use = ec.in_use;
+
+  poly.synth_ec.atomics[tree_atomics].erase();
+  poly.synth_ec.audit_features[tree_atomics].erase();
+  poly.synth_ec.num_features = 0;
+  poly.synth_ec.total_sum_feat_sq = 0;
+  poly.synth_ec.sum_feat_sq[tree_atomics] = 0;
+  poly.synth_ec.example_t = ec.example_t;
+
+  if (poly.synth_ec.indices.size()==0)
+    poly.synth_ec.indices.push_back(tree_atomics);
+}
+
+void synthetic_decycle(stagewise_poly &poly)
+{
+  for (feature *f = poly.synth_ec.atomics[tree_atomics].begin;
+       f != poly.synth_ec.atomics[tree_atomics].end; ++f) {
+    assert(cycle_get(poly, f->weight_index));
+    cycle_toggle(poly, f->weight_index);
   }
+}
 
-  void synthetic_reset(stagewise_poly &poly, example &ec)
-  {
-    poly.synth_ec.l = ec.l;
-    poly.synth_ec.tag = ec.tag;
-    poly.synth_ec.example_counter = ec.example_counter;
+void synthetic_create_rec(stagewise_poly &poly, float v, float &w)
+{
+  //Note: need to un_ft_shift since gd::foreach_feature bakes in the offset.
+  uint32_t wid_atomic = wid_mask(poly, un_ft_offset(poly, (uint32_t)((&w - poly.all->reg.weight_vector))));
+  uint32_t wid_cur = child_wid(poly, wid_atomic, poly.synth_rec_f.weight_index);
+  assert(wid_atomic % stride_shift(poly, 1) == 0);
 
-    /**
-     * Some comments on ft_offset.
-     *
-     * The plan is to do the feature mapping dfs with weight indices ignoring
-     * the ft_offset.  This is because ft_offset is then added at the end,
-     * guaranteeing local/strided access on synth_ec.  This might not matter
-     * too much in this implementation (where, e.g., --oaa runs one after the
-     * other, not interleaved), but who knows.
-     *
-     * (The other choice is to basically ignore adjusting for ft_offset when
-     * doing the traversal, which means synth_ec.ft_offset is 0 here...)
-     *
-     * Anyway, so here is how ft_offset matters:
-     *   - synthetic_create_rec must "normalize it out" of the fed weight value
-     *   - parent and min_depths set/get are adjusted for it.
-     *   - cycle set/get are not adjusted for it, since it doesn't matter for them.
-     *   - operations on the whole weight vector (sorting, save_load, all_reduce)
-     *     ignore ft_offset, just treat the thing as a flat vector.
-     **/
-    poly.synth_ec.ft_offset = ec.ft_offset;
-
-    poly.synth_ec.test_only = ec.test_only;
-    poly.synth_ec.end_pass = ec.end_pass;
-    poly.synth_ec.sorted = ec.sorted;
-    poly.synth_ec.in_use = ec.in_use;
-
-    poly.synth_ec.atomics[tree_atomics].erase();
-    poly.synth_ec.audit_features[tree_atomics].erase();
-    poly.synth_ec.num_features = 0;
-    poly.synth_ec.total_sum_feat_sq = 0;
-    poly.synth_ec.sum_feat_sq[tree_atomics] = 0;
-    poly.synth_ec.example_t = ec.example_t;
-
-    if (poly.synth_ec.indices.size()==0)
-      poly.synth_ec.indices.push_back(tree_atomics);
-  }
-
-  void synthetic_decycle(stagewise_poly &poly)
-  {
-    for (feature *f = poly.synth_ec.atomics[tree_atomics].begin;
-        f != poly.synth_ec.atomics[tree_atomics].end; ++f) {
-      assert(cycle_get(poly, f->weight_index));
-      cycle_toggle(poly, f->weight_index);
-    }
-  }
-
-  void synthetic_create_rec(stagewise_poly &poly, float v, float &w)
-  {
-    //Note: need to un_ft_shift since gd::foreach_feature bakes in the offset.
-    uint32_t wid_atomic = wid_mask(poly, un_ft_offset(poly, (uint32_t)((&w - poly.all->reg.weight_vector))));
-    uint32_t wid_cur = child_wid(poly, wid_atomic, poly.synth_rec_f.weight_index);
-    assert(wid_atomic % stride_shift(poly, 1) == 0);
-
-    //Note: only mutate learner state when in training mode.  This is because
-    //the average test errors across multiple data sets should be equal to
-    //the test error on the merged dataset (which is violated if the code
-    //below is run at training time).
-    if (poly.cur_depth < min_depths_get(poly, wid_cur) && poly.training) {
-      if (parent_get(poly, wid_cur)) {
+  //Note: only mutate learner state when in training mode.  This is because
+  //the average test errors across multiple data sets should be equal to
+  //the test error on the merged dataset (which is violated if the code
+  //below is run at training time).
+  if (poly.cur_depth < min_depths_get(poly, wid_cur) && poly.training) {
+    if (parent_get(poly, wid_cur)) {
 #ifdef DEBUG
-        cout
+      cout
           << "FOUND A TRANSPLANT!!! moving [" << wid_cur
           << "] from depth " << (uint32_t) min_depths_get(poly, wid_cur)
           << " to depth " << poly.cur_depth << endl;
 #endif //DEBUG
-        //XXX arguably, should also fear transplants that occured with
-        //a different ft_offset ; e.g., need to look out for cross-reduction
-        //collisions.  Have not played with this issue yet...
-        parent_toggle(poly, wid_cur);
-      }
-      min_depths_set(poly, wid_cur, poly.cur_depth);
+      //XXX arguably, should also fear transplants that occured with
+      //a different ft_offset ; e.g., need to look out for cross-reduction
+      //collisions.  Have not played with this issue yet...
+      parent_toggle(poly, wid_cur);
     }
-
-    if ( ! cycle_get(poly, wid_cur)
-        && ((poly.cur_depth > default_depth ? default_depth : poly.cur_depth) == min_depths_get(poly, wid_cur))
-       ) {
-      cycle_toggle(poly, wid_cur);
-
-#ifdef DEBUG
-      ++poly.depths[poly.cur_depth];
-#endif //DEBUG
-
-      feature new_f = { v * poly.synth_rec_f.x, wid_cur };
-      poly.synth_ec.atomics[tree_atomics].push_back(new_f);
-      poly.synth_ec.num_features++;
-      poly.synth_ec.sum_feat_sq[tree_atomics] += new_f.x * new_f.x;
-
-      if (parent_get(poly, new_f.weight_index)) {
-        feature parent_f = poly.synth_rec_f;
-        poly.synth_rec_f = new_f;
-        ++poly.cur_depth;
-#ifdef DEBUG
-        poly.max_depth = (poly.max_depth > poly.cur_depth) ? poly.max_depth : poly.cur_depth;
-#endif //DEBUG
-        GD::foreach_feature<stagewise_poly, synthetic_create_rec>(*(poly.all), *(poly.original_ec), poly);
-        --poly.cur_depth;
-        poly.synth_rec_f = parent_f;
-      }
-    }
+    min_depths_set(poly, wid_cur, poly.cur_depth);
   }
 
-  void synthetic_create(stagewise_poly &poly, example &ec, bool training)
-  {
-    synthetic_reset(poly, ec);
+  if ( ! cycle_get(poly, wid_cur)
+       && ((poly.cur_depth > default_depth ? default_depth : poly.cur_depth) == min_depths_get(poly, wid_cur))
+     ) {
+    cycle_toggle(poly, wid_cur);
 
-    poly.cur_depth = 0;
+#ifdef DEBUG
+    ++poly.depths[poly.cur_depth];
+#endif //DEBUG
 
-    poly.synth_rec_f.x = 1.0;
-    poly.synth_rec_f.weight_index = constant_feat_masked(poly); //note: not ft_offset'd
-    poly.training = training;
-    /*
-     * Another choice is to mark the constant feature as the single initial
-     * parent, and recurse just on that feature (which arguably correctly interprets poly.cur_depth).
-     * Problem with this is if there is a collision with the root...
-     */
-    GD::foreach_feature<stagewise_poly, synthetic_create_rec>(*poly.all, *poly.original_ec, poly);
-    synthetic_decycle(poly);
-    poly.synth_ec.total_sum_feat_sq = poly.synth_ec.sum_feat_sq[tree_atomics];
+    feature new_f = { v * poly.synth_rec_f.x, wid_cur };
+    poly.synth_ec.atomics[tree_atomics].push_back(new_f);
+    poly.synth_ec.num_features++;
+    poly.synth_ec.sum_feat_sq[tree_atomics] += new_f.x * new_f.x;
 
-    if (training) {
-      poly.sum_sparsity += poly.synth_ec.num_features;
-      poly.sum_input_sparsity += ec.num_features;
-      poly.num_examples += 1;
+    if (parent_get(poly, new_f.weight_index)) {
+      feature parent_f = poly.synth_rec_f;
+      poly.synth_rec_f = new_f;
+      ++poly.cur_depth;
+#ifdef DEBUG
+      poly.max_depth = (poly.max_depth > poly.cur_depth) ? poly.max_depth : poly.cur_depth;
+#endif //DEBUG
+      GD::foreach_feature<stagewise_poly, synthetic_create_rec>(*(poly.all), *(poly.original_ec), poly);
+      --poly.cur_depth;
+      poly.synth_rec_f = parent_f;
     }
   }
+}
 
-  void predict(stagewise_poly &poly, base_learner &base, example &ec)
-  {
-    poly.original_ec = &ec;
-    synthetic_create(poly, ec, false);
-    base.predict(poly.synth_ec);
+void synthetic_create(stagewise_poly &poly, example &ec, bool training)
+{
+  synthetic_reset(poly, ec);
+
+  poly.cur_depth = 0;
+
+  poly.synth_rec_f.x = 1.0;
+  poly.synth_rec_f.weight_index = constant_feat_masked(poly); //note: not ft_offset'd
+  poly.training = training;
+  /*
+   * Another choice is to mark the constant feature as the single initial
+   * parent, and recurse just on that feature (which arguably correctly interprets poly.cur_depth).
+   * Problem with this is if there is a collision with the root...
+   */
+  GD::foreach_feature<stagewise_poly, synthetic_create_rec>(*poly.all, *poly.original_ec, poly);
+  synthetic_decycle(poly);
+  poly.synth_ec.total_sum_feat_sq = poly.synth_ec.sum_feat_sq[tree_atomics];
+
+  if (training) {
+    poly.sum_sparsity += poly.synth_ec.num_features;
+    poly.sum_input_sparsity += ec.num_features;
+    poly.num_examples += 1;
+  }
+}
+
+void predict(stagewise_poly &poly, base_learner &base, example &ec)
+{
+  poly.original_ec = &ec;
+  synthetic_create(poly, ec, false);
+  base.predict(poly.synth_ec);
+  ec.partial_prediction = poly.synth_ec.partial_prediction;
+  ec.updated_prediction = poly.synth_ec.updated_prediction;
+  ec.pred.scalar = poly.synth_ec.pred.scalar;
+}
+
+void learn(stagewise_poly &poly, base_learner &base, example &ec)
+{
+  bool training = poly.all->training && ec.l.simple.label != FLT_MAX;
+  poly.original_ec = &ec;
+
+  if (training) {
+    if(poly.update_support) {
+      sort_data_update_support(poly);
+      poly.update_support = false;
+    }
+
+    synthetic_create(poly, ec, training);
+    base.learn(poly.synth_ec);
     ec.partial_prediction = poly.synth_ec.partial_prediction;
     ec.updated_prediction = poly.synth_ec.updated_prediction;
     ec.pred.scalar = poly.synth_ec.pred.scalar;
+
+    if (ec.example_counter
+        //following line is to avoid repeats when multiple reductions on same example.
+        //XXX ideally, would get all "copies" of an example before scheduling the support
+        //update, but how do we know?
+        && poly.last_example_counter != ec.example_counter
+        && poly.batch_sz
+        && ( (poly.batch_sz_double && !(ec.example_counter % poly.next_batch_sz))
+             || (!poly.batch_sz_double && !(ec.example_counter % poly.batch_sz)))) {
+      poly.next_batch_sz *= 2; //no effect when !poly.batch_sz_double
+      poly.update_support = (poly.all->span_server == "" || poly.numpasses == 1);
+    }
+    poly.last_example_counter = ec.example_counter;
+  } else
+    predict(poly, base, ec);
+}
+
+
+void reduce_min(uint8_t &v1,const uint8_t &v2)
+{
+  if(v1 == default_depth)
+    v1 = v2;
+  else if(v2 != default_depth)
+    v1 = (v1 <= v2) ? v1 : v2;
+}
+
+void reduce_min_max(uint8_t &v1,const uint8_t &v2)
+{
+  bool parent_or_depth;
+  if (v1 & indicator_bit)
+    parent_or_depth = true;
+  else
+    parent_or_depth = false;
+  bool p_or_d2;
+  if (v2 & indicator_bit)
+    p_or_d2 = true;
+  else
+    p_or_d2 = false;
+  if(parent_or_depth != p_or_d2) {
+#ifdef DEBUG
+    cout << "Reducing parent with depth!!!!!";
+#endif //DEBUG
+    return;
   }
 
-  void learn(stagewise_poly &poly, base_learner &base, example &ec)
-  {
-    bool training = poly.all->training && ec.l.simple.label != FLT_MAX;
-    poly.original_ec = &ec;
-
-    if (training) {
-      if(poly.update_support) {
-        sort_data_update_support(poly);
-        poly.update_support = false;
-      }
-
-      synthetic_create(poly, ec, training);
-      base.learn(poly.synth_ec);
-      ec.partial_prediction = poly.synth_ec.partial_prediction;
-      ec.updated_prediction = poly.synth_ec.updated_prediction;
-      ec.pred.scalar = poly.synth_ec.pred.scalar;
-
-      if (ec.example_counter
-          //following line is to avoid repeats when multiple reductions on same example.
-          //XXX ideally, would get all "copies" of an example before scheduling the support
-          //update, but how do we know?
-          && poly.last_example_counter != ec.example_counter
-          && poly.batch_sz
-          && ( (poly.batch_sz_double && !(ec.example_counter % poly.next_batch_sz))
-            || (!poly.batch_sz_double && !(ec.example_counter % poly.batch_sz)))) {
-        poly.next_batch_sz *= 2; //no effect when !poly.batch_sz_double
-        poly.update_support = (poly.all->span_server == "" || poly.numpasses == 1);
-      }
-      poly.last_example_counter = ec.example_counter;
-    } else
-      predict(poly, base, ec);
-  }
-
-
-  void reduce_min(uint8_t &v1,const uint8_t &v2)
-  {
+  if(parent_or_depth)
+    v1 = (v1 >= v2) ? v1 : v2;
+  else {
     if(v1 == default_depth)
       v1 = v2;
     else if(v2 != default_depth)
       v1 = (v1 <= v2) ? v1 : v2;
   }
+}
 
-  void reduce_min_max(uint8_t &v1,const uint8_t &v2)
-  {
-	  bool parent_or_depth;
-	  if (v1 & indicator_bit)
-		  parent_or_depth = true;
-	  else
-		  parent_or_depth = false;
-	  bool p_or_d2;
-	  if (v2 & indicator_bit)
-		  p_or_d2 = true;
-	  else
-		  p_or_d2 = false;
-    if(parent_or_depth != p_or_d2) {
-#ifdef DEBUG
-      cout << "Reducing parent with depth!!!!!";
-#endif //DEBUG
-      return;
-    }
+void end_pass(stagewise_poly &poly)
+{
+  if (!!poly.batch_sz || (poly.all->span_server != "" && poly.numpasses > 1))
+    return;
 
-    if(parent_or_depth)
-      v1 = (v1 >= v2) ? v1 : v2;
-    else {
-      if(v1 == default_depth)
-        v1 = v2;
-      else if(v2 != default_depth)
-        v1 = (v1 <= v2) ? v1 : v2;
-    }
-  }
-
-  void end_pass(stagewise_poly &poly)
-  {
-    if (!!poly.batch_sz || (poly.all->span_server != "" && poly.numpasses > 1))
-      return;
-
-    uint64_t sum_sparsity_inc = poly.sum_sparsity - poly.sum_sparsity_sync;
-    uint64_t sum_input_sparsity_inc = poly.sum_input_sparsity - poly.sum_input_sparsity_sync;
-    uint64_t num_examples_inc = poly.num_examples - poly.num_examples_sync;
+  uint64_t sum_sparsity_inc = poly.sum_sparsity - poly.sum_sparsity_sync;
+  uint64_t sum_input_sparsity_inc = poly.sum_input_sparsity - poly.sum_input_sparsity_sync;
+  uint64_t num_examples_inc = poly.num_examples - poly.num_examples_sync;
 
 #ifdef DEBUG
-    cout << "Sanity before allreduce\n";
-    sanity_check_state(poly);
+  cout << "Sanity before allreduce\n";
+  sanity_check_state(poly);
 #endif //DEBUG
 
-    vw &all = *poly.all;
-    if (all.span_server != "") {
-      /*
-       * The following is inconsistent with the transplant code in
-       * synthetic_create_rec(), which clears parent bits on depth mismatches.
-       * But it's unclear what the right behavior is in general for either
-       * case...
-       */
-      all_reduce<uint8_t, reduce_min_max>(poly.depthsbits, depthsbits_sizeof(poly),
-          all.span_server, all.unique_id, all.total, all.node, all.socks);
+  vw &all = *poly.all;
+  if (all.span_server != "") {
+    /*
+     * The following is inconsistent with the transplant code in
+     * synthetic_create_rec(), which clears parent bits on depth mismatches.
+     * But it's unclear what the right behavior is in general for either
+     * case...
+     */
+    all_reduce<uint8_t, reduce_min_max>(poly.depthsbits, depthsbits_sizeof(poly),
+                                        all.span_server, all.unique_id, all.total, all.node, all.socks);
 
-      sum_input_sparsity_inc = (uint64_t)accumulate_scalar(all, all.span_server, (float)sum_input_sparsity_inc);
-      sum_sparsity_inc = (uint64_t)accumulate_scalar(all, all.span_server, (float)sum_sparsity_inc);
-      num_examples_inc = (uint64_t)accumulate_scalar(all, all.span_server, (float)num_examples_inc);
-    }
+    sum_input_sparsity_inc = (uint64_t)accumulate_scalar(all, all.span_server, (float)sum_input_sparsity_inc);
+    sum_sparsity_inc = (uint64_t)accumulate_scalar(all, all.span_server, (float)sum_sparsity_inc);
+    num_examples_inc = (uint64_t)accumulate_scalar(all, all.span_server, (float)num_examples_inc);
+  }
 
-    poly.sum_input_sparsity_sync = poly.sum_input_sparsity_sync + sum_input_sparsity_inc;
-    poly.sum_input_sparsity = poly.sum_input_sparsity_sync;
-    poly.sum_sparsity_sync = poly.sum_sparsity_sync + sum_sparsity_inc;
-    poly.sum_sparsity = poly.sum_sparsity_sync;
-    poly.num_examples_sync = poly.num_examples_sync + num_examples_inc;
-    poly.num_examples = poly.num_examples_sync;
+  poly.sum_input_sparsity_sync = poly.sum_input_sparsity_sync + sum_input_sparsity_inc;
+  poly.sum_input_sparsity = poly.sum_input_sparsity_sync;
+  poly.sum_sparsity_sync = poly.sum_sparsity_sync + sum_sparsity_inc;
+  poly.sum_sparsity = poly.sum_sparsity_sync;
+  poly.num_examples_sync = poly.num_examples_sync + num_examples_inc;
+  poly.num_examples = poly.num_examples_sync;
 
 #ifdef DEBUG
-    cout << "Sanity after allreduce\n";
-    sanity_check_state(poly);
+  cout << "Sanity after allreduce\n";
+  sanity_check_state(poly);
 #endif //DEBUG
 
-    if (poly.numpasses != poly.all->numpasses) {
-      poly.update_support = true;
-      poly.numpasses++;
-    }
+  if (poly.numpasses != poly.all->numpasses) {
+    poly.update_support = true;
+    poly.numpasses++;
   }
+}
 
-  void finish_example(vw &all, stagewise_poly &poly, example &ec)
-  {
-    size_t temp_num_features = ec.num_features;
-    ec.num_features = poly.synth_ec.num_features;
-    output_and_account_example(all, ec);
-    ec.num_features = temp_num_features;
-    VW::finish_example(all, &ec);
-  }
+void finish_example(vw &all, stagewise_poly &poly, example &ec)
+{
+  size_t temp_num_features = ec.num_features;
+  ec.num_features = poly.synth_ec.num_features;
+  output_and_account_example(all, ec);
+  ec.num_features = temp_num_features;
+  VW::finish_example(all, &ec);
+}
 
-  void finish(stagewise_poly &poly)
-  {
+void finish(stagewise_poly &poly)
+{
 #ifdef DEBUG
-    cout << "total feature number (after poly expansion!) = " << poly.sum_sparsity << endl;
+  cout << "total feature number (after poly expansion!) = " << poly.sum_sparsity << endl;
 #endif //DEBUG
 
-    poly.synth_ec.atomics[tree_atomics].delete_v();
-    sort_data_destroy(poly);
-    depthsbits_destroy(poly);
-  }
+  poly.synth_ec.atomics[tree_atomics].delete_v();
+  sort_data_destroy(poly);
+  depthsbits_destroy(poly);
+}
 
 
-  void save_load(stagewise_poly &poly, io_buf &model_file, bool read, bool text)
-  {
-    if (model_file.files.size() > 0)
-      bin_text_read_write_fixed(model_file, (char *) poly.depthsbits, depthsbits_sizeof(poly), "", read, "", 0, text);
+void save_load(stagewise_poly &poly, io_buf &model_file, bool read, bool text)
+{
+  if (model_file.files.size() > 0)
+    bin_text_read_write_fixed(model_file, (char *) poly.depthsbits, depthsbits_sizeof(poly), "", read, "", 0, text);
 
-    //unfortunately, following can't go here since save_load called before gd::save_load and thus
-    //weight vector state uninitialiazed.
-    //#ifdef DEBUG
-    //      cout << "Sanity check after save_load... " << flush;
-    //      sanity_check_state(poly);
-    //      cout << "done" << endl;
-    //#endif //DEBUG
-  }
+  //unfortunately, following can't go here since save_load called before gd::save_load and thus
+  //weight vector state uninitialiazed.
+  //#ifdef DEBUG
+  //      cout << "Sanity check after save_load... " << flush;
+  //      sanity_check_state(poly);
+  //      cout << "done" << endl;
+  //#endif //DEBUG
+}
 
-  base_learner *stagewise_poly_setup(vw &all)
-  {
-    if (missing_option(all, true, "stage_poly", "use stagewise polynomial feature learning"))
-      return nullptr;
-    
-    new_options(all, "Stagewise poly options")
-      ("sched_exponent", po::value<float>(), "exponent controlling quantity of included features")
-      ("batch_sz", po::value<uint32_t>(), "multiplier on batch size before including more features")
-      ("batch_sz_no_doubling", "batch_sz does not double")
+base_learner *stagewise_poly_setup(vw &all)
+{
+  if (missing_option(all, true, "stage_poly", "use stagewise polynomial feature learning"))
+    return nullptr;
+
+  new_options(all, "Stagewise poly options")
+  ("sched_exponent", po::value<float>(), "exponent controlling quantity of included features")
+  ("batch_sz", po::value<uint32_t>(), "multiplier on batch size before including more features")
+  ("batch_sz_no_doubling", "batch_sz does not double")
 #ifdef MAGIC_ARGUMENT
-      ("magic_argument", po::value<float>(), "magical feature flag")
+  ("magic_argument", po::value<float>(), "magical feature flag")
 #endif //MAGIC_ARGUMENT
-      ;
-    add_options(all);
+  ;
+  add_options(all);
 
-    po::variables_map &vm = all.vm;
-    stagewise_poly& poly = calloc_or_die<stagewise_poly>();
-    poly.all = &all;
-    depthsbits_create(poly);
-    sort_data_create(poly);
+  po::variables_map &vm = all.vm;
+  stagewise_poly& poly = calloc_or_die<stagewise_poly>();
+  poly.all = &all;
+  depthsbits_create(poly);
+  sort_data_create(poly);
 
-    poly.sched_exponent = vm.count("sched_exponent") ? vm["sched_exponent"].as<float>() : 1.f;
-    poly.batch_sz = vm.count("batch_sz") ? vm["batch_sz"].as<uint32_t>() : 1000;
-    poly.batch_sz_double = vm.count("batch_sz_no_doubling") ? false : true;
+  poly.sched_exponent = vm.count("sched_exponent") ? vm["sched_exponent"].as<float>() : 1.f;
+  poly.batch_sz = vm.count("batch_sz") ? vm["batch_sz"].as<uint32_t>() : 1000;
+  poly.batch_sz_double = vm.count("batch_sz_no_doubling") ? false : true;
 #ifdef MAGIC_ARGUMENT
-    poly.magic_argument = vm.count("magic_argument") ? vm["magic_argument"].as<float>() : 0.;
+  poly.magic_argument = vm.count("magic_argument") ? vm["magic_argument"].as<float>() : 0.;
 #endif //MAGIC_ARGUMENT
 
-    poly.sum_sparsity = 0;
-    poly.sum_input_sparsity = 0;
-    poly.num_examples = 0;
-    poly.sum_sparsity_sync = 0;
-    poly.sum_input_sparsity_sync = 0;
-    poly.num_examples_sync = 0;
-    poly.last_example_counter = -1;
-    poly.numpasses = 1;
-    poly.update_support = false;
-    poly.original_ec = nullptr;
-    poly.next_batch_sz = poly.batch_sz;
+  poly.sum_sparsity = 0;
+  poly.sum_input_sparsity = 0;
+  poly.num_examples = 0;
+  poly.sum_sparsity_sync = 0;
+  poly.sum_input_sparsity_sync = 0;
+  poly.num_examples_sync = 0;
+  poly.last_example_counter = -1;
+  poly.numpasses = 1;
+  poly.update_support = false;
+  poly.original_ec = nullptr;
+  poly.next_batch_sz = poly.batch_sz;
 
-    learner<stagewise_poly>& l = init_learner(&poly, setup_base(all), learn, predict);
-    l.set_finish(finish);
-    l.set_save_load(save_load);
-    l.set_finish_example(finish_example);
-    l.set_end_pass(end_pass);
+  learner<stagewise_poly>& l = init_learner(&poly, setup_base(all), learn, predict);
+  l.set_finish(finish);
+  l.set_save_load(save_load);
+  l.set_finish_example(finish_example);
+  l.set_end_pass(end_pass);
 
-    return make_base(l);
-  }
+  return make_base(l);
+}

--- a/vowpalwabbit/svrg.cc
+++ b/vowpalwabbit/svrg.cc
@@ -19,8 +19,8 @@ struct svrg
   int stage_size;               // Number of data passes per stage.
   int prev_pass;                // To detect that we're in a new pass.
   int stable_grad_count;        // Number of data points that
-                                // contributed to the stable gradient
-                                // calculation.
+  // contributed to the stable gradient
+  // calculation.
 
   // The VW process' global state.
   vw* all;
@@ -59,7 +59,7 @@ void predict(svrg& s, base_learner&, example& ec)
 float gradient_scalar(const svrg& s, const example& ec, float pred)
 {
   return s.all->loss->first_derivative(s.all->sd, pred, ec.l.simple.label)
-    * ec.l.simple.weight;
+         * ec.l.simple.weight;
 }
 
 // -- Updates, taking inner steps vs. accumulating a full gradient --
@@ -162,7 +162,7 @@ base_learner* svrg_setup(vw& all)
     return NULL;
   }
   new_options(all, "SVRG options")
-    ("stage_size", po::value<int>()->default_value(1), "Number of passes per SVRG stage");
+  ("stage_size", po::value<int>()->default_value(1), "Number of passes per SVRG stage");
   add_options(all);
 
   svrg& s = calloc_or_die<svrg>();

--- a/vowpalwabbit/topk.cc
+++ b/vowpalwabbit/topk.cc
@@ -15,7 +15,9 @@ typedef pair<float, v_array<char> > scored_example;
 struct compare_scored_examples
 {
   bool operator()(scored_example const& a, scored_example const& b) const
-  { return a.first > b.first; }
+  {
+    return a.first > b.first;
+  }
 };
 
 struct topk {
@@ -26,37 +28,37 @@ struct topk {
 void print_result(int f, priority_queue<scored_example, vector<scored_example>, compare_scored_examples > &pr_queue)
 {
   if (f >= 0)
+  {
+    char temp[30];
+    std::stringstream ss;
+    scored_example tmp_example;
+    while(!pr_queue.empty())
     {
-      char temp[30];
-      std::stringstream ss;
-      scored_example tmp_example;
-      while(!pr_queue.empty())
-	{
-	  tmp_example = pr_queue.top(); 
-	  pr_queue.pop();       
-	  sprintf(temp, "%f", tmp_example.first);
-	  ss << temp;
-	  ss << ' ';
-	  print_tag(ss, tmp_example.second);
-	  ss << ' ';
-	  ss << '\n';      
-	}
-      ss << '\n';        
-      ssize_t len = ss.str().size();
+      tmp_example = pr_queue.top();
+      pr_queue.pop();
+      sprintf(temp, "%f", tmp_example.first);
+      ss << temp;
+      ss << ' ';
+      print_tag(ss, tmp_example.second);
+      ss << ' ';
+      ss << '\n';
+    }
+    ss << '\n';
+    ssize_t len = ss.str().size();
 #ifdef _WIN32
-      ssize_t t = _write(f, ss.str().c_str(), (unsigned int)len);
+    ssize_t t = _write(f, ss.str().c_str(), (unsigned int)len);
 #else
-      ssize_t t = write(f, ss.str().c_str(), (unsigned int)len);
+    ssize_t t = write(f, ss.str().c_str(), (unsigned int)len);
 #endif
-      if (t != len)
-        cerr << "write error: " << strerror(errno) << endl;
-    }    
+    if (t != len)
+      cerr << "write error: " << strerror(errno) << endl;
+  }
 }
 
 void output_example(vw& all, topk& d, example& ec)
 {
   label_data& ld = ec.l.simple;
-  
+
   if (ld.label != FLT_MAX)
     all.sd->weighted_labels += ld.label * ld.weight;
   all.sd->weighted_examples += ld.weight;
@@ -64,11 +66,11 @@ void output_example(vw& all, topk& d, example& ec)
   all.sd->sum_loss_since_last_dump += ec.loss;
   all.sd->total_features += ec.num_features;
   all.sd->example_number++;
-  
+
   if (example_is_newline(ec))
     for (int* sink = all.final_prediction_sink.begin; sink != all.final_prediction_sink.end; sink++)
       print_result(*sink, d.pr_queue);
-  
+
   print_update(all, ec);
 }
 
@@ -76,20 +78,20 @@ template <bool is_learn>
 void predict_or_learn(topk& d, LEARNER::base_learner& base, example& ec)
 {
   if (example_is_newline(ec)) return;//do not predict newline
-  
+
   if (is_learn)
     base.learn(ec);
   else
     base.predict(ec);
-  
-  if(d.pr_queue.size() < d.B)      
+
+  if(d.pr_queue.size() < d.B)
     d.pr_queue.push(make_pair(ec.pred.scalar, ec.tag));
-  
+
   else if(d.pr_queue.top().first < ec.pred.scalar)
-    {
-      d.pr_queue.pop();
-      d.pr_queue.push(make_pair(ec.pred.scalar, ec.tag));
-    }
+  {
+    d.pr_queue.pop();
+    d.pr_queue.push(make_pair(ec.pred.scalar, ec.tag));
+  }
 }
 
 void finish_example(vw& all, topk& d, example& ec)
@@ -102,13 +104,13 @@ LEARNER::base_learner* topk_setup(vw& all)
 {
   if (missing_option<size_t, false>(all, "top", "top k recommendation"))
     return nullptr;
-  
+
   topk& data = calloc_or_die<topk>();
   data.B = (uint32_t)all.vm["top"].as<size_t>();
-  
-  LEARNER::learner<topk>& l = init_learner(&data, setup_base(all), predict_or_learn<true>, 
-					   predict_or_learn<false>);
+
+  LEARNER::learner<topk>& l = init_learner(&data, setup_base(all), predict_or_learn<true>,
+                              predict_or_learn<false>);
   l.set_finish_example(finish_example);
-  
+
   return make_base(l);
 }

--- a/vowpalwabbit/unique_sort.cc
+++ b/vowpalwabbit/unique_sort.cc
@@ -6,7 +6,9 @@ license as described in the file LICENSE.
 #include "example.h"
 
 int order_features(const void* first, const void* second)
-{ return ((feature*)first)->weight_index - ((feature*)second)->weight_index;}
+{
+  return ((feature*)first)->weight_index - ((feature*)second)->weight_index;
+}
 
 int order_audit_features(const void* first, const void* second)
 {
@@ -19,16 +21,16 @@ void unique_features(v_array<feature>& features, int max=-1)
     return;
   feature* last = features.begin;
   if (max < 0)
-    {
-      for (feature* current = features.begin+1; current != features.end; current++)
-	if (current->weight_index != last->weight_index) 
-	  *(++last) = *current;
-    }
+  {
+    for (feature* current = features.begin+1; current != features.end; current++)
+      if (current->weight_index != last->weight_index)
+        *(++last) = *current;
+  }
   else
     for (feature* current = features.begin+1; current != features.end && last+1 < features.begin+max; current++)
-      if (current->weight_index != last->weight_index) 
-	*(++last) = *current;
-  
+      if (current->weight_index != last->weight_index)
+        *(++last) = *current;
+
   features.end = ++last;
 }
 
@@ -38,44 +40,44 @@ void unique_audit_features(v_array<audit_data>& features, int max = -1)
     return;
   audit_data* last = features.begin;
   if (max < 0)
-    {
-      for (audit_data* current = features.begin+1; 
-	   current != features.end; current++)
-	if (current->weight_index != last->weight_index) 
-	  *(++last) = *current;
-    }
+  {
+    for (audit_data* current = features.begin+1;
+         current != features.end; current++)
+      if (current->weight_index != last->weight_index)
+        *(++last) = *current;
+  }
   else
-    for (audit_data* current = features.begin+1; 
-	 current != features.end && last+1 < features.begin+max; current++)
-      if (current->weight_index != last->weight_index) 
-	*(++last) = *current;
-    
+    for (audit_data* current = features.begin+1;
+         current != features.end && last+1 < features.begin+max; current++)
+      if (current->weight_index != last->weight_index)
+        *(++last) = *current;
+
   features.end = ++last;
 }
 
 void unique_sort_features(bool audit, uint32_t parse_mask, example* ae)
 {
   for (unsigned char* b = ae->indices.begin; b != ae->indices.end; b++)
-    {
-      v_array<feature> features = ae->atomics[*b];
-      
-      for (size_t i = 0; i < features.size(); i++)
-	features[i].weight_index &= parse_mask;
-      qsort(features.begin, features.size(), sizeof(feature), 
-	    order_features);
-      unique_features(ae->atomics[*b]);
-      
-      if (audit)
-	{
-	  v_array<audit_data> afeatures = ae->audit_features[*b];
+  {
+    v_array<feature> features = ae->atomics[*b];
 
-	  for (size_t i = 0; i < ae->atomics[*b].size(); i++)
-	    afeatures[i].weight_index &= parse_mask;
-	  
-	  qsort(afeatures.begin, afeatures.size(), sizeof(audit_data), 
-		order_audit_features);
-	  unique_audit_features(afeatures);
-	}
+    for (size_t i = 0; i < features.size(); i++)
+      features[i].weight_index &= parse_mask;
+    qsort(features.begin, features.size(), sizeof(feature),
+          order_features);
+    unique_features(ae->atomics[*b]);
+
+    if (audit)
+    {
+      v_array<audit_data> afeatures = ae->audit_features[*b];
+
+      for (size_t i = 0; i < ae->atomics[*b].size(); i++)
+        afeatures[i].weight_index &= parse_mask;
+
+      qsort(afeatures.begin, afeatures.size(), sizeof(audit_data),
+            order_audit_features);
+      unique_audit_features(afeatures);
     }
+  }
   ae->sorted=true;
 }

--- a/vowpalwabbit/v_array.h
+++ b/vowpalwabbit/v_array.h
@@ -12,7 +12,7 @@ license as described in the file LICENSE.
 #include <stdint.h>
 
 #ifdef _WIN32
-#define __INLINE 
+#define __INLINE
 #else
 #define __INLINE inline
 #endif
@@ -22,50 +22,64 @@ license as described in the file LICENSE.
 const size_t erase_point = ~ ((1 << 10) -1);
 
 template<class T> struct v_array {
- public:
+public:
   T* begin;
   T* end;
   T* end_array;
   size_t erase_count;
 
-  T last() { return *(end-1);}
-  T pop() { return *(--end);}
-  bool empty() { return begin == end;}
-  void decr() { end--;}
-  void incr() 
-  {
-	  if (end == end_array)
-		  resize(2 * (end_array - begin) + 3);
-	  end++; 
+  T last() {
+    return *(end-1);
   }
-  T& operator[](size_t i) { return begin[i]; }
-  T& get(size_t i) { return begin[i]; }
-  inline size_t size(){return end-begin;}
+  T pop() {
+    return *(--end);
+  }
+  bool empty() {
+    return begin == end;
+  }
+  void decr() {
+    end--;
+  }
+  void incr()
+  {
+    if (end == end_array)
+      resize(2 * (end_array - begin) + 3);
+    end++;
+  }
+  T& operator[](size_t i) {
+    return begin[i];
+  }
+  T& get(size_t i) {
+    return begin[i];
+  }
+  inline size_t size() {
+    return end-begin;
+  }
   void resize(size_t length, bool zero_everything=false)
+  {
+    if ((size_t)(end_array-begin) != length)
     {
-      if ((size_t)(end_array-begin) != length)
-	{
-	  size_t old_len = end-begin;
-	  T* temp = (T *)realloc(begin, sizeof(T) * length);
-	  if ((temp == nullptr) && ((sizeof(T)*length) > 0))
-	    {
-	      THROW("realloc of " << length << " failed in resize().  out of memory?"); 
-	    }
-	  else
-	    begin = temp;
-          if (zero_everything && (old_len < length))
-            memset(begin+old_len, 0, (length-old_len)*sizeof(T));
-	  end = begin+old_len;
-	  end_array = begin + length;
-	}
-    }
-
-  void erase() 
-  { if (++erase_count & erase_point)
+      size_t old_len = end-begin;
+      T* temp = (T *)realloc(begin, sizeof(T) * length);
+      if ((temp == nullptr) && ((sizeof(T)*length) > 0))
       {
-	resize(end-begin);
-	erase_count = 0;
+        THROW("realloc of " << length << " failed in resize().  out of memory?");
       }
+      else
+        begin = temp;
+      if (zero_everything && (old_len < length))
+        memset(begin+old_len, 0, (length-old_len)*sizeof(T));
+      end = begin+old_len;
+      end_array = begin + length;
+    }
+  }
+
+  void erase()
+  { if (++erase_count & erase_point)
+    {
+      resize(end-begin);
+      erase_count = 0;
+    }
     end = begin;
   }
   void delete_v()
@@ -76,69 +90,69 @@ template<class T> struct v_array {
   }
   void push_back(const T &new_ele)
   {
-   if(end == end_array)
+    if(end == end_array)
       resize(2 * (end_array-begin) + 3);
     *(end++) = new_ele;
   }
   size_t find_sorted(const T& ele)  //index of the smallest element >= ele, return true if element is in the array
   {
     size_t size = end - begin;
-    size_t a = 0;			
-    size_t b = size;	
+    size_t a = 0;
+    size_t b = size;
     size_t i = (a + b) / 2;
 
     while(b - a > 1)
     {
-	if(begin[i] < ele)	//if a = 0, size = 1, if in while we have b - a >= 1 the loop is infinite
-		a = i;
-	else if(begin[i] > ele)
-		b = i;
-	else
-		return i;
+      if(begin[i] < ele)	//if a = 0, size = 1, if in while we have b - a >= 1 the loop is infinite
+        a = i;
+      else if(begin[i] > ele)
+        b = i;
+      else
+        return i;
 
-	i = (a + b) / 2;		
+      i = (a + b) / 2;
     }
 
     if((size == 0) || (begin[a] > ele) || (begin[a] == ele))		//pusta tablica, nie wchodzi w while
-	return a;
-    else	//size = 1, ele = 1, begin[0] = 0	
-	return b;
- }
- size_t unique_add_sorted(const T &new_ele)//ANNA
- {
-   size_t index = 0;
-   size_t size = end - begin;
-   size_t to_move;
+      return a;
+    else	//size = 1, ele = 1, begin[0] = 0
+      return b;
+  }
+  size_t unique_add_sorted(const T &new_ele)//ANNA
+  {
+    size_t index = 0;
+    size_t size = end - begin;
+    size_t to_move;
 
-   if(!contain_sorted(new_ele, index))
-   {
-	if(end == end_array)
-		resize(2 * (end_array-begin) + 3);
+    if(!contain_sorted(new_ele, index))
+    {
+      if(end == end_array)
+        resize(2 * (end_array-begin) + 3);
 
-	to_move = size - index;
+      to_move = size - index;
 
-	if(to_move > 0)
-		memmove(begin + index + 1, begin + index, to_move * sizeof(T));   //kopiuje to_move*.. bytow z begin+index do begin+index+1
+      if(to_move > 0)
+        memmove(begin + index + 1, begin + index, to_move * sizeof(T));   //kopiuje to_move*.. bytow z begin+index do begin+index+1
 
-	begin[index] = new_ele;
+      begin[index] = new_ele;
 
-	end++;
-   }
+      end++;
+    }
 
-   return index;
- }
- bool contain_sorted(const T &ele, size_t& index) 
- {
-   index = find_sorted(ele);
+    return index;
+  }
+  bool contain_sorted(const T &ele, size_t& index)
+  {
+    index = find_sorted(ele);
 
-   if(index == this->size())
-	return false;
+    if(index == this->size())
+      return false;
 
-   if(begin[index] == ele) 
-	return true;		
+    if(begin[index] == ele)
+      return true;
 
-   return false;	
- }
+    return false;
+  }
 };
 
 
@@ -148,14 +162,18 @@ template<class T> struct v_array {
 #endif
 
 inline size_t max(size_t a, size_t b)
-{ if ( a < b) return b; else return a;
+{ if ( a < b) return b;
+  else return a;
 }
 inline size_t min(size_t a, size_t b)
-{ if ( a < b) return a; else return b;
+{ if ( a < b) return a;
+  else return b;
 }
 
-template<class T> 
-inline v_array<T> v_init() { return {nullptr, nullptr, nullptr, 0};}
+template<class T>
+inline v_array<T> v_init() {
+  return {nullptr, nullptr, nullptr, 0};
+}
 
 template<class T> void copy_array(v_array<T>& dst, v_array<T>& src)
 {
@@ -173,8 +191,8 @@ template<class T> void copy_array(v_array<T>& dst, v_array<T>& src, T(*copy_item
 template<class T> void push_many(v_array<T>& v, const T* begin, size_t num)
 {
   if(v.end+num >= v.end_array)
-    v.resize(max(2 * (size_t)(v.end_array - v.begin) + 3, 
-		 v.end - v.begin + num));
+    v.resize(max(2 * (size_t)(v.end_array - v.begin) + 3,
+                 v.end - v.begin + num));
   memcpy(v.end, begin, num * sizeof(T));
   v.end += num;
 }
@@ -192,7 +210,7 @@ template<class T> v_array<T> pop(v_array<v_array<T> > &stack)
     return *(--stack.end);
   else
     return v_array<T>();
-}  
+}
 
 template<class T> bool v_array_contains(v_array<T> &A, T x) {
   for (T* e = A.begin; e != A.end; ++e)
@@ -202,7 +220,7 @@ template<class T> bool v_array_contains(v_array<T> &A, T x) {
 
 template<class T>std::ostream& operator<<(std::ostream& os, const v_array<T>& v) {
   os << '[';
-  for (T* i=v.begin; i!=v.end; ++i) os << ' ' << *i; 
+  for (T* i=v.begin; i!=v.end; ++i) os << ' ' << *i;
   os << " ]";
   return os;
 }
@@ -218,16 +236,16 @@ typedef v_array<unsigned char> v_string;
 
 inline v_string string2v_string(const std::string& s)
 {
-    v_string res = v_init<unsigned char>();
-    if (!s.empty())
-        push_many(res, (unsigned  char*)s.data(), s.size());
-    return res;
+  v_string res = v_init<unsigned char>();
+  if (!s.empty())
+    push_many(res, (unsigned  char*)s.data(), s.size());
+  return res;
 }
 
 inline std::string v_string2string(const v_string& v_s)
 {
-    std::string res;
-    for (unsigned char* i = v_s.begin; i != v_s.end; ++i)
-        res.push_back(*i);
-    return res;
+  std::string res;
+  for (unsigned char* i = v_s.begin; i != v_s.end; ++i)
+    res.push_back(*i);
+  return res;
 }

--- a/vowpalwabbit/v_hashmap.h
+++ b/vowpalwabbit/v_hashmap.h
@@ -10,8 +10,8 @@ license as described in the file LICENSE.
 #include <string.h>
 #include "v_array.h"
 
-template<class K, class V> class v_hashmap{
- public:
+template<class K, class V> class v_hashmap {
+public:
 
   struct hash_elem {
     bool   occupied;
@@ -34,8 +34,10 @@ template<class K, class V> class v_hashmap{
     return dat.end_array-dat.begin;
   }
 
-  void set_default_value(V def) { default_value = def; }
-  
+  void set_default_value(V def) {
+    default_value = def;
+  }
+
   void init_dat(size_t min_size, V def, bool (*eq)(void*,K&,K&), void *eq_dat = nullptr) {
     dat = v_init<hash_elem>();
     if (min_size < 1023) min_size = 1023;
@@ -76,17 +78,35 @@ template<class K, class V> class v_hashmap{
     last_position = 0;
     num_occupants = 0;
   }
-  
-  v_hashmap(size_t min_size, V def, bool (*eq)(void*,K&,K&), void*eq_dat=nullptr) { init_dat(min_size, def, eq, eq_dat); }
-  v_hashmap(size_t min_size, V def, bool (*eq)(K&,K&))                         { init(min_size, def, eq); }
-  v_hashmap() { init(1023, nullptr); }
-  
-  void set_equivalent(bool (*eq)(void*,K&,K&), void*eq_dat=nullptr) { equivalent = eq; eq_data = eq_dat; equivalent_no_data = nullptr; }
-  void set_equivalent(bool (*eq)(K&,K&)) { equivalent_no_data = eq; eq_data = nullptr; equivalent = nullptr; }
 
-  void delete_v() { dat.delete_v(); }
-  
-  ~v_hashmap() { delete_v(); }
+  v_hashmap(size_t min_size, V def, bool (*eq)(void*,K&,K&), void*eq_dat=nullptr) {
+    init_dat(min_size, def, eq, eq_dat);
+  }
+  v_hashmap(size_t min_size, V def, bool (*eq)(K&,K&))                         {
+    init(min_size, def, eq);
+  }
+  v_hashmap() {
+    init(1023, nullptr);
+  }
+
+  void set_equivalent(bool (*eq)(void*,K&,K&), void*eq_dat=nullptr) {
+    equivalent = eq;
+    eq_data = eq_dat;
+    equivalent_no_data = nullptr;
+  }
+  void set_equivalent(bool (*eq)(K&,K&)) {
+    equivalent_no_data = eq;
+    eq_data = nullptr;
+    equivalent = nullptr;
+  }
+
+  void delete_v() {
+    dat.delete_v();
+  }
+
+  ~v_hashmap() {
+    delete_v();
+  }
 
   void clear() {
     if (num_occupants == 0) return;
@@ -149,7 +169,7 @@ template<class K, class V> class v_hashmap{
     for (hash_elem* e=dat.begin; e!=dat.end_array; e++)
       if (e->occupied)
         tmp.push_back(*e);
-    
+
     // double the size and clear
     //std::cerr<<"doubling to "<<(base_size()*2) << " units == " << (base_size()*2*sizeof(hash_elem)) << " bytes / " << ((size_t)-1)<<std::endl;
     dat.resize(base_size()*2, true);
@@ -172,7 +192,7 @@ template<class K, class V> class v_hashmap{
     else
       return equivalent_no_data(key, key2);
   }
-  
+
   V& get(K key, size_t hash) {
     size_t sz  = base_size();
     size_t first_position = hash % sz;
@@ -194,8 +214,8 @@ template<class K, class V> class v_hashmap{
         last_position = 0;
 
       // check to make sure we haven't cycled around -- this is a bug!
-      if (last_position == first_position) 
-	THROW("error: v_hashmap did not grow enough!");
+      if (last_position == first_position)
+        THROW("error: v_hashmap did not grow enough!");
     }
   }
 
@@ -219,10 +239,10 @@ template<class K, class V> class v_hashmap{
 
       // check to make sure we haven't cycled around -- this is a bug!
       if (last_position == first_position)
-	THROW("error: v_hashmap did not grow enough!");
+        THROW("error: v_hashmap did not grow enough!");
     }
   }
-    
+
 
   // only call put_after_get(key, hash, val) if you've already
   // run get(key, hash).  if you haven't already run get, then
@@ -246,7 +266,9 @@ template<class K, class V> class v_hashmap{
     put_after_get(key, hash, val);
   }
 
-  size_t size() { return num_occupants; }
+  size_t size() {
+    return num_occupants;
+  }
 };
 
 void test_v_hashmap();

--- a/vowpalwabbit/vw.h
+++ b/vowpalwabbit/vw.h
@@ -16,135 +16,143 @@ namespace VW {
     (1) Some commandline parameters do not make sense as a library.
     (2) The code is not yet reentrant.
    */
-  vw* initialize(string s);
-  vw* seed_vw_model(vw* vw_model, string extra_args);
+vw* initialize(string s);
+vw* seed_vw_model(vw* vw_model, string extra_args);
 
-  void cmd_string_replace_value( std::stringstream*& ss, string flag_to_replace, string new_value );
+void cmd_string_replace_value( std::stringstream*& ss, string flag_to_replace, string new_value );
 
-  char** get_argv_from_string(string s, int& argc);
+char** get_argv_from_string(string s, int& argc);
 
-  /*
-    Call finish() after you are done with the vw instance.  This cleans up memory usage.
-   */
-  void finish(vw& all, bool delete_all=true);
+/*
+  Call finish() after you are done with the vw instance.  This cleans up memory usage.
+ */
+void finish(vw& all, bool delete_all=true);
 
-  void start_parser(vw& all, bool do_init = true);
-  void end_parser(vw& all);
-  bool is_ring_example(vw& all, example* ae);
-  bool parse_atomic_example(vw& all, example* ae, bool do_read);
+void start_parser(vw& all, bool do_init = true);
+void end_parser(vw& all);
+bool is_ring_example(vw& all, example* ae);
+bool parse_atomic_example(vw& all, example* ae, bool do_read);
 
-  typedef pair< unsigned char, vector<feature> > feature_space; //just a helper definition.
-  struct primitive_feature_space { //just a helper definition.
-    unsigned char name;
-    feature* fs;
-    size_t len;
-  };
+typedef pair< unsigned char, vector<feature> > feature_space; //just a helper definition.
+struct primitive_feature_space { //just a helper definition.
+  unsigned char name;
+  feature* fs;
+  size_t len;
+};
 
-  //The next commands deal with creating examples.  Caution: VW does not all allow creation of many examples at once by default.  You can adjust the exact number by tweaking ring_size.
+//The next commands deal with creating examples.  Caution: VW does not all allow creation of many examples at once by default.  You can adjust the exact number by tweaking ring_size.
 
-  /* The simplest of two ways to create an example.  An example_line is the literal line in a VW-format datafile.
-   */
-  example* read_example(vw& all, char* example_line);
-  example* read_example(vw& all, string example_line);
+/* The simplest of two ways to create an example.  An example_line is the literal line in a VW-format datafile.
+ */
+example* read_example(vw& all, char* example_line);
+example* read_example(vw& all, string example_line);
 
-  //The more complex way to create an example.
+//The more complex way to create an example.
 
-  //after you create and fill feature_spaces, get an example with everything filled in.
-  example* import_example(vw& all, string label, primitive_feature_space* features, size_t len);
+//after you create and fill feature_spaces, get an example with everything filled in.
+example* import_example(vw& all, string label, primitive_feature_space* features, size_t len);
 
-  // callers must free memory using release_example
-  // this interface must be used with care as finish_example is a no-op for these examples.
-  // thus any delay introduced when freeing examples must be at least as long as the one
-  // introduced by all.l->finish_example implementations. 
-  // e.g. multiline examples as used by cb_adf must not be released before the finishing newline example.
-  example *alloc_examples(size_t, size_t);
-  void dealloc_example(void(*delete_label)(void*), example&ec, void(*delete_prediction)(void*) = nullptr);
+// callers must free memory using release_example
+// this interface must be used with care as finish_example is a no-op for these examples.
+// thus any delay introduced when freeing examples must be at least as long as the one
+// introduced by all.l->finish_example implementations.
+// e.g. multiline examples as used by cb_adf must not be released before the finishing newline example.
+example *alloc_examples(size_t, size_t);
+void dealloc_example(void(*delete_label)(void*), example&ec, void(*delete_prediction)(void*) = nullptr);
 
-  void parse_example_label(vw&all, example&ec, string label);
-  void setup_example(vw& all, example* ae);
-  example* new_unused_example(vw& all);
-  example* get_example(parser* pf);
-  float get_topic_prediction(example*ec, size_t i);//i=0 to max topic -1
-  float get_label(example*ec);
-  float get_importance(example*ec);
-  float get_initial(example*ec);
-  float get_prediction(example*ec);
-  float get_cost_sensitive_prediction(example*ec);
-  uint32_t* get_multilabel_predictions(example* ec, size_t& len);
-  size_t get_tag_length(example* ec);
-  const char* get_tag(example* ec);
-  size_t get_feature_number(example* ec);
-  feature* get_features(vw& all, example* ec, size_t& feature_number);
-  void return_features(feature* f);
+void parse_example_label(vw&all, example&ec, string label);
+void setup_example(vw& all, example* ae);
+example* new_unused_example(vw& all);
+example* get_example(parser* pf);
+float get_topic_prediction(example*ec, size_t i);//i=0 to max topic -1
+float get_label(example*ec);
+float get_importance(example*ec);
+float get_initial(example*ec);
+float get_prediction(example*ec);
+float get_cost_sensitive_prediction(example*ec);
+uint32_t* get_multilabel_predictions(example* ec, size_t& len);
+size_t get_tag_length(example* ec);
+const char* get_tag(example* ec);
+size_t get_feature_number(example* ec);
+feature* get_features(vw& all, example* ec, size_t& feature_number);
+void return_features(feature* f);
 
-  void add_constant_feature(vw& all, example*ec);
-  void add_label(example* ec, float label, float weight = 1, float base = 0);
+void add_constant_feature(vw& all, example*ec);
+void add_label(example* ec, float label, float weight = 1, float base = 0);
 
-  //notify VW that you are done with the example.
-  void finish_example(vw& all, example* ec);
-  void empty_example(vw& all, example& ec);
+//notify VW that you are done with the example.
+void finish_example(vw& all, example* ec);
+void empty_example(vw& all, example& ec);
 
-  void copy_example_data(bool audit, example*, example*, size_t, void(*copy_label)(void*,void*));
-  void copy_example_data(bool audit, example*, example*);  // don't copy the label
-  void clear_example_data(example&);  // don't clear the label
+void copy_example_data(bool audit, example*, example*, size_t, void(*copy_label)(void*,void*));
+void copy_example_data(bool audit, example*, example*);  // don't copy the label
+void clear_example_data(example&);  // don't clear the label
 
-  // after export_example, must call releaseFeatureSpace to free native memory
-  primitive_feature_space* export_example(vw& all, example* e, size_t& len);
-  void releaseFeatureSpace(primitive_feature_space* features, size_t len);
+// after export_example, must call releaseFeatureSpace to free native memory
+primitive_feature_space* export_example(vw& all, example* e, size_t& len);
+void releaseFeatureSpace(primitive_feature_space* features, size_t len);
 
-  void save_predictor(vw& all, string reg_name);
+void save_predictor(vw& all, string reg_name);
 
-  // inlines
+// inlines
 
-  //First create the hash of a namespace.
-  inline uint32_t hash_space(vw& all, string s)
-  {
-    substring ss;
-    ss.begin = (char*)s.c_str();
-    ss.end = ss.begin + s.length();
-    return (uint32_t)all.p->hasher(ss,hash_base);
-  }
-  inline uint32_t hash_space_static(string s, string hash)
-  {
-      substring ss;
-      ss.begin = (char*)s.c_str();
-      ss.end = ss.begin + s.length();
-      return (uint32_t)getHasher(hash)(ss, hash_base);
-  }
-  //Then use it as the seed for hashing features.
-  inline uint32_t hash_feature(vw& all, string s, unsigned long u)
-  {
-    substring ss;
-    ss.begin = (char*)s.c_str();
-    ss.end = ss.begin + s.length();
-    return (uint32_t)(all.p->hasher(ss,u) & all.parse_mask);
-  }
-  inline uint32_t hash_feature_static(string s, unsigned long u, string h, uint32_t num_bits)
-  {
-      substring ss;
-      ss.begin = (char*)s.c_str();
-      ss.end = ss.begin + s.length();
-      size_t parse_mark = (1 << num_bits) - 1;
-      return (uint32_t)(getHasher(h)(ss, u) & parse_mark);
-  }
+//First create the hash of a namespace.
+inline uint32_t hash_space(vw& all, string s)
+{
+  substring ss;
+  ss.begin = (char*)s.c_str();
+  ss.end = ss.begin + s.length();
+  return (uint32_t)all.p->hasher(ss,hash_base);
+}
+inline uint32_t hash_space_static(string s, string hash)
+{
+  substring ss;
+  ss.begin = (char*)s.c_str();
+  ss.end = ss.begin + s.length();
+  return (uint32_t)getHasher(hash)(ss, hash_base);
+}
+//Then use it as the seed for hashing features.
+inline uint32_t hash_feature(vw& all, string s, unsigned long u)
+{
+  substring ss;
+  ss.begin = (char*)s.c_str();
+  ss.end = ss.begin + s.length();
+  return (uint32_t)(all.p->hasher(ss,u) & all.parse_mask);
+}
+inline uint32_t hash_feature_static(string s, unsigned long u, string h, uint32_t num_bits)
+{
+  substring ss;
+  ss.begin = (char*)s.c_str();
+  ss.end = ss.begin + s.length();
+  size_t parse_mark = (1 << num_bits) - 1;
+  return (uint32_t)(getHasher(h)(ss, u) & parse_mark);
+}
 
-  inline uint32_t hash_feature_cstr(vw& all, char* fstr, unsigned long u)
-  {
-    substring ss;
-    ss.begin = fstr;
-    ss.end = ss.begin + strlen(fstr);
-    return (uint32_t)(all.p->hasher(ss,u) & all.parse_mask);
-  }
+inline uint32_t hash_feature_cstr(vw& all, char* fstr, unsigned long u)
+{
+  substring ss;
+  ss.begin = fstr;
+  ss.end = ss.begin + strlen(fstr);
+  return (uint32_t)(all.p->hasher(ss,u) & all.parse_mask);
+}
 
-  inline float get_weight(vw& all, uint32_t index, uint32_t offset)
-  { return all.reg.weight_vector[(((index << all.reg.stride_shift) + offset) & all.reg.weight_mask)];}
+inline float get_weight(vw& all, uint32_t index, uint32_t offset)
+{
+  return all.reg.weight_vector[(((index << all.reg.stride_shift) + offset) & all.reg.weight_mask)];
+}
 
-  inline void set_weight(vw& all, uint32_t index, uint32_t offset, float value)
-  { all.reg.weight_vector[(((index << all.reg.stride_shift) + offset) & all.reg.weight_mask)] = value;}
+inline void set_weight(vw& all, uint32_t index, uint32_t offset, float value)
+{
+  all.reg.weight_vector[(((index << all.reg.stride_shift) + offset) & all.reg.weight_mask)] = value;
+}
 
-  inline uint32_t num_weights(vw& all)
-  { return (uint32_t)all.length();}
+inline uint32_t num_weights(vw& all)
+{
+  return (uint32_t)all.length();
+}
 
-  inline uint32_t get_stride(vw& all)
-  { return (uint32_t)(1 << all.reg.stride_shift);}
+inline uint32_t get_stride(vw& all)
+{
+  return (uint32_t)(1 << all.reg.stride_shift);
+}
 }

--- a/vowpalwabbit/vw_exception.cc
+++ b/vowpalwabbit/vw_exception.cc
@@ -2,32 +2,32 @@
 
 namespace VW {
 
-	vw_exception::vw_exception(const char* pfile, int plineNumber, std::string pmessage)
-	  : file(pfile), message(pmessage), lineNumber(plineNumber)
-	{
-	}
+vw_exception::vw_exception(const char* pfile, int plineNumber, std::string pmessage)
+  : file(pfile), message(pmessage), lineNumber(plineNumber)
+{
+}
 
-	vw_exception::vw_exception(const vw_exception& ex)
-	  : file(ex.file), message(ex.message), lineNumber(ex.lineNumber)
-	{
-	}
+vw_exception::vw_exception(const vw_exception& ex)
+  : file(ex.file), message(ex.message), lineNumber(ex.lineNumber)
+{
+}
 
-	vw_exception::~vw_exception() _NOEXCEPT
-	{
-	}
+vw_exception::~vw_exception() _NOEXCEPT
+{
+}
 
-	const char* vw_exception::what() const _NOEXCEPT
-	{
-		return message.c_str();
-	}
-	
-	const char* vw_exception::Filename() const
-	{
-		return file;
-	}
+const char* vw_exception::what() const _NOEXCEPT
+{
+  return message.c_str();
+}
 
-	int vw_exception::LineNumber() const
-	{
-		return lineNumber;
-	}
+const char* vw_exception::Filename() const
+{
+  return file;
+}
+
+int vw_exception::LineNumber() const
+{
+  return lineNumber;
+}
 }

--- a/vowpalwabbit/vw_exception.h
+++ b/vowpalwabbit/vw_exception.h
@@ -11,34 +11,34 @@ license as described in the file LICENSE.
 #ifndef _NOEXCEPT
 // _NOEXCEPT is required on Mac OS
 // making sure other platforms don't barf
-#define _NOEXCEPT throw () 
+#define _NOEXCEPT throw ()
 #endif
 
 namespace VW {
 
-	class vw_exception : public std::exception
-	{
-	private:
-		// source file exception was thrown
-		const char* file;
+class vw_exception : public std::exception
+{
+private:
+  // source file exception was thrown
+  const char* file;
 
-		std::string message;
+  std::string message;
 
-		// line number exception was thrown
-		int lineNumber;
-	public:
-		vw_exception(const char* file, int lineNumber, std::string message);
+  // line number exception was thrown
+  int lineNumber;
+public:
+  vw_exception(const char* file, int lineNumber, std::string message);
 
-		vw_exception(const vw_exception& ex);
+  vw_exception(const vw_exception& ex);
 
-		~vw_exception() _NOEXCEPT;
+  ~vw_exception() _NOEXCEPT;
 
-		virtual const char* what() const _NOEXCEPT;
+  virtual const char* what() const _NOEXCEPT;
 
-		const char* Filename() const;
+  const char* Filename() const;
 
-		int LineNumber() const;
-	};
+  int LineNumber() const;
+};
 
 #ifdef _WIN32
 #define THROWERRNO(args) \
@@ -51,7 +51,7 @@ namespace VW {
 		else \
 			__msg << ", errno = " << __errmsg; \
 		throw VW::vw_exception(__FILE__, __LINE__, __msg.str()); \
-	} 
+	}
 #else
 #define THROWERRNO(args) \
 	{ \

--- a/vowpalwabbit/vwdll.h
+++ b/vowpalwabbit/vwdll.h
@@ -14,7 +14,7 @@ license as described in the file LICENSE.
 // enable wide character (32 bit) versions of functions
 // these are optional  since other compilers may not have wide to narrow char libarray facilities built in.
 #ifdef WIN32
-#define USE_CODECVT 
+#define USE_CODECVT
 #endif
 
 
@@ -52,73 +52,73 @@ extern "C"
 #define VW_TYPE_SAFE_NULL NULL
 #endif
 
-	typedef void * VW_HANDLE;
-	typedef void * VW_EXAMPLE;
-	typedef void * VW_LABEL;
-	typedef void * VW_FEATURE_SPACE;
-	typedef void * VW_FEATURE;
- 
-	const VW_HANDLE INVALID_VW_HANDLE = VW_TYPE_SAFE_NULL;
-	const VW_HANDLE INVALID_VW_EXAMPLE = VW_TYPE_SAFE_NULL;
+  typedef void * VW_HANDLE;
+  typedef void * VW_EXAMPLE;
+  typedef void * VW_LABEL;
+  typedef void * VW_FEATURE_SPACE;
+  typedef void * VW_FEATURE;
+
+  const VW_HANDLE INVALID_VW_HANDLE = VW_TYPE_SAFE_NULL;
+  const VW_HANDLE INVALID_VW_EXAMPLE = VW_TYPE_SAFE_NULL;
 
 #ifdef USE_CODECVT
-	VW_DLL_MEMBER VW_HANDLE VW_CALLING_CONV VW_Initialize(const char16_t * pstrArgs);
+  VW_DLL_MEMBER VW_HANDLE VW_CALLING_CONV VW_Initialize(const char16_t * pstrArgs);
 #endif
-	VW_DLL_MEMBER VW_HANDLE VW_CALLING_CONV VW_InitializeA(const char * pstrArgs);
+  VW_DLL_MEMBER VW_HANDLE VW_CALLING_CONV VW_InitializeA(const char * pstrArgs);
 
-	VW_DLL_MEMBER void VW_CALLING_CONV VW_Finish_Passes(VW_HANDLE handle);
-	VW_DLL_MEMBER void VW_CALLING_CONV VW_Finish(VW_HANDLE handle);
+  VW_DLL_MEMBER void VW_CALLING_CONV VW_Finish_Passes(VW_HANDLE handle);
+  VW_DLL_MEMBER void VW_CALLING_CONV VW_Finish(VW_HANDLE handle);
 
-	VW_DLL_MEMBER VW_EXAMPLE VW_CALLING_CONV VW_ImportExample(VW_HANDLE handle, const char * label, VW_FEATURE_SPACE * features, size_t len);
+  VW_DLL_MEMBER VW_EXAMPLE VW_CALLING_CONV VW_ImportExample(VW_HANDLE handle, const char * label, VW_FEATURE_SPACE * features, size_t len);
 
-	VW_DLL_MEMBER VW_FEATURE_SPACE VW_CALLING_CONV VW_ExportExample(VW_HANDLE handle, VW_EXAMPLE e, size_t* plen);
-	VW_DLL_MEMBER void VW_CALLING_CONV VW_ReleaseFeatureSpace(VW_FEATURE_SPACE * features, size_t len);
+  VW_DLL_MEMBER VW_FEATURE_SPACE VW_CALLING_CONV VW_ExportExample(VW_HANDLE handle, VW_EXAMPLE e, size_t* plen);
+  VW_DLL_MEMBER void VW_CALLING_CONV VW_ReleaseFeatureSpace(VW_FEATURE_SPACE * features, size_t len);
 #ifdef USE_CODECVT
-	VW_DLL_MEMBER VW_EXAMPLE VW_CALLING_CONV VW_ReadExample(VW_HANDLE handle, const char16_t * line);
+  VW_DLL_MEMBER VW_EXAMPLE VW_CALLING_CONV VW_ReadExample(VW_HANDLE handle, const char16_t * line);
 #endif
-	VW_DLL_MEMBER VW_EXAMPLE VW_CALLING_CONV VW_ReadExampleA(VW_HANDLE handle, const char * line);
+  VW_DLL_MEMBER VW_EXAMPLE VW_CALLING_CONV VW_ReadExampleA(VW_HANDLE handle, const char * line);
 
-	VW_DLL_MEMBER void VW_CALLING_CONV VW_StartParser(VW_HANDLE handle, bool do_init);
-	VW_DLL_MEMBER void VW_CALLING_CONV VW_EndParser(VW_HANDLE handle);
+  VW_DLL_MEMBER void VW_CALLING_CONV VW_StartParser(VW_HANDLE handle, bool do_init);
+  VW_DLL_MEMBER void VW_CALLING_CONV VW_EndParser(VW_HANDLE handle);
 
-	VW_DLL_MEMBER VW_EXAMPLE VW_CALLING_CONV VW_GetExample(VW_HANDLE handle);
-	VW_DLL_MEMBER void VW_CALLING_CONV VW_FinishExample(VW_HANDLE handle, VW_EXAMPLE e);
-	VW_DLL_MEMBER float VW_CALLING_CONV VW_GetLabel(VW_EXAMPLE e);
-	VW_DLL_MEMBER float VW_CALLING_CONV VW_GetImportance(VW_EXAMPLE e);
-	VW_DLL_MEMBER float VW_CALLING_CONV VW_GetInitial(VW_EXAMPLE e);
-	VW_DLL_MEMBER float VW_CALLING_CONV VW_GetPrediction(VW_EXAMPLE e);
-	VW_DLL_MEMBER float VW_CALLING_CONV VW_GetCostSensitivePrediction(VW_EXAMPLE e);
-    VW_DLL_MEMBER void* VW_CALLING_CONV VW_GetMultilabelPredictions(VW_EXAMPLE e, size_t* plen);
-	VW_DLL_MEMBER float VW_CALLING_CONV VW_GetTopicPrediction(VW_EXAMPLE e, size_t i);
-	VW_DLL_MEMBER size_t VW_CALLING_CONV VW_GetTagLength(VW_EXAMPLE e);
-	VW_DLL_MEMBER const char* VW_CALLING_CONV VW_GetTag(VW_EXAMPLE e);
-	VW_DLL_MEMBER size_t VW_CALLING_CONV VW_GetFeatureNumber(VW_EXAMPLE e);
-	VW_DLL_MEMBER VW_FEATURE VW_CALLING_CONV VW_GetFeatures(VW_HANDLE handle, VW_EXAMPLE e, size_t* plen);
-	VW_DLL_MEMBER void VW_CALLING_CONV VW_ReturnFeatures(VW_FEATURE f);
+  VW_DLL_MEMBER VW_EXAMPLE VW_CALLING_CONV VW_GetExample(VW_HANDLE handle);
+  VW_DLL_MEMBER void VW_CALLING_CONV VW_FinishExample(VW_HANDLE handle, VW_EXAMPLE e);
+  VW_DLL_MEMBER float VW_CALLING_CONV VW_GetLabel(VW_EXAMPLE e);
+  VW_DLL_MEMBER float VW_CALLING_CONV VW_GetImportance(VW_EXAMPLE e);
+  VW_DLL_MEMBER float VW_CALLING_CONV VW_GetInitial(VW_EXAMPLE e);
+  VW_DLL_MEMBER float VW_CALLING_CONV VW_GetPrediction(VW_EXAMPLE e);
+  VW_DLL_MEMBER float VW_CALLING_CONV VW_GetCostSensitivePrediction(VW_EXAMPLE e);
+  VW_DLL_MEMBER void* VW_CALLING_CONV VW_GetMultilabelPredictions(VW_EXAMPLE e, size_t* plen);
+  VW_DLL_MEMBER float VW_CALLING_CONV VW_GetTopicPrediction(VW_EXAMPLE e, size_t i);
+  VW_DLL_MEMBER size_t VW_CALLING_CONV VW_GetTagLength(VW_EXAMPLE e);
+  VW_DLL_MEMBER const char* VW_CALLING_CONV VW_GetTag(VW_EXAMPLE e);
+  VW_DLL_MEMBER size_t VW_CALLING_CONV VW_GetFeatureNumber(VW_EXAMPLE e);
+  VW_DLL_MEMBER VW_FEATURE VW_CALLING_CONV VW_GetFeatures(VW_HANDLE handle, VW_EXAMPLE e, size_t* plen);
+  VW_DLL_MEMBER void VW_CALLING_CONV VW_ReturnFeatures(VW_FEATURE f);
 #ifdef USE_CODECVT
-	VW_DLL_MEMBER size_t VW_CALLING_CONV VW_HashSpace(VW_HANDLE handle, const char16_t * s);
-    VW_DLL_MEMBER size_t VW_CALLING_CONV VW_HashSpaceStatic(const char16_t * s, const char16_t * h);
+  VW_DLL_MEMBER size_t VW_CALLING_CONV VW_HashSpace(VW_HANDLE handle, const char16_t * s);
+  VW_DLL_MEMBER size_t VW_CALLING_CONV VW_HashSpaceStatic(const char16_t * s, const char16_t * h);
 #endif
-	VW_DLL_MEMBER size_t VW_CALLING_CONV VW_HashSpaceA(VW_HANDLE handle, const char * s);
-    VW_DLL_MEMBER size_t VW_CALLING_CONV VW_HashSpaceStaticA(const char * s, const char* h);
+  VW_DLL_MEMBER size_t VW_CALLING_CONV VW_HashSpaceA(VW_HANDLE handle, const char * s);
+  VW_DLL_MEMBER size_t VW_CALLING_CONV VW_HashSpaceStaticA(const char * s, const char* h);
 #ifdef USE_CODECVT
-	VW_DLL_MEMBER size_t VW_CALLING_CONV VW_HashFeature(VW_HANDLE handle, const char16_t * s, unsigned long u);
-    VW_DLL_MEMBER size_t VW_CALLING_CONV VW_HashFeatureStatic(const char16_t * s, unsigned long u, const char16_t * h, unsigned int num_bits);
+  VW_DLL_MEMBER size_t VW_CALLING_CONV VW_HashFeature(VW_HANDLE handle, const char16_t * s, unsigned long u);
+  VW_DLL_MEMBER size_t VW_CALLING_CONV VW_HashFeatureStatic(const char16_t * s, unsigned long u, const char16_t * h, unsigned int num_bits);
 #endif
-	VW_DLL_MEMBER size_t VW_CALLING_CONV VW_HashFeatureA(VW_HANDLE handle, const char * s, unsigned long u);
-    VW_DLL_MEMBER size_t VW_CALLING_CONV VW_HashFeatureStaticA(const char * s, unsigned long u, const char * h, unsigned int num_bits);
+  VW_DLL_MEMBER size_t VW_CALLING_CONV VW_HashFeatureA(VW_HANDLE handle, const char * s, unsigned long u);
+  VW_DLL_MEMBER size_t VW_CALLING_CONV VW_HashFeatureStaticA(const char * s, unsigned long u, const char * h, unsigned int num_bits);
 
-	VW_DLL_MEMBER float VW_CALLING_CONV VW_Learn(VW_HANDLE handle, VW_EXAMPLE e);
-	VW_DLL_MEMBER float VW_CALLING_CONV VW_Predict(VW_HANDLE handle, VW_EXAMPLE e);
-	VW_DLL_MEMBER void VW_CALLING_CONV VW_AddLabel(VW_EXAMPLE e, float label, float weight, float base);
-	VW_DLL_MEMBER void VW_CALLING_CONV VW_AddStringLabel(VW_HANDLE handle, VW_EXAMPLE e, const char* label);
+  VW_DLL_MEMBER float VW_CALLING_CONV VW_Learn(VW_HANDLE handle, VW_EXAMPLE e);
+  VW_DLL_MEMBER float VW_CALLING_CONV VW_Predict(VW_HANDLE handle, VW_EXAMPLE e);
+  VW_DLL_MEMBER void VW_CALLING_CONV VW_AddLabel(VW_EXAMPLE e, float label, float weight, float base);
+  VW_DLL_MEMBER void VW_CALLING_CONV VW_AddStringLabel(VW_HANDLE handle, VW_EXAMPLE e, const char* label);
 
-	VW_DLL_MEMBER float VW_CALLING_CONV VW_Get_Weight(VW_HANDLE handle, size_t index, size_t offset);
-    VW_DLL_MEMBER void VW_CALLING_CONV VW_Set_Weight(VW_HANDLE handle, size_t index, size_t offset, float value);
-	VW_DLL_MEMBER size_t VW_CALLING_CONV VW_Num_Weights(VW_HANDLE handle);
-	VW_DLL_MEMBER size_t VW_CALLING_CONV VW_Get_Stride(VW_HANDLE handle);
+  VW_DLL_MEMBER float VW_CALLING_CONV VW_Get_Weight(VW_HANDLE handle, size_t index, size_t offset);
+  VW_DLL_MEMBER void VW_CALLING_CONV VW_Set_Weight(VW_HANDLE handle, size_t index, size_t offset, float value);
+  VW_DLL_MEMBER size_t VW_CALLING_CONV VW_Num_Weights(VW_HANDLE handle);
+  VW_DLL_MEMBER size_t VW_CALLING_CONV VW_Get_Stride(VW_HANDLE handle);
 
-	VW_DLL_MEMBER void VW_CALLING_CONV VW_SaveModel(VW_HANDLE handle);
+  VW_DLL_MEMBER void VW_CALLING_CONV VW_SaveModel(VW_HANDLE handle);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
A suggestion how to solve #769.
I've added .editorconfig file and applied [`astyle`](http://astyle.sourceforge.net/) on the C++ source files as
```
astyle --lineend=linux --indent=spaces=2 *.cc *.h
```
I have not changed the bracketing style: attached (K&R, Stroustrup,...)  vs. broken (Allman, GNU,...). This could be unified with `astyle` with e.g. `--style=stroustrup` in future PR if we (well, John) decide on the preferred style for VW.