### PR TITLE
vw-hyperopt extract label from input

### DIFF
--- a/utl/vw-hyperopt.py
+++ b/utl/vw-hyperopt.py
@@ -260,7 +260,7 @@ class HyperOptimizer(object):
         v = open('%s' % self.holdout_pred, 'r')
         y_pred_holdout = []
         for line in v:
-            y_pred_holdout.append(float(line.strip()))
+            y_pred_holdout.append(float(line.split()[0].strip()))
 
         if self.outer_loss_function == 'logistic':
             y_pred_holdout_proba = [1. / (1 + exp(-i)) for i in y_pred_holdout]


### PR DESCRIPTION
adds support for optional arguments in order to prevent the following error:

`ValueError: invalid literal for float(): -5.123953 6171_1851165462_2016-05-23_02:00:00[0.0]`