### PR TITLE
Small refactorization in parser.cc::delete_mutex()

### DIFF
--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -62,14 +62,14 @@ void initialize_mutex(MUTEX * pm)
 #endif
 }
 
+#ifndef _WIN32
+void delete_mutex(MUTEX *) { /* no operation necessary here*/ }
+#else
 void delete_mutex(MUTEX * pm)
 {
-#ifndef _WIN32
-  // no operation necessary here
-#else
   ::DeleteCriticalSection(pm);
-#endif
 }
+#endif
 
 void initialize_condition_variable(CV * pcv)
 {


### PR DESCRIPTION
Every time I get a warning about unused argument in `delete_mutex()` during linux build I'm tempted to comment `pm` out. But it'll break the code for Win32 builds. Let's just refactorize this function a little.