### PR TITLE
Getting build.sh working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ library/library_example
 library/recommend
 library/gd_mf_weights
 library/test_search
+library/search_generate
 test/RunTests.last.times
 *.dSYM
 

--- a/cluster/Makefile
+++ b/cluster/Makefile
@@ -12,7 +12,8 @@ ifeq ($(CXX),)
   $(error No compiler found)
 endif
 
-FLAGS += -I ../vowpalwabbit -std=c++0x 
+FLAGS += -I ../vowpalwabbit
+STDLIBS = $(BOOST_LIBRARY) $(LIBS)
 
 all:	spanning_tree
 
@@ -23,7 +24,7 @@ all:	spanning_tree
 	$(CXX) $(FLAGS) -c $< -o $@
 
 spanning_tree: spanning_tree_main.o ../vowpalwabbit/spanning_tree.o ../vowpalwabbit/vw_exception.o
-	$(CXX) $(FLAGS) -o $@ $+ $(LIBS) 
+	$(CXX) $(FLAGS) -o $@ $+ $(STDLIBS) 
 
 install: spanning_tree
 	cp spanning_tree /usr/local/bin

--- a/java/src/main/c++/jni_base_learner.h
+++ b/java/src/main/c++/jni_base_learner.h
@@ -20,7 +20,7 @@ T base_predict(
         jboolean learn,
         jlong vwPtr,
         const F &predictor) {
-    T result;
+    T result = 0;
     try {
         vw* vwInstance = (vw*)vwPtr;
         const char *utf_string = env->GetStringUTFChars(example_string, NULL);


### PR DESCRIPTION
It would appear that build.sh is broken.  The Centos 5 build was failing because the cluster `Makefile` now requires the boost library.  This fix will supply the boost library when linking the cluster build.