### PR TITLE
Fixed init_driver call

### DIFF
--- a/cs/cli/vowpalwabbit.cpp
+++ b/cs/cli/vowpalwabbit.cpp
@@ -73,7 +73,7 @@ namespace VW
       {
         adjust_used_index(*m_vw);
         m_vw->do_reset_source = true;
-        VW::start_parser(*m_vw, false);
+        VW::start_parser(*m_vw);
         LEARNER::generic_driver(*m_vw);
         VW::end_parser(*m_vw);
       }

--- a/cs/cli/vw_base.h
+++ b/cs/cli/vw_base.h
@@ -50,11 +50,6 @@ namespace VW
         VowpalWabbitArguments^ m_arguments;
 
         /// <summary>
-        /// Initialize from passed model.
-        /// </summary>
-        void InitializeFromModel(string args, io_buf& model);
-
-        /// <summary>
         /// Reference count to native data structure.
         /// </summary>
         System::Int32 m_instanceCount;

--- a/library/ezexample_predict.cc
+++ b/library/ezexample_predict.cc
@@ -6,7 +6,7 @@
 using namespace std;
 
 int main(int argc, char *argv[])
-{ string init_string = "-t -q st --hash all --noconstant --ldf_override s -i ";
+{ string init_string = "-t -q st --hash all --noconstant --ldf_override s --no_stdin -i ";
   if (argc > 1)
     init_string += argv[1];
   else

--- a/library/library_example.cc
+++ b/library/library_example.cc
@@ -12,7 +12,7 @@ inline feature vw_feature_from_string(vw& v, string fstr, unsigned long seed, fl
 }
 
 int main(int argc, char *argv[])
-{ vw* model = VW::initialize("--hash all -q st --noconstant -i train.w -f train2.vw");
+{ vw* model = VW::initialize("--hash all -q st --noconstant -i train.w -f train2.vw --no_stdin");
 
   example *vec2 = VW::read_example(*model, (char*)"|s p^the_man w^the w^man |t p^un_homme w^un w^homme");
   model->learn(vec2);
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
 
   VW::finish(*model);
 
-  vw* model2 = VW::initialize("--hash all -q st --noconstant -i train2.vw");
+  vw* model2 = VW::initialize("--hash all -q st --noconstant -i train2.vw --no_stdin");
   vec2 = VW::read_example(*model2, (char*)" |s p^the_man w^the w^man |t p^un_homme w^un w^homme");
   model2->learn(vec2);
   cerr << "p4 = " << vec2->pred.scalar << endl;

--- a/test/train-sets/ref/ezexample_predict.stderr
+++ b/test/train-sets/ref/ezexample_predict.stderr
@@ -1,4 +1,4 @@
-initializing with: '-t -q st --hash all --noconstant --ldf_override s -i models/library_train.w'
+initializing with: '-t -q st --hash all --noconstant --ldf_override s --no_stdin -i models/library_train.w'
 WARNING: model file has set of {-q, --cubic, --interactions} settings stored, but they'll be OVERRIDEN by set of {-q, --cubic, --interactions} settings from command line.
 creating quadratic features for pairs: st 
 only testing

--- a/vowpalwabbit/learner.cc
+++ b/vowpalwabbit/learner.cc
@@ -41,7 +41,6 @@ void process_example(vw& all, example* ec)
 template <class T, void(*f)(T, example*)> void generic_driver(vw& all, T context)
 { example* ec = nullptr;
 
-  all.l->init_driver();
   while ( all.early_terminate == false )
     if ((ec = VW::get_example(all.p)) != nullptr)
       f(context, ec);

--- a/vowpalwabbit/main.cc
+++ b/vowpalwabbit/main.cc
@@ -19,16 +19,12 @@ license as described in the file LICENSE.
 
 using namespace std;
 
-vw& setup(int argc, char* argv[])
-{ vw& all = parse_args(argc, argv);
-  io_buf model;
-  parse_regressor_args(all, model);
-  parse_modules(all, model);
-  parse_sources(all, model);
+vw* setup(int argc, char* argv[])
+{ vw* all = VW::initialize(argc, argv);
 
-  all.vw_is_main = true;
+  all->vw_is_main = true;
 
-  if (!all.quiet && !all.bfgs && !all.searchstr)
+  if (!all->quiet && !all->bfgs && !all->searchstr)
   { std::cerr << std::left
               << std::setw(shared_data::col_avg_loss) << std::left << "average"
               << " "
@@ -86,11 +82,11 @@ int main(int argc, char *argv[])
         int l_argc;
         char** l_argv = VW::get_argv_from_string(new_args, l_argc);
 
-        alls.push_back(&setup(l_argc, l_argv));
+        alls.push_back(setup(l_argc, l_argv));
       }
     }
     else
-    { alls.push_back(&setup(argc, argv));
+    { alls.push_back(setup(argc, argv));
     }
 
     vw& all = *alls[0];

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -1309,7 +1309,7 @@ char** get_argv_from_string(string s, int& argc)
   return argv;
 }
 
-void free_args(int argc, char* argv[]) 
+void free_args(int argc, char* argv[])
 { for (int i = 0; i < argc; i++)
     free(argv[i]);
   free(argv);
@@ -1318,7 +1318,6 @@ void free_args(int argc, char* argv[])
 vw* initialize(string s, io_buf* model)
 {
   int argc = 0;
-  s += " --no_stdin";
   char** argv = get_argv_from_string(s,argc);
 
   try

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -1012,9 +1012,8 @@ void initialize_parser_datastructures(vw& all)
 
 namespace VW
 {
-void start_parser(vw& all, bool init_structures)
-{ if (init_structures)
-    initialize_parser_datastructures(all);
+void start_parser(vw& all)
+{ 
 #ifndef _WIN32
   pthread_create(&all.parse_thread, nullptr, main_parse_loop, &all);
 #else

--- a/vowpalwabbit/vw.h
+++ b/vowpalwabbit/vw.h
@@ -26,7 +26,8 @@ namespace VW
     (1) Some commandline parameters do not make sense as a library.
     (2) The code is not yet reentrant.
    */
-vw* initialize(string s);
+vw* initialize(string s, io_buf* model=nullptr);
+vw* initialize(int argc, char* argv[], io_buf* model=nullptr);
 vw* seed_vw_model(vw* vw_model, string extra_args);
 
 void cmd_string_replace_value( std::stringstream*& ss, string flag_to_replace, string new_value );
@@ -40,7 +41,7 @@ const char* are_features_compatible(vw& vw1, vw& vw2);
 void finish(vw& all, bool delete_all=true);
 void sync_stats(vw& all);
 
-void start_parser(vw& all, bool do_init = true);
+void start_parser(vw& all);
 void end_parser(vw& all);
 bool is_ring_example(vw& all, example* ae);
 bool parse_atomic_example(vw& all, example* ae, bool do_read);

--- a/vowpalwabbit/vwdll.cpp
+++ b/vowpalwabbit/vwdll.cpp
@@ -47,7 +47,7 @@ extern "C"
     if (pointer->numpasses > 1)
     { adjust_used_index(*pointer);
       pointer->do_reset_source = true;
-      VW::start_parser(*pointer,false);
+      VW::start_parser(*pointer);
       LEARNER::generic_driver(*pointer);
       VW::end_parser(*pointer);
     }
@@ -88,9 +88,9 @@ extern "C"
     return static_cast<VW_EXAMPLE>(VW::read_example(*pointer, const_cast<char*>(line)));
   }
 
-  VW_DLL_MEMBER void VW_CALLING_CONV VW_StartParser(VW_HANDLE handle, bool do_init)
+  VW_DLL_MEMBER void VW_CALLING_CONV VW_StartParser(VW_HANDLE handle)
   { vw * pointer = static_cast<vw*>(handle);
-    VW::start_parser(*pointer, do_init);
+    VW::start_parser(*pointer);
   }
 
   VW_DLL_MEMBER void VW_CALLING_CONV VW_EndParser(VW_HANDLE handle)

--- a/vowpalwabbit/vwdll.h
+++ b/vowpalwabbit/vwdll.h
@@ -78,7 +78,7 @@ extern "C"
 #endif
   VW_DLL_MEMBER VW_EXAMPLE VW_CALLING_CONV VW_ReadExampleA(VW_HANDLE handle, const char * line);
 
-  VW_DLL_MEMBER void VW_CALLING_CONV VW_StartParser(VW_HANDLE handle, bool do_init);
+  VW_DLL_MEMBER void VW_CALLING_CONV VW_StartParser(VW_HANDLE handle);
   VW_DLL_MEMBER void VW_CALLING_CONV VW_EndParser(VW_HANDLE handle);
 
   VW_DLL_MEMBER VW_EXAMPLE VW_CALLING_CONV VW_GetExample(VW_HANDLE handle);


### PR DESCRIPTION
It turns out that init_driver never got called from the Windows side. I walked through it with John and we also simplified the code a bit. Note: generic_driver is not used when going through the C# part, as the parser is externalized there.

@trufanov-nok can you merge that into #923 and try again?