### PR TITLE
Enable marking weight vector to be sharable using KSM

### DIFF
--- a/vowpalwabbit/memory.h
+++ b/vowpalwabbit/memory.h
@@ -44,7 +44,10 @@ T* calloc_mergable_or_throw(size_t nmemb)
 // it allows to save memory if you run multiple instances of the same model
 // see more https://www.kernel.org/doc/Documentation/vm/ksm.txt
 // you need to have Linux kernel >= 2.6.32 and KSM enabled
-// to check is KSM enabled: `grep KSM /boot/config-`uname -r` CONFIG_KSM=y`
+// to check is KSM enabled run the command
+// $ grep KSM /boot/config-`uname -r`
+// if KSM is enabled you should see:
+// >> CONFIG_KSM=y
 // you can enable ksmd with sudo "echo 1 > /sys/kernel/mm/ksm/run"
 // mark address space as a candidate for merging
 

--- a/vowpalwabbit/memory.h
+++ b/vowpalwabbit/memory.h
@@ -55,19 +55,8 @@ T* calloc_mergable_or_throw(size_t nmemb)
     const char* msg = "internal warning: marking memory as ksm mergeable failed!\n";
     fputs(msg, stderr);
   }
-
-  void* data = calloc(nmemb, sizeof(T));
-  if (data == nullptr)
-  { const char* msg = "internal error: memory allocation failed!\n";
-    // use low-level function since we're already out of memory.
-    fputs(msg, stderr);
-    THROW(msg);
-  }
-
   return (T*)data;
 }
-template<class T> T& calloc_mergable_or_throw()
-{ return *calloc_mergable_or_throw<T>(1); }
 #else
 #define calloc_mergable_or_throw calloc_or_throw
 #endif

--- a/vowpalwabbit/memory.h
+++ b/vowpalwabbit/memory.h
@@ -21,4 +21,44 @@ T* calloc_or_throw(size_t nmemb)
 template<class T> T& calloc_or_throw()
 { return *calloc_or_throw<T>(1); }
 
+template<class T>
+T* calloc_mergable_or_throw(size_t nmemb)
+{ if (nmemb == 0)
+    return nullptr;
+
+  size_t length = nmemb * sizeof(T);
+  void* data;
+  if (0 != posix_memalign(&data, sysconf(_SC_PAGE_SIZE), length))
+  {
+    const char* msg = "internal error: memory allocation failed!\n";
+    fputs(msg, stderr);
+    THROW(msg);
+  }
+  if (data == nullptr)
+  { const char* msg = "internal error: memory allocation failed!\n";
+    fputs(msg, stderr);
+    THROW(msg);
+  }
+  memset(data, 0, lengh);
+#ifdef MADV_MERGEABLE
+// mark weight vector as KSM sharable
+// it allows to save memory if you run multiple instances of the same model
+// see more https://www.kernel.org/doc/Documentation/vm/ksm.txt
+// you need to have Linux kernel >= 2.6.32 and KSM enabled
+// to check is KSM enabled: `grep KSM /boot/config-`uname -r` CONFIG_KSM=y`
+// you can enable ksmd with sudo "echo 1 > /sys/kernel/mm/ksm/run"
+// mark address space as a candidate for merging
+
+  if (0 != madvise(data, length, MADV_MERGEABLE)) {
+    const char* msg = "internal warning: marking memory as ksm mergeable failed!\n";
+    fputs(msg, stderr);
+  }
+#endif
+  return (T*)data;
+}
+
+template<class T> T& calloc_mergable_or_throw()
+{ return *calloc_mergable_or_throw<T>(1); }
+
+
 inline void free_it(void* ptr) { if (ptr != nullptr) free(ptr); ptr = nullptr; }

--- a/vowpalwabbit/memory.h
+++ b/vowpalwabbit/memory.h
@@ -69,7 +69,7 @@ T* calloc_mergable_or_throw(size_t nmemb)
 template<class T> T& calloc_mergable_or_throw()
 { return *calloc_mergable_or_throw<T>(1); }
 #else
-#define calloc_mergable_or_throw calloc_mergable_or_throw
+#define calloc_mergable_or_throw calloc_or_throw
 #endif
 
 

