### PR TITLE
removed use of std::to_string

### DIFF
--- a/explore/static/MWTExplorer.h
+++ b/explore/static/MWTExplorer.h
@@ -174,7 +174,7 @@ MWT_NAMESPACE
   struct StringRecorder : public IRecorder<Ctx>
   { void Record(Ctx& context, u32 action, float probability, string unique_key)
     { // Implicitly enforce To_String() API on the context
-      m_recording.append(to_string((unsigned long long)action));
+      m_recording.append(StringUtils::to_string(action));
       m_recording.append(" ", 1);
       m_recording.append(unique_key);
       m_recording.append(" ", 1);

--- a/explore/static/utility.h
+++ b/explore/static/utility.h
@@ -226,6 +226,24 @@ public:
     }
   };
 
+  class StringUtils
+  { public:
+    static inline string to_string(size_t& n)
+    {
+      const int buf_size = 512;
+      char buff[buf_size];
+      sprintf_s(buff, buf_size, "%llu", (unsigned long long)n);
+      return string(buff);
+    }
+    static inline string to_string(u32& n)
+    {
+      const int buf_size = 512;
+      char buff[buf_size];
+      sprintf_s(buff, buf_size, "%u", (unsigned int)n);
+      return string(buff);
+    }
+  };
+
 //A quick implementation similar to drand48 for cross-platform compatibility
   namespace PRG {
   const uint64_t a = 0xeece66d5deece66dULL;

--- a/vowpalwabbit/cbify.cc
+++ b/vowpalwabbit/cbify.cc
@@ -147,7 +147,7 @@ void predict_or_learn_first(cbify& data, base_learner& base, example& ec)
   //Use CB to find current prediction for remaining rounds.
 
   vw_context vwc = {data, base, ec};
-  uint32_t action = data.mwt_explorer->Choose_Action(*data.tau_explorer, to_string((unsigned long long)ec.example_counter), vwc);
+  uint32_t action = data.mwt_explorer->Choose_Action(*data.tau_explorer, StringUtils::to_string(ec.example_counter), vwc);
 
   if (vwc.recorded && is_learn)
   { CB::cb_class l = {loss(ld.label, action), action, data.recorder->probability };
@@ -169,7 +169,7 @@ void predict_or_learn_greedy(cbify& data, base_learner& base, example& ec)
   ec.l.cb = data.cb_label;
 
   vw_context vwc = {data, base, ec};
-  uint32_t action = data.mwt_explorer->Choose_Action(*data.greedy_explorer, to_string((unsigned long long)ec.example_counter), vwc);
+  uint32_t action = data.mwt_explorer->Choose_Action(*data.greedy_explorer, StringUtils::to_string(ec.example_counter), vwc);
 
   if (is_learn)
   { CB::cb_class l = { loss(ld.label, action), action, data.recorder->probability };
@@ -192,7 +192,7 @@ void predict_or_learn_bag(cbify& data, base_learner& base, example& ec)
   ec.l.cb = data.cb_label;
 
   vw_context context = {data, base, ec};
-  uint32_t action = data.mwt_explorer->Choose_Action(*data.bootstrap_explorer, to_string((unsigned long long)ec.example_counter), context);
+  uint32_t action = data.mwt_explorer->Choose_Action(*data.bootstrap_explorer, StringUtils::to_string(ec.example_counter), context);
 
   if (is_learn)
   { CB::cb_class l = {loss(ld.label, action),
@@ -274,7 +274,7 @@ void predict_or_learn_cover(cbify& data, base_learner& base, example& ec)
   float min_prob = epsilon * min(1.f / data.k, 1.f / (float)sqrt(counter * data.k));
 
   vw_context cp = {data, base, ec};
-  uint32_t action = data.mwt_explorer->Choose_Action(*data.generic_explorer, to_string((unsigned long long)ec.example_counter), cp);
+  uint32_t action = data.mwt_explorer->Choose_Action(*data.generic_explorer, StringUtils::to_string(ec.example_counter), cp);
 
   if (is_learn)
   { data.cb_label.costs.erase();

--- a/vowpalwabbit/multiclass.cc
+++ b/vowpalwabbit/multiclass.cc
@@ -4,6 +4,10 @@
 #include "vw.h"
 #include "vw_exception.h"
 
+#ifndef _WIN32
+#define sprintf_s snprintf
+#endif
+
 namespace MULTICLASS
 {
 
@@ -101,11 +105,17 @@ void print_update(vw& all, example &ec)
 
 void print_update_with_probability(vw& all, example &ec, uint32_t prediction)
 { if (all.sd->weighted_examples >= all.sd->dump_interval && !all.quiet && !all.bfgs)
-  { char temp_str[10];
-    sprintf(temp_str, "%d(%2.0f%%)", prediction, 100*ec.pred.probs[prediction-1]);
-    if (! all.sd->ldict)
-      all.sd->print_update(all.holdout_set_off, all.current_pass, std::to_string(ec.l.multi.label), temp_str,
-                           ec.num_features, all.progress_add, all.progress_arg);
+  { if (!all.sd->ldict)
+    {
+      char temp_str[10];
+      sprintf_s(temp_str, 10, "%d(%2.0f%%)", prediction, 100 * ec.pred.probs[prediction - 1]);
+
+      char label_str[512];
+      sprintf_s(label_str, 512, "%u", ec.l.multi.label);
+
+      all.sd->print_update(all.holdout_set_off, all.current_pass, label_str, temp_str,
+        ec.num_features, all.progress_add, all.progress_arg);
+    }
     else
     { substring ss_label = all.sd->ldict->get(ec.l.multi.label);
       substring ss_pred  = all.sd->ldict->get(prediction);

--- a/vowpalwabbit/vwdll.cpp
+++ b/vowpalwabbit/vwdll.cpp
@@ -239,8 +239,8 @@ extern "C"
   
   VW_DLL_MEMBER float VW_CALLING_CONV VW_PredictCostSensitive(VW_HANDLE handle, VW_EXAMPLE e)
   {
-    vw * pointer = static_cast(handle);
-    example * ex = static_cast(e);
+    vw * pointer = static_cast<vw*>(handle);
+    example * ex = static_cast<example*>(e);
     pointer->l->predict(*ex);
     return VW::get_cost_sensitive_prediction(ex);
   }


### PR DESCRIPTION
Removing all references to std::to_string to avoid build issues with other platforms (such as Cygwin). I didn't hear back from cygwin on whether there's a workaround for the "to_string not declared" error so am rewriting it using sprintf_s, which is actually faster. Linux tests ran ok, and cygwin no longer complains about this. 