### PR TITLE
Bugfix of compilation error

### DIFF
--- a/vowpalwabbit/memory.h
+++ b/vowpalwabbit/memory.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <stdlib.h>
+#include <stdio.h>
 #include <iostream>
 
 template<class T>


### PR DESCRIPTION
Was previously throwing a compilation error that stderr was not defined in the call to fputs(...) on what's now line 15 and was [introduced in](https://github.com/wbt/vowpal_wabbit/blob/d1697f80fe2f174b7acd55ec64f2415632bc97df/vowpalwabbit/memory.h) version d1697f8. 