### PR TITLE
--cb: fix one eligible action for test sample

### DIFF
--- a/vowpalwabbit/gen_cs_example.cc
+++ b/vowpalwabbit/gen_cs_example.cc
@@ -40,7 +40,7 @@ void gen_cs_example_ips(cb_to_cs& c, CB::label& ld, COST_SENSITIVE::label& cs_ld
 { //this implements the inverse propensity score method, where cost are importance weighted by the probability of the chosen action
   //generate cost-sensitive example
   cs_ld.costs.erase();
-  if (ld.costs.size() == 1)   //this is a typical example where we can perform all actions
+  if (ld.costs.size() == 1 && !is_test_label(ld))   //this is a typical example where we can perform all actions
     { //in this case generate cost-sensitive example with all actions
       for (uint32_t i = 1; i <= c.num_actions; i++)
 	{

--- a/vowpalwabbit/gen_cs_example.h
+++ b/vowpalwabbit/gen_cs_example.h
@@ -42,7 +42,7 @@ void gen_cs_example_dm(cb_to_cs& c, example& ec, COST_SENSITIVE::label& cs_ld)
   cs_ld.costs.erase();
   c.pred_scores.costs.erase();
 
-  if (ld.costs.size() == 1)   //this is a typical example where we can perform all actions
+  if (ld.costs.size() == 1 && !is_test_label(ld))   //this is a typical example where we can perform all actions
     { //in this case generate cost-sensitive example with all actions
       for (uint32_t i = 1; i <= c.num_actions; i++)
 	{
@@ -148,7 +148,7 @@ void gen_cs_example_dr(cb_to_cs& c, example& ec, CB::label& ld, COST_SENSITIVE::
 	COST_SENSITIVE::wclass c = { FLT_MAX, i, 0., 0. };
 	cs_ld.costs.push_back(c);
       }
-  else if (ld.costs.size() == 1) //this is a typical example where we can perform all actions
+  else if (ld.costs.size() == 1 && !is_test_label(ld)) //this is a typical example where we can perform all actions
     //in this case generate cost-sensitive example with all actions
     for (uint32_t i = 1; i <= c.num_actions; i++) {
       gen_cs_label<is_learn>(c, ec, cs_ld, i);


### PR DESCRIPTION
John,
This is a fix for the small bug for --cb we discussed, where if only one action is provided without cost or prob, it should be treated as only one action is eligible (and prediction should be this action). 

The problem was, when generating cost-sensitive example, when ld.costs.size() == 1, all actions are generated. This is valid for sth like 3:1:0.5 | features, but not consistent for example with test label, such as 3 | features.

So the fix is to generate all actions when (ld.costs.size() == 1 && !is_test_label(ld)). This is added for all 3 cb algorithms. 

after fix:
 echo "3:1:0.5 | three
3 | three" | ./vowpalwabbit/vw --cb 5 --cb_type ips
Num weight bits = 18
learning rate = 0.5
initial_t = 0
power_t = 0.5
using no cache
Reading datafile = 
num sources = 1
average  since         example        example  current  current  current
loss     last          counter         weight    label  predict features
0.000000 0.000000            1            1.0    known        1        2
0.000000 0.000000            2            2.0  unknown       **3**       2

finished run
number of examples per pass = 2
passes used = 1
weighted example sum = 2.000000
weighted label sum = 0.000000
average loss = 0.000000

Please let me know if there are any concerns.