### PR TITLE
Reduce warnings and enable strict aliasing

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,6 +4,7 @@ nobase_include_HEADERS = vowpalwabbit/allreduce.h \
 	vowpalwabbit/comp_io.h \
 	vowpalwabbit/config.h \
 	vowpalwabbit/example.h \
+	vowpalwabbit/floatbits.h \
 	vowpalwabbit/global_data.h \
 	vowpalwabbit/hash.h \
 	vowpalwabbit/io_buf.h \

--- a/vowpalwabbit/Makefile.am
+++ b/vowpalwabbit/Makefile.am
@@ -25,7 +25,7 @@ endif
 if VWBUG
 CXXOPTIMIZE += -g -O1
 else
-CXXOPTIMIZE += -O3 -fomit-frame-pointer -fno-strict-aliasing -DNDEBUG
+CXXOPTIMIZE += -O3 -fomit-frame-pointer -DNDEBUG
 endif
 
 if NITPICK

--- a/vowpalwabbit/Makefile.am
+++ b/vowpalwabbit/Makefile.am
@@ -13,7 +13,7 @@ libvw_la_LIBADD = liballreduce.la
 
 ACLOCAL_AMFLAGS = -I acinclude.d
 
-AM_CXXFLAGS = ${BOOST_CPPFLAGS} ${ZLIB_CPPFLAGS} ${PTHREAD_CFLAGS} -Wall -Wno-unused-local-typedef
+AM_CXXFLAGS = ${BOOST_CPPFLAGS} ${ZLIB_CPPFLAGS} ${PTHREAD_CFLAGS} -Wall -Wno-unused-local-typedefs
 AM_LDFLAGS = ${BOOST_LDFLAGS} ${BOOST_PROGRAM_OPTIONS_LIB} ${ZLIB_LDFLAGS} ${PTHREAD_LIBS}
 
 CXXOPTIMIZE = -ffast-math

--- a/vowpalwabbit/example.h
+++ b/vowpalwabbit/example.h
@@ -28,7 +28,7 @@ struct feature
 { float x;
   uint32_t weight_index;
   bool operator==(feature j) {return weight_index == j.weight_index;}
-  feature(float x=0., uint32_t weight_index=0) : x(x), weight_index(weight_index) {}
+  feature(float x_=0., uint32_t weight_index_=0) : x(x_), weight_index(weight_index_) {}
 };
 
 struct audit_data

--- a/vowpalwabbit/floatbits.h
+++ b/vowpalwabbit/floatbits.h
@@ -1,0 +1,22 @@
+/*
+  Copyright (c) by respective owners including Yahoo!, Microsoft, and
+  individual contributors. All rights reserved.  Released under a BSD
+  license as described in the file LICENSE.
+*/
+#pragma once
+#include <stdint.h>
+#include <string.h>
+
+static inline uint32_t float_to_bits(float a)
+{
+  uint32_t ret;
+  memcpy(&ret, &a, sizeof(uint32_t));
+  return ret;
+}
+
+static inline float bits_to_float(uint32_t a)
+{
+  float ret;
+  memcpy(&ret, &a, sizeof(float));
+  return ret;
+}

--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -23,6 +23,7 @@ license as described in the file LICENSE.
 #include "accumulate.h"
 #include "reductions.h"
 #include "vw.h"
+#include "floatbits.h"
 
 #define VERSION_SAVE_RESUME_FIX "7.10.1"
 
@@ -57,9 +58,9 @@ void sync_weights(vw& all);
 inline float quake_InvSqrt(float x)
 { // Carmack/Quake/SGI fast method:
   float xhalf = 0.5f * x;
-  int i = *(int*)&x; // store floating-point bits in integer
+  int i = float_to_bits(x); // store floating-point bits in integer
   i = 0x5f3759d5 - (i >> 1); // initial guess for Newton's method
-  x = *(float*)&i; // convert new bits into float
+  x = bits_to_float(i); // convert new bits into float
   x = x*(1.5f - xhalf*x*x); // One round of Newton's method
   return x;
 }

--- a/vowpalwabbit/learner.h
+++ b/vowpalwabbit/learner.h
@@ -14,8 +14,6 @@ license as described in the file LICENSE.
 #include "parser.h"
 using namespace std;
 
