### PR TITLE
Fixing JavaDoc to be compatible with Java 8's fail fast mechanism

### DIFF
--- a/java/src/main/java/vw/VW.java
+++ b/java/src/main/java/vw/VW.java
@@ -42,10 +42,10 @@ public class VW implements Closeable {
     /**
      * Create a new VW instance that is ready to either create predictions or learn based on examples.
      * This allows the user to instead of using the prepackaged JNI layer to load their own external JNI layer.
-     * This means that if a user wants to use this code with an OS that is not supported they would follow the following steps:<br/>
-     * 1.  Download VW<br/>
-     * 2.  Build VW for the OS they wish to support<br/>
-     * 3.  Call either {@link System#load(String)} or {@link System#loadLibrary(String)}<br/>
+     * This means that if a user wants to use this code with an OS that is not supported they would follow the following steps:<br>
+     * 1.  Download VW<br>
+     * 2.  Build VW for the OS they wish to support<br>
+     * 3.  Call either {@link System#load(String)} or {@link System#loadLibrary(String)}<br>
      * If a user wishes to use the prepackaged JNI libraries (which is encouraged) then no additional steps need to be taken.
      * @param command The same string that is passed to VW, see
      *                <a href="https://github.com/JohnLangford/vowpal_wabbit/wiki/Command-line-arguments">here</a>


### PR DESCRIPTION
The Java layer should build properly on Java 8 now.  The problem is that Java 8 is now much more strict on their JavaDoc requirements.  More information can be found [here](http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html).