### PR TITLE
fixed empty id being overridden in seeded model with @eisber

### DIFF
--- a/vowpalwabbit/parse_regressor.cc
+++ b/vowpalwabbit/parse_regressor.cc
@@ -120,7 +120,7 @@ void save_load_header(vw& all, io_buf& model_file, bool read, bool text)
                                                   "", read, msg, text);
           all.id = buff2;
 
-          if (read && find(all.args.begin(), all.args.end(), "--id") == all.args.end())
+          if (read && find(all.args.begin(), all.args.end(), "--id") == all.args.end() && !all.id.empty())
             { all.args.push_back("--id");
               all.args.push_back(all.id);
             }


### PR DESCRIPTION
When --id is not specified, we still add it to vw args as --id "", eventually this empty string is removed during the args copy in seeded model, causing the next flag to be used as --id, which is bad.