### PR TITLE
hex encoding of namespaces in comand line

### DIFF
--- a/vowpalwabbit/global_data.cc
+++ b/vowpalwabbit/global_data.cc
@@ -179,7 +179,7 @@ void compile_gram(vector<string> grams, uint32_t* dest, char* descriptor, bool q
       cout << "You must specify the namespace index before the n" << endl;
     else {
       int n = atoi(ngram.c_str()+1);
-      dest[(uint32_t)ngram[0]] = n;
+      dest[(uint32_t)(unsigned char)*ngram.c_str()] = n;
       if (!quiet)
         cerr << "Generating " << n << "-" << descriptor << " for " << ngram[0] << " namespaces." << endl;
     }

--- a/vowpalwabbit/lrq.cc
+++ b/vowpalwabbit/lrq.cc
@@ -3,6 +3,7 @@
 #include "reductions.h"
 #include "rand48.h"
 #include "vw_exception.h"
+#include "parse_args.h" // for spoof_hex_encoded_namespaces
 
 using namespace LEARNER;
 
@@ -208,9 +209,11 @@ base_learner* lrq_setup(vw& all)
   LRQstate& lrq = calloc_or_die<LRQstate>();
   size_t maxk = 0;
   lrq.all = &all;
-  new(&lrq.lrpairs)
-  std::set<std::string> (all.vm["lrq"].as<vector<string> > ().begin (),
-                         all.vm["lrq"].as<vector<string> > ().end ());
+
+  vector<string> arg = all.vm["lrq"].as<vector<string> > ();
+  for (size_t i = 0; i < arg.size(); i++) arg[i] = spoof_hex_encoded_namespaces( arg[i] );
+
+  new(&lrq.lrpairs) std::set<std::string> (arg.begin (), arg.end ());
 
   lrq.initial_seed = lrq.seed = all.random_seed | 8675309;
   if (all.vm.count("lrqdropout"))

--- a/vowpalwabbit/lrqfa.cc
+++ b/vowpalwabbit/lrqfa.cc
@@ -1,6 +1,7 @@
 #include <string>
 #include "reductions.h"
 #include "rand48.h"
+#include "parse_args.h" // for spoof_hex_encoded_namespaces
 
 using namespace LEARNER;
 
@@ -135,7 +136,7 @@ LEARNER::base_learner* lrqfa_setup(vw& all) {
   LRQFAstate& lrq = calloc_or_die<LRQFAstate>();
   lrq.all = &all;
 
-  string lrqopt = all.vm["lrqfa"].as<string>();
+  string lrqopt = spoof_hex_encoded_namespaces( all.vm["lrqfa"].as<string>() );
   size_t last_index = lrqopt.find_last_not_of("0123456789");
   new(&lrq.field_name) string(lrqopt.substr(0, last_index+1)); // make sure there is no duplicates
   lrq.k = atoi(lrqopt.substr(last_index+1).c_str());

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -637,7 +637,7 @@ void parse_feature_tweaks(vw& all)
     {
         *i = spoof_hex_encoded_namespaces(*i);
         for (string::const_iterator j = i->begin(); j != i->end(); j++)
-            all.ignore[(size_t)*j] = true;
+            all.ignore[(size_t)(unsigned char)*j] = true;
 
     }
 
@@ -664,7 +664,7 @@ void parse_feature_tweaks(vw& all)
     {
         *i = spoof_hex_encoded_namespaces(*i);
         for (string::const_iterator j = i->begin(); j != i->end(); j++)
-            all.ignore[(size_t)*j] = false;
+            all.ignore[(size_t)(unsigned char)*j] = false;
     }
 
     if (!all.quiet)

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -539,10 +539,9 @@ void parse_feature_tweaks(vw& all)
 
       for (vector<string>::iterator i = vec_arg.begin(); i != vec_arg.end(); ++i)
       {
-	if (!all.quiet)
-	  cerr << *i << " ";
         *all.file_options << " --quadratic " << *i;
         *i = spoof_hex_encoded_namespaces(*i);
+        if (!all.quiet) cerr << *i << " ";
       }
 
     expanded_interactions = INTERACTIONS::expand_interactions(vec_arg, 2, "error, quadratic features must involve two sets.");
@@ -557,10 +556,10 @@ void parse_feature_tweaks(vw& all)
     {
       cerr << "creating cubic features for triples: ";
       for (vector<string>::iterator i = vec_arg.begin(); i != vec_arg.end(); ++i)
-      {
-        if (!all.quiet) cerr << *i << " ";
+      {        
         *all.file_options << " --cubic " << *i;
         *i = spoof_hex_encoded_namespaces(*i);
+        if (!all.quiet) cerr << *i << " ";
       }
     }
 
@@ -578,10 +577,10 @@ void parse_feature_tweaks(vw& all)
     {
       cerr << "creating features for following interactions: ";
       for (vector<string>::iterator i = vec_arg.begin(); i != vec_arg.end(); ++i)
-      {
-        if (!all.quiet) cerr << *i << " ";
+      {        
         *all.file_options << " --interactions " << *i;
         *i = spoof_hex_encoded_namespaces(*i);
+        if (!all.quiet) cerr << *i << " ";
       }
     }
 

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -391,12 +391,42 @@ void parse_source(vw& all)
 
 bool interactions_settings_doubled = false; // local setting setted in parse_modules()
 
+// return a copy of string replacing \x00 sequences in it
+string spoof_hex_encoded_namespaces(const string& arg)
+{
+    string res;
+    int pos = 0;
+    while (pos < (int)arg.size()-3)
+    {
+        if (arg[pos] == '\\' && arg[pos+1] == 'x')
+        {
+            string substr = arg.substr(pos+2,2);
+            char* p;
+            unsigned char c = (unsigned char) strtoul(substr.c_str(), &p, 16);
+            if (*p == '\0')
+            {
+                res.push_back(c);
+                pos += 4;
+            } else {
+                cerr << "Possibly malformed hex representation of a namespace: '\\x" << substr << "'\n";
+                res.push_back(arg[pos++]);
+            }
+        } else
+            res.push_back(arg[pos++]);
+    }
+
+    while (pos < (int)arg.size()) //copy last 2 characters
+        res.push_back(arg[pos++]);
+
+    return res;
+}
+
 void parse_feature_tweaks(vw& all)
 {
   new_options(all, "Feature options")
   ("hash", po::value< string > (), "how to hash the features. Available options: strings, all")
-  ("ignore", po::value< vector<unsigned char> >(), "ignore namespaces beginning with character <arg>")
-  ("keep", po::value< vector<unsigned char> >(), "keep namespaces beginning with character <arg>")
+  ("ignore", po::value< vector<string> >(), "ignore namespaces beginning with character <arg>")
+  ("keep", po::value< vector<string> >(), "keep namespaces beginning with character <arg>")
   ("redefine", po::value< vector<string> >(), "redefine namespaces beginning with characters of string S as namespace N. <arg> shall be in form 'N:=S' where := is operator. Empty N or S are treated as default namespace. Use ':' as a wildcard in S.")
   ("bit_precision,b", po::value<size_t>(), "number of bits in the feature table")
   ("noconstant", "Don't add a constant feature")
@@ -428,6 +458,7 @@ void parse_feature_tweaks(vw& all)
   if (vm.count("spelling")) {
     vector<string> spelling_ns = vm["spelling"].as< vector<string> >();
     for (size_t id=0; id<spelling_ns.size(); id++) {
+      spelling_ns[id] = spoof_hex_encoded_namespaces(spelling_ns[id]);
       if (spelling_ns[id][0] == '_') all.spelling_features[(unsigned char)' '] = true;
       else all.spelling_features[(size_t)spelling_ns[id][0]] = true;
       *all.file_options << " --spelling " << spelling_ns[id];
@@ -435,7 +466,7 @@ void parse_feature_tweaks(vw& all)
   }
 
   if (vm.count("affix")) {
-    parse_affix_argument(all, vm["affix"].as<string>());
+    parse_affix_argument(all, spoof_hex_encoded_namespaces(vm["affix"].as<string>()));
     *all.file_options << " --affix " << vm["affix"].as<string>();
   }
 
@@ -444,6 +475,8 @@ void parse_feature_tweaks(vw& all)
       THROW("ngram is incompatible with sort_features.");
 
     all.ngram_strings = vm["ngram"].as< vector<string> >();
+    for (size_t i = 0; i < all.ngram_strings.size(); i++)
+        all.ngram_strings[i] = spoof_hex_encoded_namespaces(all.ngram_strings[i]);
     compile_gram(all.ngram_strings, all.ngram, (char*)"grams", all.quiet);
   }
 
@@ -453,6 +486,8 @@ void parse_feature_tweaks(vw& all)
       THROW("You can not skip unless ngram is > 1");
 
     all.skip_strings = vm["skips"].as<vector<string> >();
+    for (size_t i = 0; i < all.skip_strings.size(); i++)
+        all.skip_strings[i] = spoof_hex_encoded_namespaces(all.skip_strings[i]);
     compile_gram(all.skip_strings, all.skips, (char*)"skips", all.quiet);
   }
 
@@ -498,15 +533,16 @@ void parse_feature_tweaks(vw& all)
 
   if (vm.count("quadratic"))
   {
-    const vector<string> vec_arg = vm["quadratic"].as< vector<string> >();
+    vector<string> vec_arg = vm["quadratic"].as< vector<string> >();
     if (!all.quiet)
       cerr << "creating quadratic features for pairs: ";
 
-      for (vector<string>::const_iterator i = vec_arg.begin(); i != vec_arg.end(); ++i)
+      for (vector<string>::iterator i = vec_arg.begin(); i != vec_arg.end(); ++i)
       {
 	if (!all.quiet)
 	  cerr << *i << " ";
         *all.file_options << " --quadratic " << *i;
+        *i = spoof_hex_encoded_namespaces(*i);
       }
 
     expanded_interactions = INTERACTIONS::expand_interactions(vec_arg, 2, "error, quadratic features must involve two sets.");
@@ -520,10 +556,11 @@ void parse_feature_tweaks(vw& all)
     if (!all.quiet)
     {
       cerr << "creating cubic features for triples: ";
-      for (vector<string>::const_iterator i = vec_arg.begin(); i != vec_arg.end(); ++i)
+      for (vector<string>::iterator i = vec_arg.begin(); i != vec_arg.end(); ++i)
       {
         if (!all.quiet) cerr << *i << " ";
         *all.file_options << " --cubic " << *i;
+        *i = spoof_hex_encoded_namespaces(*i);
       }
     }
 
@@ -540,10 +577,11 @@ void parse_feature_tweaks(vw& all)
     if (!all.quiet)
     {
       cerr << "creating features for following interactions: ";
-      for (vector<string>::const_iterator i = vec_arg.begin(); i != vec_arg.end(); ++i)
+      for (vector<string>::iterator i = vec_arg.begin(); i != vec_arg.end(); ++i)
       {
         if (!all.quiet) cerr << *i << " ";
         *all.file_options << " --interactions " << *i;
+        *i = spoof_hex_encoded_namespaces(*i);
       }
     }
 
@@ -595,16 +633,21 @@ void parse_feature_tweaks(vw& all)
   {
     all.ignore_some = true;
 
-    vector<unsigned char> ignore = vm["ignore"].as< vector<unsigned char> >();
-    for (vector<unsigned char>::iterator i = ignore.begin(); i != ignore.end(); i++)
+    vector<string> ignore = vm["ignore"].as< vector<string> >();
+    for (vector<string>::iterator i = ignore.begin(); i != ignore.end(); i++)
     {
-      all.ignore[*i] = true;
+        *i = spoof_hex_encoded_namespaces(*i);
+        for (string::const_iterator j = i->begin(); j != i->end(); j++)
+            all.ignore[(size_t)*j] = true;
+
     }
+
     if (!all.quiet)
     {
       cerr << "ignoring namespaces beginning with: ";
-      for (vector<unsigned char>::iterator i = ignore.begin(); i != ignore.end(); i++)
-        cerr << *i << " ";
+      for (vector<string>::iterator i = ignore.begin(); i != ignore.end(); i++)
+          for (string::const_iterator j = i->begin(); j != i->end(); j++)
+              cerr << *j << " ";
 
       cerr << endl;
     }
@@ -617,18 +660,22 @@ void parse_feature_tweaks(vw& all)
 
     all.ignore_some = true;
 
-    vector<unsigned char> keep = vm["keep"].as< vector<unsigned char> >();
-    for (vector<unsigned char>::iterator i = keep.begin(); i != keep.end(); i++)
+    vector<string> keep = vm["keep"].as< vector<string> >();
+    for (vector<string>::iterator i = keep.begin(); i != keep.end(); i++)
     {
-      all.ignore[*i] = false;
+        *i = spoof_hex_encoded_namespaces(*i);
+        for (string::const_iterator j = i->begin(); j != i->end(); j++)
+            all.ignore[(size_t)*j] = false;
     }
+
     if (!all.quiet)
     {
-      cerr << "using namespaces beginning with: ";
-      for (vector<unsigned char>::iterator i = keep.begin(); i != keep.end(); i++)
-        cerr << *i << " ";
+        cerr << "using namespaces beginning with: ";
+        for (vector<string>::iterator i = keep.begin(); i != keep.end(); i++)
+            for (string::const_iterator j = i->begin(); j != i->end(); j++)
+                cerr << *j << " ";
 
-      cerr << endl;
+        cerr << endl;
     }
   }
 
@@ -647,7 +694,7 @@ void parse_feature_tweaks(vw& all)
     vector< string > arg_list = vm["redefine"].as< vector< string > >();
     for (vector<string>::iterator arg_iter = arg_list.begin(); arg_iter != arg_list.end(); arg_iter++)
     {
-      string arg = *arg_iter;
+      string arg = spoof_hex_encoded_namespaces(*arg_iter);
       size_t arg_len = arg.length();
 
       size_t operator_pos = 0; //keeps operator pos + 1 to stay unsigned type

--- a/vowpalwabbit/parse_args.h
+++ b/vowpalwabbit/parse_args.h
@@ -13,4 +13,5 @@ void parse_sources(vw& all, io_buf& model);
 
 LEARNER::base_learner* setup_base(vw& all);
 
+string spoof_hex_encoded_namespaces(const string& arg);
 // char** get_argv_from_string(string s, int& argc);


### PR DESCRIPTION
resolves #808 
New platform independent format for namespace encoding is `\xAA` where AA is hex code of char.  
In bash it will be `vw -q \\xAA` as \ must be escaped.  
Note: `x` is case sensitive in `\xAA`. Just to decrease probability of accidental use.  
Change affects following vw params: q, cubic, interactions, ignore, keep, redefine, ngram, skips, lrq, lrqfa, affix, spelling.  
As a bonus --ignore and -keep now supports strings as well as single characters:
WAS: ``vw --ignore a --ignore b --ignore c --ignore d --ignore e``
NOW: ``vw --ignore abcde`` OR ``vw --ignore ab --ignore cd --ignore e``