### PR TITLE
java NativeUtils: lsb_release to get linux distro and version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ These prerequisites are usually pre-installed on many platforms. However, you ma
 manager (*yum*, *apt*, *MacPorts*, *brew*, ...) to install missing software.
 
 - [Boost](http://www.boost.org) library, with the `Boost::Program_Options` library option enabled.
+- lsb-release  (RedHat/CentOS: redhat-lsb-core, Debian: lsb-release, Ubuntu: you're all set, OSX: not required)
 - GNU *autotools*: *autoconf*, *automake*, *libtool*, *autoheader*, et. al. This is not a strict prereq. On many systems (notably Ubuntu with `libboost-program-options-dev` installed), the provided `Makefile` works fine.
 - (optional) [git](http://git-scm.com) if you want to check out the latest version of *vowpal wabbit*,
   work on the code, or even contribute code to the main project.
@@ -133,13 +134,16 @@ brew install vowpal-wabbit
 ```
 [The homebrew formula for VW is located on github](https://github.com/Homebrew/homebrew/blob/master/Library/Formula/vowpal-wabbit.rb).
 
-### brew install dependencies + manual install of vowpal wabbit
+### Manual install ov Vowpal Wabbit
+#### OSX Dependencies (if using Brew): 
 ```
 brew install libtool
+brew install autoconf
+brew install automake
 brew install boost --with-python
 ```
 
-### MacPorts
+#### OSX Dependencies (if using MacPorts):
 ```
 ## Install glibtool and other GNU autotool friends:
 $ port install libtool autoconf automake
@@ -151,6 +155,7 @@ $ port install boost +no_single +no_static +openmpi +python27 configure.cxx_stdl
 $ port install boost +no_single +no_static +openmpi +python27
 ```
 
+#### OSX Manual compile:
 *Mac OS X 10.8 and below*: ``configure.cxx_stdlib=libc++`` and ``configure.cxx=clang++`` ensure that ``clang++`` uses
 the correct C++11 functionality while building Boost. Ordinarily, ``clang++`` relies on the older GNU ``g++`` 4.2 series
 header files and ``stdc++`` library; ``libc++`` is the ``clang`` replacement that provides newer C++11 functionality. If

--- a/java/src/main/bin/build.sh
+++ b/java/src/main/bin/build.sh
@@ -29,7 +29,7 @@ $make_base
 mv java/target/vw_jni.lib java/target/vw_jni.Ubuntu.14.amd64.lib"
 
 early_red_hat="yum update -q -y
-yum install -q -y wget which zlib-devel java-1.7.0-openjdk-devel perl;
+yum install -q -y wget which zlib-devel java-1.7.0-openjdk-devel perl redhat-lsb-core;
 cd /etc/yum.repos.d;
 wget http://people.centos.org/tru/devtools-2/devtools-2.repo;
 yum clean all;
@@ -55,7 +55,7 @@ make -f Makefile.permissive;
 rm -f Makefile.permissive;
 mv java/target/vw_jni.lib java/target/vw_jni.Red_Hat.6.amd64.lib"
 
-red_hat_7="yum install -q -y gcc-c++ make boost-devel zlib-devel java-1.7.0-openjdk-devel perl;
+red_hat_7="yum install -q -y gcc-c++ make boost-devel zlib-devel java-1.7.0-openjdk-devel perl redhat-lsb-core;
 export JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk;
 $make_base
 mv java/target/vw_jni.lib java/target/vw_jni.Red_Hat.7.amd64.lib"

--- a/java/src/main/bin/build.sh
+++ b/java/src/main/bin/build.sh
@@ -11,7 +11,7 @@ make clean;
 make vw java;"
 
 ubuntu_base="apt-get update -qq;
-apt-get install -qq software-properties-common g++ make libboost-all-dev default-jdk;"
+apt-get install -qq software-properties-common g++ make libboost-program-options-dev default-jdk;"
 
 ubuntu_12="$ubuntu_base
 export JAVA_HOME=/usr/lib/jvm/java-6-openjdk-amd64;
@@ -55,7 +55,8 @@ make -f Makefile.permissive vw java;
 rm -f Makefile.permissive;
 mv java/target/vw_jni.lib java/target/vw_jni.Red_Hat.6.amd64.lib"
 
-red_hat_7="yum install -q -y gcc-c++ make boost-devel zlib-devel java-1.7.0-openjdk-devel perl clang redhat-lsb-core;
+red_hat_7="yum update -q -y;
+yum install -q -y gcc-c++ make boost-devel zlib-devel java-1.7.0-openjdk-devel perl clang redhat-lsb-core;
 export JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk;
 $make_base
 mv java/target/vw_jni.lib java/target/vw_jni.Red_Hat.7.amd64.lib"
@@ -145,6 +146,7 @@ install_brew_app "docker-machine"
 install_brew_app "docker"
 
 docker-machine create --driver virtualbox default
+docker-machine start default
 eval "$(docker-machine env default)"
 
 set -e
@@ -165,5 +167,5 @@ run_docker "centos:6" "$red_hat_6"
 run_docker "centos:7" "$red_hat_7"
 
 make clean
-make
+make vw java
 mv java/target/vw_jni.lib java/target/vw_jni.$(uname -s).$(uname -m).lib

--- a/java/src/main/bin/build.sh
+++ b/java/src/main/bin/build.sh
@@ -8,7 +8,7 @@ __brew_not_installed=2
 
 make_base="cd /vowpal_wabbit;
 make clean;
-make;"
+make vw java;"
 
 ubuntu_base="apt-get update -qq;
 apt-get install -qq software-properties-common g++ make libboost-all-dev default-jdk;"
@@ -44,18 +44,18 @@ yum install -q -y make epel-release;
 yum install -q -y boost141-devel;
 make clean;
 cat Makefile.permissive | sed 's/BOOST_LIBRARY = -L \/usr\/lib/BOOST_LIBRARY = -L \/usr\/lib64\/boost141/g' | sed 's/BOOST_INCLUDE = -I \/usr\/include/BOOST_INCLUDE = -I \/usr\/include\/boost141/g' > Makefile.permissive.boost141;
-make -f Makefile.permissive.boost141;
+make -f Makefile.permissive.boost141 vw java;
 rm -f Makefile.permissive Makefile.permissive.boost141;
 mv java/target/vw_jni.lib java/target/vw_jni.Red_Hat.5.amd64.lib"
 
 red_hat_6="$early_red_hat
 yum install -q -y boost-devel;
 make clean;
-make -f Makefile.permissive;
+make -f Makefile.permissive vw java;
 rm -f Makefile.permissive;
 mv java/target/vw_jni.lib java/target/vw_jni.Red_Hat.6.amd64.lib"
 
-red_hat_7="yum install -q -y gcc-c++ make boost-devel zlib-devel java-1.7.0-openjdk-devel perl redhat-lsb-core;
+red_hat_7="yum install -q -y gcc-c++ make boost-devel zlib-devel java-1.7.0-openjdk-devel perl clang redhat-lsb-core;
 export JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk;
 $make_base
 mv java/target/vw_jni.lib java/target/vw_jni.Red_Hat.7.amd64.lib"
@@ -131,7 +131,7 @@ install_cask_app() {
 run_docker() {
   local machine=$1
   local script=$2
-  docker run -v $(pwd):/vowpal_wabbit $machine /bin/bash -c "$script"
+  docker run --rm -v $(pwd):/vowpal_wabbit $machine /bin/bash -c "$script"
 }
 
 # =============================================================================
@@ -147,6 +147,9 @@ install_brew_app "docker"
 docker-machine create --driver virtualbox default
 eval "$(docker-machine env default)"
 
+set -e
+set -u
+set -x
 run_docker "ubuntu:12.04" "$ubuntu_12"
 run_docker "32bit/ubuntu:14.04" "$ubuntu_14_32"
 run_docker "ubuntu:14.04" "$ubuntu_14"

--- a/java/src/main/bin/build.sh
+++ b/java/src/main/bin/build.sh
@@ -11,7 +11,7 @@ make clean;
 make vw java;"
 
 ubuntu_base="apt-get update -qq;
-apt-get install -qq software-properties-common g++ make libboost-program-options-dev default-jdk;"
+apt-get install -qq software-properties-common g++ make libboost-program-options-dev zlib1g-dev default-jdk;"
 
 ubuntu_12="$ubuntu_base
 export JAVA_HOME=/usr/lib/jvm/java-6-openjdk-amd64;

--- a/java/src/main/java/vw/jni/NativeUtils.java
+++ b/java/src/main/java/vw/jni/NativeUtils.java
@@ -20,7 +20,10 @@ public class NativeUtils {
     }
 
     /**
-     * lsb_args = "-i", regexp = "Distributor ID: *(.*)$"
+     * Shell call to lsb_release to get OS info
+     * @param lsb_args parameters to lsb_release.  EX: "-i" or "-a"
+     * @param regexp a regular expression pattern used to parse the response from lsb_release
+     *   For example:  lsb_args = "-i", regexp = "Distributor ID: *(.*)$"
      */
     public static String lsbRelease(String lsb_args, Pattern regexp) throws IOException {
         BufferedReader reader = null;

--- a/java/src/main/java/vw/jni/NativeUtils.java
+++ b/java/src/main/java/vw/jni/NativeUtils.java
@@ -24,6 +24,8 @@ public class NativeUtils {
      * @param lsb_args parameters to lsb_release.  EX: "-i" or "-a"
      * @param regexp a regular expression pattern used to parse the response from lsb_release
      *   For example:  lsb_args = "-i", regexp = "Distributor ID: *(.*)$"
+     * @return A system dependent string identifying the OS.
+     * @throws IOException If an error occurs while running shell command
      */
     public static String lsbRelease(String lsb_args, Pattern regexp) throws IOException {
         BufferedReader reader = null;

--- a/java/src/main/java/vw/jni/NativeUtils.java
+++ b/java/src/main/java/vw/jni/NativeUtils.java
@@ -22,7 +22,7 @@ public class NativeUtils {
     /**
      * lsb_args = "-i", regexp = "Distributor ID: *(.*)$"
      */
-    public static String lsb_release(String lsb_args, Pattern regexp) throws IOException {
+    public static String lsbRelease(String lsb_args, Pattern regexp) throws IOException {
         BufferedReader reader = null;
         try {
             Process process = Runtime.getRuntime().exec("lsb_release " + lsb_args);
@@ -48,7 +48,7 @@ public class NativeUtils {
      * @throws IOException If an I/O error occurs
      */
     public static String getDistroName() throws IOException {
-        return lsb_release("-i", Pattern.compile("Distributor ID:\\s*(.*)\\s*$"));
+        return lsbRelease("-i", Pattern.compile("Distributor ID:\\s*(.*)\\s*$"));
     }
 
     /**
@@ -57,7 +57,7 @@ public class NativeUtils {
      * @throws IOException If an I/O error occurs
      */
     public static String getLinuxVersion() throws IOException {
-        return lsb_release("-r", Pattern.compile("Release:\\s*(.*)\\s*$"));
+        return lsbRelease("-r", Pattern.compile("Release:\\s*(.*)\\s*$"));
     }
 
     /**

--- a/java/src/main/java/vw/jni/NativeUtils.java
+++ b/java/src/main/java/vw/jni/NativeUtils.java
@@ -79,12 +79,13 @@ public class NativeUtils {
             if (distro == null) {
                 throw new UnsupportedEncodingException("Cannot determine linux distribution");
             }
-
             String version = getLinuxVersion();
             if (version == null) {
                 throw new UnsupportedOperationException("Cannot determine linux version");
             }
-            return String.format("%s.%s", distro, version.split("\\.")[0]);
+            // get the major version.
+            // don't expect a period because linux version might not have one
+            return distro + "." + version.split("\\.")[0];
         }
         throw new IllegalStateException("Unsupported operating system " + osName);
     }


### PR DESCRIPTION
closes #894 
related:  #807 #780 #822

a change to java NativeUtils class to attempt more standardized access to linux distro and version
fixes a couple bugs in build.sh
updates readme


@jmorra Build.sh passes up to the last 3 lines, where I have issues (unrelated to this PR) compiling the C code on my mac.  After some bug fixes to build.sh, VW appears to compile correctly in the linux docker images.   Could you check out this branch and try to compile it on your mac?  Or if you happen to know what's wrong in the traceback below, that would be helpful.  I wouldn't think this change should prevent VW java from working on mac, as the changes relate to linux issues, but it probably makes sense to check.

---

Some error msgs (unrelated to this PR) that I get when trying to manually compile VW on my mac (10.11.2):
```
./../explore/cpp/utility.h:241:24: note: candidate function not viable: no known conversion from
      'size_t' (aka 'unsigned long') to 'u32 &' (aka 'unsigned int &') for 1st argument
  static inline string to_string(u32& n)
                       ^
cbify.cc:277:78: error: no matching function for call to 'to_string'
  ...= data.mwt_explorer->Choose_Action(*data.generic_explorer, StringUtils::to_string(ec.exa...
              ```