### PR TITLE
Remove error-causing backslash at end of first definition in Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,7 +26,7 @@ nobase_include_HEADERS = vowpalwabbit/allreduce.h \
 	vowpalwabbit/vw_validate.h \
 	vowpalwabbit/multilabel.h \
 	vowpalwabbit/constant.h \
-	vowpalwabbit/ezexample.h \
+	vowpalwabbit/ezexample.h 
 
 
 noinst_HEADERS = vowpalwabbit/accumulate.h \


### PR DESCRIPTION
Please consult #968 for reasoning behind this. 
This backslash produces an error when using autoconf or autoreconf.