-void return_simple_example(vw& all, void*, example& ec);
-
 namespace LEARNER
 {
 template<class T> struct learner;

--- a/vowpalwabbit/main.cc
+++ b/vowpalwabbit/main.cc
@@ -11,6 +11,7 @@ license as described in the file LICENSE.
 #endif
 #include <sys/timeb.h>
 #include "parse_args.h"
+#include "parse_regressor.h"
 #include "accumulate.h"
 #include "best_constant.h"
 #include "vw_exception.h"

--- a/vowpalwabbit/parse_args.h
+++ b/vowpalwabbit/parse_args.h
@@ -7,7 +7,6 @@ license as described in the file LICENSE.
 #include "global_data.h"
 
 vw& parse_args(int argc, char *argv[]);
-void parse_regressor_args(vw& all, io_buf& model);
 void parse_modules(vw& all, io_buf& model);
 void parse_sources(vw& all, io_buf& model);
 

--- a/vowpalwabbit/parse_primitives.h
+++ b/vowpalwabbit/parse_primitives.h
@@ -8,6 +8,7 @@ license as described in the file LICENSE.
 #include <stdint.h>
 #include <math.h>
 #include "v_array.h"
+#include "floatbits.h"
 
 #ifdef _WIN32
 #include <WinSock2.h>
@@ -102,8 +103,8 @@ inline float parseFloat(char * p, char **end)
     return (float)strtod(start,end);
 }
 
-inline bool nanpattern( float value ) { return ((*(uint32_t*)&value) & 0x7fC00000) == 0x7fC00000; }
-inline bool infpattern( float value ) { return ((*(uint32_t*)&value) & 0x7fC00000) == 0x7f800000; }
+inline bool nanpattern( float value ) { return (float_to_bits(value) & 0x7fC00000) == 0x7fC00000; }
+inline bool infpattern( float value ) { return (float_to_bits(value) & 0x7fC00000) == 0x7f800000; }
 
 inline float float_of_substring(substring s)
 { char* endptr = s.end;

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -192,12 +192,11 @@ uint32_t cache_numbits(io_buf* buf, int filepointer)
   t.delete_v();
 
   const int total = sizeof(uint32_t);
-  char* p[total];
-  if (buf->read_file(filepointer, p, total) < total)
+  uint32_t cache_numbits;
+  if (buf->read_file(filepointer, &cache_numbits, total) < total)
   { return true;
   }
 
-  uint32_t cache_numbits = *(uint32_t *)p;
   return cache_numbits;
 }
 

--- a/vowpalwabbit/rand48.cc
+++ b/vowpalwabbit/rand48.cc
@@ -1,5 +1,6 @@
 //A quick implementation similar to drand48 for cross-platform compatibility
 #include <stdint.h>
+#include "floatbits.h"
 //
 // NB: the 'ULL' suffix is not part of the constant it is there to
 // prevent truncation of constant to (32-bit long) when compiling
@@ -16,7 +17,7 @@ int bias = 127 << 23;
 float merand48(uint64_t& initial)
 { initial = a * initial + c;
   int32_t temp = ((initial >> 25) & 0x7FFFFF) | bias;
-  return *(float *)&temp - 1;
+  return bits_to_float(temp) - 1;
 }
 
 uint64_t v = c;

--- a/vowpalwabbit/v_array.h
+++ b/vowpalwabbit/v_array.h
@@ -47,7 +47,7 @@ public:
   }
   T& operator[](size_t i) { return begin[i]; }
   T& get(size_t i) { return begin[i]; }
-  inline const size_t size() {return end-begin;}
+  inline size_t size() {return end-begin;}
   void resize(size_t length)
   { if ((size_t)(end_array-begin) != length)
     { size_t old_len = end-begin;

--- a/vowpalwabbit/vw.h
+++ b/vowpalwabbit/vw.h
@@ -9,6 +9,7 @@ license as described in the file LICENSE.
 #include "hash.h"
 #include "simple_label.h"
 #include "parser.h"
+#include "parse_example.h"
 
 namespace VW
 {
@@ -62,7 +63,6 @@ example* import_example(vw& all, string label, primitive_feature_space* features
 example *alloc_examples(size_t, size_t);
 void dealloc_example(void(*delete_label)(void*), example&ec, void(*delete_prediction)(void*) = nullptr);
 
-void read_line(vw& all, example* ex, char* line);
 void parse_example_label(vw&all, example&ec, string label);
 void setup_example(vw& all, example* ae);
 example* new_unused_example(vw& all);


### PR DESCRIPTION

These changes reduce the levels of warnings that can be generated from the headers. These are only seen with --enable-nitpick or if the headers are included in a source base that has those some of those additional warnings enabled.

In the process it fixes the aliasing warnings and removes -fno-strict-aliasing. The latter is a behavioural change which should provide potentially better optimization of the code but may cause bugs if subtle alias issues are present in the code. The tests still pass and I went back into the git history but couldn't find the precise reason why the flag was added in the first place.
