### PR TITLE
Upgrade to VW Java interface to Java 8

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -97,8 +97,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Java 6 has reached it's end-of-life in February 2013. Upgrade to Java 8.
http://www.oracle.com/technetwork/java/eol-135779.html