### PR TITLE
sync bin_text_write and bin_write for empty obj

### DIFF
--- a/vowpalwabbit/io_buf.h
+++ b/vowpalwabbit/io_buf.h
@@ -182,7 +182,7 @@ public:
 
   virtual void flush()
   { if (files.size() > 0)
-    { if (write_file(files[0], space.begin, head - space.begin) != (int) (head - space.begin))
+      { if (write_file(files[0], space.begin, head - space.begin) != (int) (head - space.begin))
         std::cerr << "error, failed to write example\n";
       head = space.begin;
     }
@@ -267,7 +267,7 @@ inline size_t bin_text_write(io_buf& io, char* data, uint32_t len,
                              const char* text_data, uint32_t text_len, bool text)
 { if (text)
     return bin_write_fixed (io, text_data, text_len);
-  else if (len > 0)
+  else
     return bin_write (io, data, len);
   return 0;
 }


### PR DESCRIPTION
refers #876

> about confusing inconsistency in bin_text_write and bin_write. They store 0-length objects in a different way. 1st one write nothing while 2nd one write 4 zero bytes (length). 2nd approach would be better for saving empty strings (no need to store trailing 0 byte), but changing this may make models binary incompatible.

Now bin_text_write behaves as  bin_write 

the line 185 seems to be changed by my browser as I've edited the file online on github. Let me know if this is unwanted.