### PR TITLE
Disable doclint check to make build work with Java 8

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -14,6 +14,10 @@
     </description>
     <url>https://github.com/JohnLangford/vowpal_wabbit</url>
 
+    <properties>
+        <additionalparam>-Xdoclint:none</additionalparam>
+    </properties>
+
     <scm>
         <connection>scm:git:git@github.com:JohnLangford/vowpal_wabbit.git</connection>
         <developerConnection>scm:git:git@github.com:JohnLangford/vowpal_wabbit.git</developerConnection>


### PR DESCRIPTION
Workaround for a doclint check failure.
The Javadoc should also be fixed.