### PR TITLE
better malformed ex warning

### DIFF
--- a/vowpalwabbit/parse_example.cc
+++ b/vowpalwabbit/parse_example.cc
@@ -49,6 +49,13 @@ public:
 
   ~TC_parser() { }
 
+  inline void parserWarning(const char* message, char* begin, char* pos, const char* message2)
+  {
+      cout << message << std::string(begin, pos - begin).c_str() << message2
+           << "\nExample #" << this->p->end_parsed_examples << ": \"" << std::string(this->beginLine, this->endLine).c_str() << "\""
+           << endl;
+  }
+
   inline float featureValue() {
     if(*reading_head == ' ' || *reading_head == '\t' || *reading_head == '|' || reading_head == endLine || *reading_head == '\r')
       return 1.;
@@ -58,17 +65,17 @@ public:
       char *end_read = nullptr;
       v = parseFloat(reading_head,&end_read);
       if(end_read == reading_head) {
-        cout << "malformed example !\nFloat expected after : \"" << std::string(beginLine, reading_head - beginLine).c_str()<< "\"" << endl;
+        parserWarning("malformed example !\nFloat expected after : \"", beginLine, reading_head, "\"");
       }
       if(nanpattern(v)) {
         v = 0.f;
-        cout << "warning: invalid feature value:\"" << std::string(reading_head, end_read - reading_head).c_str() << "\" read as NaN. Replacing with 0." << endl;
+        parserWarning("warning: invalid feature value:\"", reading_head, end_read, "\" read as NaN. Replacing with 0.");
       }
       reading_head = end_read;
       return v;
     } else {
       // syntax error
-      cout << "malformed example !\n'|' , ':' , space or EOL expected after : \"" << std::string(beginLine, reading_head - beginLine).c_str()<< "\"" << endl;
+      parserWarning("malformed example !\n'|' , ':' , space or EOL expected after : \"", beginLine, reading_head, "\"");
       return 0.f;
     }
   }
@@ -209,23 +216,23 @@ public:
       char *end_read = nullptr;
       cur_channel_v = parseFloat(reading_head,&end_read);
       if(end_read == reading_head) {
-        cout << "malformed example !\nFloat expected after : \"" << std::string(beginLine, reading_head - beginLine).c_str()<< "\"" << endl;
+        parserWarning("malformed example !\nFloat expected after : \"", beginLine, reading_head, "\"");
       }
       if(nanpattern(cur_channel_v)) {
         cur_channel_v = 1.f;
-        cout << "warning: invalid namespace value:\"" << std::string(reading_head, end_read - reading_head).c_str() << "\" read as NaN. Replacing with 1." << endl;
+        parserWarning("warning: invalid namespace value:\"", reading_head, end_read, "\" read as NaN. Replacing with 1.");
       }
       reading_head = end_read;
     } else {
       // syntax error
-      cout << "malformed example !\n'|' , ':' , space or EOL expected after : \"" << std::string(beginLine, reading_head - beginLine).c_str()<< "\"" << endl;
+      parserWarning("malformed example !\n'|' , ':' , space or EOL expected after : \"", beginLine, reading_head, "\"");
     }
   }
 
   inline void nameSpaceInfo() {
     if(reading_head == endLine ||*reading_head == '|' || *reading_head == ' ' || *reading_head == '\t' || *reading_head == ':' || *reading_head == '\r') {
       // syntax error
-      cout << "malformed example !\nString expected after : " << std::string(beginLine, reading_head - beginLine).c_str()<< "\"" << endl;
+      parserWarning("malformed example !\nString expected after : \"", beginLine, reading_head, "\"");
     } else {
       // NameSpaceInfo --> 'String' NameSpaceInfoValue
       index = (unsigned char)(*reading_head);
@@ -254,7 +261,7 @@ public:
     }
     if(!(*reading_head == '|' || reading_head == endLine || *reading_head == '\r')) {
       //syntax error
-      cout << "malformed example !\n'|' , space or EOL expected after : \"" << std::string(beginLine, reading_head - beginLine).c_str() << "\"" << endl;
+      parserWarning("malformed example !\n'|' , space or EOL expected after : \"", beginLine, reading_head, "\"");
     }
   }
 
@@ -284,7 +291,7 @@ public:
       listFeatures();
     } else {
       // syntax error
-      cout << "malformed example !\n'|' , String, space or EOL expected after : \"" << std::string(beginLine, reading_head - beginLine).c_str()<< "\"" << endl;
+      parserWarning("malformed example !\n'|' , String, space or EOL expected after : \"", beginLine, reading_head, "\"");
     }
     if(new_index && ae->atomics[index].begin != ae->atomics[index].end)
       ae->indices.push_back(index);
@@ -298,7 +305,7 @@ public:
     if(reading_head != endLine && *reading_head != '\r')
     {
       // syntax error
-      cout << "malformed example !\n'|' or EOL expected after : \"" << std::string(beginLine, reading_head - beginLine).c_str()<< "\"" << endl;
+      parserWarning("malformed example !\n'|' or EOL expected after : \"", beginLine, reading_head, "\"");
     }
   }
 


### PR DESCRIPTION
As discussed in #726 (2).
Was:
```
$ echo '1 |1
2 |sda:4.0fdfd:4' | ./vw
...
average  since         example        example  current  current  current
loss     last          counter         weight    label  predict features
malformed example !
'|' , space or EOL expected after : "|sda:4.0"
malformed example !
'|' or EOL expected after : "|sda:4.0"
1.000000 1.000000            1            1.0   1.0000   0.0000        1
1.790589 2.581179            2            2.0   2.0000   0.3934        1

finished run
```

Proposed:
```
$ echo '1 |1                                    
2 |sda:4.0fdfd:4' | ./vw
...
average  since         example        example  current  current  current
loss     last          counter         weight    label  predict features
malformed example !
'|' , space or EOL expected after : "|sda:4.0"
Example #1: "|sda:4.0fdfd:4"
malformed example !
'|' or EOL expected after : "|sda:4.0"
Example #1: "|sda:4.0fdfd:4"
1.000000 1.000000            1            1.0   1.0000   0.0000        1
1.790589 2.581179            2            2.0   2.0000   0.3934        1

finished run
```

I've refactored code a bit and moved warning code to inline function.
In first example user is getting only "|sda:4.0" which displays proper float weight. User doesn't see the rest of the line. In second example the rest of the line is shown. Unfortunately I can't display whole example line (label header is missing) without more serious code changes, but I can display line number which precisely addresses the example in file.