### PR TITLE
disable one of warnings for cache file

### DIFF
--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -334,11 +334,7 @@ void parse_cache(vw& all, po::variables_map &vm, string source,
       try
       { f = all.p->input->open_file(caches[i].c_str(), all.stdin_off, io_buf::READ);
       }
-      catch (exception e) 
-      { f = -1;
-        if (!quiet)
-          cerr << "WARNING: cache file is ignored as it can't be opened!" << endl;
-      }
+      catch (exception e) { f = -1; }
     if (f == -1)
       make_write_cache(all, caches[i], quiet);
     else


### PR DESCRIPTION
I realized that one of warnings that's triggered by exception is printed out even if there was no cache file. Like in `vw - data.vw --cache_file data.cache` when user creates cache for a first time.  In this case user gets 
```
WARNING: cache file is ignored as it can't be opened!
creating cache_file = data.cache
```
which is confusing. I don't like that.
Let's roll back this piece of code and disable this warning for now. Perhaps I'll find a time to make some cross-platform checks to separate "file not exists" from all other problems in `catch` later.