### PR TITLE
bugfix - namespace now stores 16 instead of just 2 affixes

### DIFF
--- a/vowpalwabbit/global_data.h
+++ b/vowpalwabbit/global_data.h
@@ -475,7 +475,7 @@ struct vw
   uint32_t skips[256];//skips in ngrams.
   std::vector<std::string> limit_strings; // descriptor of feature limits
   uint32_t limit[256];//count to limit features by
-  char affix_features[256]; // affixes to generate (up to 8 per namespace)
+  uint64_t affix_features[256]; // affixes to generate (up to 16 per namespace - 4 bits per affix)
   bool     spelling_features[256]; // generate spelling features for which namespace
   vector<string> dictionary_path;  // where to look for dictionaries
   vector<feature_dict*> namespace_dictionaries[256]; // each namespace has a list of dictionaries attached to it

--- a/vowpalwabbit/parse_example.cc
+++ b/vowpalwabbit/parse_example.cc
@@ -33,7 +33,7 @@ public:
   unsigned char (*redefine)[256];
   parser* p;
   example* ae;
-  char* affix_features;
+  uint64_t* affix_features;
   bool* spelling_features;
   v_array<char> spelling;
 
@@ -110,10 +110,10 @@ public:
             features& affix_fs = ae->feature_space[affix_namespace];
             if (affix_fs.size() == 0)
               ae->indices.push_back(affix_namespace);
-            char affix = affix_features[index];
+            uint64_t affix = affix_features[index];
             while (affix > 0)
               { bool is_prefix = affix & 0x1;
-                char len   = (affix >> 1) & 0x7;
+                uint64_t len   = (affix >> 1) & 0x7;
                 substring affix_name = { feature_name.begin, feature_name.end };
                 if (affix_name.end > affix_name.begin + len)
                   { if (is_prefix)


### PR DESCRIPTION
fixes #983 
previously with char there were only 2 affix values possible (4 bits) per namespace
`uint32_t` could hold 8 (changed code comment)

currently 16 are available which is, I guess, more than enough.