### PR TITLE
Remove error-ful line break after trailing backslash in Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,8 +27,6 @@ nobase_include_HEADERS = vowpalwabbit/allreduce.h \
 	vowpalwabbit/multilabel.h \
 	vowpalwabbit/constant.h \
 	vowpalwabbit/ezexample.h \
-
-
 noinst_HEADERS = vowpalwabbit/accumulate.h \
 	vowpalwabbit/autolink.h \
 	vowpalwabbit/bfgs.h \


### PR DESCRIPTION
When I run autoreconf to create a configuration file, i get the error bellow.

After removing the line break, the error is gone.

```
autoreconf --install
glibtoolize: putting auxiliary files in '.'.
glibtoolize: copying file './ltmain.sh'
glibtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'acinclude.d'.
glibtoolize: copying file 'acinclude.d/libtool.m4'
glibtoolize: copying file 'acinclude.d/ltoptions.m4'
glibtoolize: copying file 'acinclude.d/ltsugar.m4'
glibtoolize: copying file 'acinclude.d/ltversion.m4'
glibtoolize: copying file 'acinclude.d/lt~obsolete.m4'
configure.ac:15: installing './compile'
configure.ac:13: installing './config.guess'
configure.ac:13: installing './config.sub'
configure.ac:3: installing './install-sh'
configure.ac:3: installing './missing'
Makefile.am:30: error: blank line following trailing backslash
cluster/Makefile.am: installing './depcomp'
autoreconf: automake failed with exit status: 1
```

*edit*: my system is Mac OS X 10.11.4