### PR TITLE
Java interface build issue fixes

### DIFF
--- a/java/Makefile
+++ b/java/Makefile
@@ -36,6 +36,7 @@ pom_version: pom.xml
 target/vw_jni.lib: src/main/c++/vw_VW.cc ../vowpalwabbit/main.o ../vowpalwabbit/libvw.a ../vowpalwabbit/liballreduce.a
 	mkdir -p target;
 	$(CXX) -shared $(FLAGS) -o $@ $< $(VWLIBS) $(STDLIBS) $(JAVA_INCLUDE)
+	osf=$$(perl script/os_info.pl osfamily) && mv target/vw_jni.lib target/vw_jni.$$osf.lib
 
 clean:
-	rm -f target/vw_jni.lib
+	rm -f target/vw_jni\.*.lib

--- a/java/script/os_info.pl
+++ b/java/script/os_info.pl
@@ -1,0 +1,49 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+if ($#ARGV != 0) {
+  die "invalid arguments, exiting"
+}
+
+my $cmd = $ARGV[0];
+
+if ($cmd eq "osfamily") {
+  my $f = get_os_family($^O);
+  print "$f." . get_os_arch($f);
+} else {
+  print "unknown command\n";
+}
+
+sub get_lsb_release {
+  my $opt = shift;
+  my $res=(split(':', `lsb_release $opt`))[1];
+  $res =~ s/\s+//g;
+  return $res;
+}
+
+sub get_os_arch {
+  my $os_family = shift;
+  my $arch = `uname -m`;
+  if ($os_family =~ /ubuntu/i) {
+    $arch = `dpkg --print-architecture`;
+  }
+  chomp($arch);
+  return $arch;
+}
+
+sub get_os_family {
+  my $os = shift;
+  if ($os =~ /darwin/i) {
+    return "Darwin";
+  } elsif ($os =~ /linux/i) {
+    my $dist = get_lsb_release("-i");
+    $dist =~ s/ /_/g;
+    my $fullVersion = get_lsb_release("-r");
+    my $majorVersion = (split('\.', $fullVersion))[0];
+    return "$dist.$majorVersion";
+  } else {
+    return "unknown";
+  }
+}


### PR DESCRIPTION
disable doclint check to make build work with Java 8; rename JNI native lib file, so that the Java lib can load it