### PR TITLE
Fix Java interface build failure due to doclint error

### DIFF
--- a/java/src/main/java/vw/learner/VWFloatLearner.java
+++ b/java/src/main/java/vw/learner/VWFloatLearner.java
@@ -1,7 +1,7 @@
 package vw.learner;
 
 /**
- * Created by deak on 10/1/15.
+ * @author deak
  */
 final public class VWFloatLearner extends VWBase {
     public VWFloatLearner(String command) {

--- a/java/src/main/java/vw/learner/VWGeneric.java
+++ b/java/src/main/java/vw/learner/VWGeneric.java
@@ -3,14 +3,14 @@ package vw.learner;
 import java.io.Closeable;
 
 /**
- * Created by deak on 9/27/15.
- *
  * This is the main generic interface to which all VW predictors should adhere.  VW predictors
  * may provided <em>additional methods</em> when the cost of boxing a primitive to an object is
  * too expensive.
  *
  * The recommended way of using this interface is to extend <code>VWGenericBase</code>.
  * See its documentation for more details.
+ *
+ * @author deak
  */
 public interface VWGeneric<T> extends Closeable {
 

--- a/java/src/main/java/vw/learner/VWGenericBase.java
+++ b/java/src/main/java/vw/learner/VWGenericBase.java
@@ -1,19 +1,21 @@
 package vw.learner;
 
 /**
- * Created by deak on 9/27/15.
- *
  * This abstract base class allows the authors of new model wrappers to just write
  * java code like the following:
  *
- * <code>
+ * <pre>
+ * {@code
  * public final class SomeLearner extends VWGenericBase<float[]> {
  *   public VWFloatArrayLearner(String command) { super(command); }
  *   protected native float[] predict(String example, boolean learn, long nativePointer);
  * }
- * </code>
+ * }
+ * </pre>
  *
  * Then the author can simply concentrate on writing the <em>JNI</em> C code.
+ *
+ * @author deak
  */
 abstract class VWGenericBase<T> extends VWBase implements VWGeneric<T> {
     protected VWGenericBase(final String command) {

--- a/java/src/main/java/vw/learner/VWIntLearner.java
+++ b/java/src/main/java/vw/learner/VWIntLearner.java
@@ -1,7 +1,7 @@
 package vw.learner;
 
 /**
- * Created by deak on 10/1/15.
+ * @author deak
  */
 final public class VWIntLearner extends VWBase {
     public VWIntLearner(String command) {


### PR DESCRIPTION
Fix Java interface build failure due to doclint error (with Java 8),
replace IDE generated author attribution with Javadoc compatible one.