### PR TITLE
I few warnings for cache file processing problems

### DIFF
--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -334,13 +334,19 @@ void parse_cache(vw& all, po::variables_map &vm, string source,
       try
       { f = all.p->input->open_file(caches[i].c_str(), all.stdin_off, io_buf::READ);
       }
-      catch (exception e) { f = -1;}
+      catch (exception e) 
+      { f = -1;
+        if (!quiet)
+          cerr << "WARNING: cache file is ignored as it can't be opened!" << endl;
+      }
     if (f == -1)
       make_write_cache(all, caches[i], quiet);
     else
     { uint64_t c = cache_numbits(all.p->input, f);
       if (c < all.num_bits)
-      { all.p->input->close_file();
+      { if (!quiet)
+          cerr << "WARNING: cache file is ignored as it's made with less bit precision than required!" << endl;
+        all.p->input->close_file();
         make_write_cache(all, caches[i], quiet);
       }
       else


### PR DESCRIPTION
Just faced with a problem when VW ignores specified cache file and tries to make another one instead. It took some time to realize that this happens bcs I forgot to specify the right `-b` value during cache creation. Frankly, I didn't realized this till I debug. I think would be nice to add a few warnings for such cases if anyone else forgets how VW processes cache files.