--- a/vowpalwabbit/memory.h
+++ b/vowpalwabbit/memory.h
@@ -39,7 +39,7 @@ T* calloc_mergable_or_throw(size_t nmemb)
     fputs(msg, stderr);
     THROW(msg);
   }
-  memset(data, 0, lengh);
+  memset(data, 0, length);
 // mark weight vector as KSM sharable
 // it allows to save memory if you run multiple instances of the same model
 // see more https://www.kernel.org/doc/Documentation/vm/ksm.txt

--- a/vowpalwabbit/memory.h
+++ b/vowpalwabbit/memory.h
@@ -21,11 +21,11 @@ T* calloc_or_throw(size_t nmemb)
 template<class T> T& calloc_or_throw()
 { return *calloc_or_throw<T>(1); }
 
+#ifdef MADV_MERGEABLE
 template<class T>
 T* calloc_mergable_or_throw(size_t nmemb)
 { if (nmemb == 0)
     return nullptr;
-#ifdef MADV_MERGEABLE
   size_t length = nmemb * sizeof(T);
   void* data;
   if (0 != posix_memalign(&data, sysconf(_SC_PAGE_SIZE), length))
@@ -55,7 +55,7 @@ T* calloc_mergable_or_throw(size_t nmemb)
     const char* msg = "internal warning: marking memory as ksm mergeable failed!\n";
     fputs(msg, stderr);
   }
-#else
+
   void* data = calloc(nmemb, sizeof(T));
   if (data == nullptr)
   { const char* msg = "internal error: memory allocation failed!\n";
@@ -63,12 +63,15 @@ T* calloc_mergable_or_throw(size_t nmemb)
     fputs(msg, stderr);
     THROW(msg);
   }
-#endif
+
   return (T*)data;
 }
-
 template<class T> T& calloc_mergable_or_throw()
 { return *calloc_mergable_or_throw<T>(1); }
+#else
+#define calloc_mergable_or_throw calloc_mergable_or_throw
+#endif
+
 
 
 inline void free_it(void* ptr) { if (ptr != nullptr) free(ptr); ptr = nullptr; }

--- a/vowpalwabbit/parse_regressor.cc
+++ b/vowpalwabbit/parse_regressor.cc
@@ -34,7 +34,7 @@ void initialize_regressor(vw& all)
   size_t length = ((size_t)1) << all.num_bits;
   all.reg.weight_mask = (length << all.reg.stride_shift) - 1;
   try
-    { all.reg.weight_vector = calloc_or_throw<weight>(length << all.reg.stride_shift);
+    { all.reg.weight_vector = calloc_mergable_or_throw<weight>(length << all.reg.stride_shift);
     }
   catch (VW::vw_exception anExc)
     { THROW(" Failed to allocate weight array with " << all.num_bits << " bits: try decreasing -b <bits>");


### PR DESCRIPTION
This would mark weight vector as KSM sharable:
Doing so allows to save memory if you run multiple instances of the same model in read only mode.
See more https://www.kernel.org/doc/Documentation/vm/ksm.txt
To make use of this feature you'll need to have Linux kernel >= 2.6.32 and KSM enabled
To check is KSM enabled run the command

    $ grep KSM /boot/config-`uname -r`

if KSM is enabled you should see:

    >> CONFIG_KSM=y

You can enable KSM with command:

     $ sudo "echo 1 > /sys/kernel/mm/ksm/run"

To monitor shared pages use command:

    $ grep [0123456789] /sys/kernel/mm/ksm/*

Here is an example of shared pages - two VW models (24 bits each) are shared between 14 processes. 32770 (4Kb each) unique pages_shared, pages_sharing - 425998 pages.

    /sys/kernel/mm/ksm/full_scans:251
    /sys/kernel/mm/ksm/merge_across_nodes:1
    /sys/kernel/mm/ksm/pages_shared:32770
    /sys/kernel/mm/ksm/pages_sharing:425998
    /sys/kernel/mm/ksm/pages_to_scan:100
    /sys/kernel/mm/ksm/pages_unshared:0
    /sys/kernel/mm/ksm/pages_volatile:0
    /sys/kernel/mm/ksm/run:1
    /sys/kernel/mm/ksm/sleep_millisecs:20
