### PR TITLE
Implement Java interface native OS library name generation using Maven

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -75,6 +75,15 @@
                 </includes>
             </testResource>
         </testResources>
+
+        <extensions>
+          <extension>
+            <groupId>kr.motd.maven</groupId>
+            <artifactId>os-maven-plugin</artifactId>
+            <version>1.4.0.Final</version>
+          </extension>
+        </extensions>
+        
         <plugins>
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
@@ -157,30 +166,26 @@
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                 </configuration>
             </plugin>
+
             <plugin>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>2.7</version>
-                <executions>
-                    <execution>
-                        <id>copy-resources</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>copy-resources</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
-                            <resources>
-                                <resource>
-                                    <directory>${project.build.directory}</directory>
-                                    <includes>
-                                        <include>vw_jni.*lib</include>
-                                    </includes>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
-                </executions>
+              <groupId>com.coderplus.maven.plugins</groupId>
+              <artifactId>copy-rename-maven-plugin</artifactId>
+              <version>1.0</version>
+              <executions>
+                <execution>
+                  <id>copy-file</id>
+                  <phase>generate-sources</phase>
+                  <goals>
+                    <goal>copy</goal>
+                  </goals>
+                  <configuration>
+                    <sourceFile>${project.build.directory}/vw_jni.lib</sourceFile>
+                    <destinationFile>${project.build.outputDirectory}/vw_jni-${os.detected.release}_${os.detected.release.version}_${os.arch}.lib</destinationFile>
+                  </configuration>
+                </execution>
+              </executions>
             </plugin>
+
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>

--- a/java/src/main/java/vw/jni/NativeUtils.java
+++ b/java/src/main/java/vw/jni/NativeUtils.java
@@ -49,7 +49,7 @@ public class NativeUtils {
             Process process = Runtime.getRuntime().exec("lsb_release -r");
             reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
             String line;
-            Pattern releasePattern = Pattern.compile("Release:\\s*(\\d+).*");
+            Pattern releasePattern = Pattern.compile("Release:\\s*(\\S+).*");
             Matcher matcher;
             while ((line = reader.readLine()) != null) {
                 matcher = releasePattern.matcher(line);
@@ -76,7 +76,7 @@ public class NativeUtils {
     public static String getOsFamily() throws IOException {
         final String osName = System.getProperty("os.name");
         if (osName.toLowerCase().contains("mac")) {
-            return "Darwin";
+            return "darwin";
         }
         else if (osName.toLowerCase().contains("linux")) {
             String distro = getDistroName();
@@ -88,7 +88,7 @@ public class NativeUtils {
             if (version == null) {
                 throw new UnsupportedOperationException("Cannot determine linux version");
             }
-            return distro.trim().replaceAll(" ", "_") + "." + version;
+            return (distro.trim().replaceAll(" ", "_") + "_" + version).toLowerCase();
         }
         throw new IllegalStateException("Unsupported operating system " + osName);
     }
@@ -103,7 +103,7 @@ public class NativeUtils {
      */
     public static void loadOSDependentLibrary(String path, String suffix) throws IOException {
         String osFamily = getOsFamily();
-        String osDependentLib = path + "." + osFamily + "." + System.getProperty("os.arch") + suffix;
+        String osDependentLib = path + "-" + osFamily + "_" + System.getProperty("os.arch") + suffix;
         if (NativeUtils.class.getResource(osDependentLib) != null) {
             loadLibraryFromJar(osDependentLib);
         }

--- a/java/src/main/java/vw/learner/VWFloatLearner.java
+++ b/java/src/main/java/vw/learner/VWFloatLearner.java
@@ -1,7 +1,7 @@
 package vw.learner;
 
 /**
- * Created by deak on 10/1/15.
+ * @author deak
  */
 final public class VWFloatLearner extends VWBase {
     public VWFloatLearner(String command) {

--- a/java/src/main/java/vw/learner/VWGeneric.java
+++ b/java/src/main/java/vw/learner/VWGeneric.java
@@ -3,14 +3,14 @@ package vw.learner;
 import java.io.Closeable;
 
 /**
- * Created by deak on 9/27/15.
- *
  * This is the main generic interface to which all VW predictors should adhere.  VW predictors
  * may provided <em>additional methods</em> when the cost of boxing a primitive to an object is
  * too expensive.
  *
  * The recommended way of using this interface is to extend <code>VWGenericBase</code>.
  * See its documentation for more details.
+ *
+ * @author deak
  */
 public interface VWGeneric<T> extends Closeable {
 

--- a/java/src/main/java/vw/learner/VWGenericBase.java
+++ b/java/src/main/java/vw/learner/VWGenericBase.java
@@ -1,19 +1,21 @@
 package vw.learner;
 
 /**
- * Created by deak on 9/27/15.
- *
  * This abstract base class allows the authors of new model wrappers to just write
  * java code like the following:
  *
- * <code>
+ * <pre>
+ * {@code
  * public final class SomeLearner extends VWGenericBase<float[]> {
  *   public VWFloatArrayLearner(String command) { super(command); }
  *   protected native float[] predict(String example, boolean learn, long nativePointer);
  * }
- * </code>
+ * }
+ * </pre>
  *
  * Then the author can simply concentrate on writing the <em>JNI</em> C code.
+ *
+ * @author deak
  */
 abstract class VWGenericBase<T> extends VWBase implements VWGeneric<T> {
     protected VWGenericBase(final String command) {

--- a/java/src/main/java/vw/learner/VWIntLearner.java
+++ b/java/src/main/java/vw/learner/VWIntLearner.java
@@ -1,7 +1,7 @@
 package vw.learner;
 
 /**
- * Created by deak on 10/1/15.
+ * @author deak
  */
 final public class VWIntLearner extends VWBase {
     public VWIntLearner(String command) {


### PR DESCRIPTION
This PR aims to resolve issues reported in #780 and #807 by implementing native OS library name generation during build-time using Maven.

@jmorra and @petro-rudenko: could you please review and test.

This PR depends on PR #821.

Also, created an issue for `os-maven-plugin` to provide additional OS info: https://github.com/trustin/os-maven-plugin/issues/15