### PR TITLE
Small improvement in int predictions print

### DIFF
--- a/vowpalwabbit/global_data.cc
+++ b/vowpalwabbit/global_data.cc
@@ -85,7 +85,7 @@ void print_result(int f, float res, float, v_array<char> tag)
     if (floorf(res) != res)
       sprintf(temp, "%f", res);
     else
-      sprintf(temp, "%d", (uint32_t) res);
+      sprintf(temp, "%.0f", res);
     std::stringstream ss;
     ss << temp;
     print_tag(ss, tag);


### PR DESCRIPTION
referring my old PR #812 

I've used `print_result()` function to output example labels and realized that it spoils `FLT_MAX` values. Looks like `sprintf(temp, "%d", (uint32_t) res)` behaves badly for very big float `res` values (which user unlikely to get on practice so it wasn't noticed). For example `FLT_MAX` is printed as `0`. 

So I suggest to use just `sprintf(temp, "%.0f", res)` instead. Looks like it provides with desired behavior and more elegant as uses same float type.

P.S. It's been a while since my last contribution to VW codebase so I may forget some nuances and I can't recall why I used float to int conversion and why I used **unsigned** int...