### PR TITLE
unbreak Makefile.am (resolve #974)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,7 +26,7 @@ nobase_include_HEADERS = vowpalwabbit/allreduce.h \
 	vowpalwabbit/vw_validate.h \
 	vowpalwabbit/multilabel.h \
 	vowpalwabbit/constant.h \
-	vowpalwabbit/ezexample.h \
+	vowpalwabbit/ezexample.h
 
 
 noinst_HEADERS = vowpalwabbit/accumulate.h \


### PR DESCRIPTION
A previous commit added a line to Makefile.am that ended in a trailing slash in an invalid position.  This broke autogen.sh, which broke the build as described in #974.