### PR TITLE
Fix RunTests

### DIFF
--- a/test/RunTests
+++ b/test/RunTests
@@ -274,28 +274,24 @@ sub ref_file($) {
     $file;
 }
 
-sub next_paragraph() {
+sub next_paragraph {
     my $paragraph = '';
-    while (! eof(DATA)) {
-        my $line = <DATA>;
 
-        if ($paragraph and ($line =~ /^\s*$/ || eof(DATA))) {
-            # end of paragraph
-            $paragraph .= $line if eof(DATA) && $line !~ /^\s*#/;
-            chomp($paragraph);
-            $paragraph = trim_spaces($paragraph);
-            return $paragraph;
-        }
-
-        next if ($line =~ /^\s*$/);
-        next if ($line =~ /^\s*#/);     # skip comment lines
-
+    while ($line = <DATA>) {
+        next if $line =~ /^\s*#/;       # skip comment lines
         if ($line =~ /\\$/) {           # support line continuation
             $line =~ s/\\\n/ /;
         }
-        $paragraph .= $line;
+        $paragraph .= $line if $line =~ /\w/;
+
+        if ($paragraph and ($line =~ /^\s*$/ || eof(DATA))) {
+            # end of paragraph
+            chomp $paragraph;
+            $paragraph = trim_spaces($paragraph);
+            return $paragraph;
+        }
     }
-    return $paragraph;
+    return;
 }
 
 sub next_test() {
@@ -303,6 +299,7 @@ sub next_test() {
 
     $TestNo++;
     my $paragraph = next_paragraph();
+    return (undef, undef, undef, undef) if !defined $paragraph;
     my @lines = split("\n", $paragraph);
 
     # The command line must be first

--- a/test/RunTests
+++ b/test/RunTests
@@ -281,6 +281,7 @@ sub next_paragraph() {
 
         if ($paragraph and ($line =~ /^\s*$/ || eof(DATA))) {
             # end of paragraph
+            $paragraph .= $line if eof(DATA) && $line !~ /^\s*#/;
             chomp($paragraph);
             $paragraph = trim_spaces($paragraph);
             return $paragraph;
@@ -294,6 +295,7 @@ sub next_paragraph() {
         }
         $paragraph .= $line;
     }
+    return;
 }
 
 sub next_test() {

--- a/test/RunTests
+++ b/test/RunTests
@@ -295,7 +295,7 @@ sub next_paragraph() {
         }
         $paragraph .= $line;
     }
-    return;
+    return $paragraph;
 }
 
 sub next_test() {

--- a/test/train-sets/ref/active_cover_oracular.stderr
+++ b/test/train-sets/ref/active_cover_oracular.stderr
@@ -1,0 +1,31 @@
+Num weight bits = 18
+learning rate = 0.5
+initial_t = 0
+power_t = 0.5
+using no cache
+Reading datafile = ./train-sets/rcv1_small.dat
+num sources = 1
+average  since         example        example  current  current  current
+loss     last          counter         weight    label  predict features
+0.000000 0.000000            1            1.0  -1.0000  -1.0000      128
+0.000000 0.000000            2            2.0  -1.0000  -1.0000       44
+0.250000 0.500000            4            4.0  -1.0000  -1.0000      190
+0.375000 0.500000            8            8.0   1.0000  -1.0000       34
+0.437500 0.500000           16           16.0   1.0000  -1.0000       43
+0.406250 0.375000           32           32.0  -1.0000   1.0000       47
+0.343750 0.281250           64           64.0   1.0000  -1.0000       54
+0.257812 0.171875          128          128.0  -1.0000  -1.0000       67
+0.203125 0.148438          256          256.0   1.0000   1.0000       86
+0.173828 0.144531          512          512.0  -1.0000  -1.0000      104
+
+finished run
+number of examples per pass = 1000
+passes used = 1
+weighted example sum = 1000.000000
+weighted label sum = -82.000000
+average loss = 0.152000
+best constant = -0.164369
+best constant's loss = 0.689781
+total feature number = 78739
+total queries = 996
+


### PR DESCRIPTION
The last line of RunTests was ignored, even if it ended with a newline,
because eof(DATA) is true in that case.
If the last line contained e.g.
  train-sets/ref/active_cover_oracular.stderr
this stderr was not tested.
In this case, the file was missing, so the poor guy,
who would try to add a new test and got an error.