### PR TITLE
install all required headers so that VW can be used as a library

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,7 +14,19 @@ nobase_include_HEADERS = vowpalwabbit/allreduce.h \
 	vowpalwabbit/simple_label.h \
 	vowpalwabbit/v_array.h \
 	vowpalwabbit/vw.h \
-	vowpalwabbit/vwdll.h
+	vowpalwabbit/vwdll.h \
+	vowpalwabbit/label_parser.h \
+	vowpalwabbit/multiclass.h \
+	vowpalwabbit/cost_sensitive.h \
+	vowpalwabbit/cb.h \
+	vowpalwabbit/v_hashmap.h \
+	vowpalwabbit/memory.h \
+	vowpalwabbit/vw_exception.h \
+	vowpalwabbit/vw_validate.h \
+	vowpalwabbit/multilabel.h \
+	vowpalwabbit/constant.h \
+	vowpalwabbit/ezexample.h
+
 
 noinst_HEADERS = vowpalwabbit/accumulate.h \
 	vowpalwabbit/autolink.h \


### PR DESCRIPTION
When installed (``make install``), the header file ``example.h`` is copied into the ``include`` directory but its dependencies aren't. Also, the header ``ezexample.h`` which provides a simpler interface is not installed. This pull request simply adds these files in ``Makefile.am``.