### PR TITLE
RunTests: clean-up temporary files

### DIFF
--- a/test/RunTests
+++ b/test/RunTests
@@ -448,6 +448,7 @@ sub diff_lenient_float($$) {
         close $sdiff;
         $status = $fuzzy_status;
     }
+    unlink($tmpf) if ($status == 0);
     $status;
 }
 
@@ -488,13 +489,14 @@ sub diff($$) {
 
     # Actually run the diff
     my $diff_cmd = "$Diff $DiffOpts $reffile $outfile";
-    mysystem("$diff_cmd >diff.tmp");
+    my $diftmp = 'diff.tmp';
+    mysystem("$diff_cmd >$diftmp");
     $status = $? >> 8;
-    v(2, "$diff_cmd >diff.tmp: status=$status\n");
+    v(2, "$diff_cmd >$diftmp: status=$status\n");
  
-    if (-s 'diff.tmp') {
+    if (-s "$diftmp") {
         # There's some difference
-        v(2, "diff.tmp has something in it. Is it meaningful?\n");
+        v(2, "$diftmp has something in it. Is it meaningful?\n");
 
         if ($opt_f && -e $reffile && -e $outfile &&
             diff_lenient_float($reffile, $outfile) == 0) {
@@ -525,6 +527,7 @@ sub diff($$) {
             }
         }
     }
+    unlink($diftmp) if ($status == 0);
     $status;
 }
 
@@ -662,6 +665,7 @@ sub run_tests() {
         } else {
             if (defined $out_ref) {
                 print STDERR "$0: test $TestNo: stdout OK\n";
+                unlink($outf);
             } else {
                 v(1, "$0: test $TestNo: stdout OK (no reference)\n");
             }
@@ -684,6 +688,7 @@ sub run_tests() {
             exit $status if ($opt_e);
         } else {
             print STDERR "$0: test $TestNo: stderr OK\n";
+            unlink($errf);
         }
 
         # -- compare all other reference files
@@ -709,6 +714,7 @@ sub run_tests() {
                     exit $status if ($opt_e);
                 } else {
                     print STDERR "$0: test $TestNo: $ref_base OK\n";
+                    unlink($ref_base);
                 }
             }
         }


### PR DESCRIPTION
This little set of changes in RunTests leaves the test directory cleaner of clutter as a result of running `make test`