### PR TITLE
Rectified linear unit option for neural net

### DIFF
--- a/test/pred-sets/ref/0022.stderr
+++ b/test/pred-sets/ref/0022.stderr
@@ -1,5 +1,6 @@
 only testing
 predictions = 0022.predict
+Use activation 'tanh' for neural network testing
 Num weight bits = 16
 learning rate = 0.5
 initial_t = 0

--- a/test/train-sets/ref/nn-1-noquiet.stderr
+++ b/test/train-sets/ref/nn-1-noquiet.stderr
@@ -1,3 +1,4 @@
+Use activation 'tanh' for neural network training
 Num weight bits = 18
 learning rate = 0.5
 initial_t = 0

--- a/test/train-sets/ref/search_dep_parser_one_learner.stderr
+++ b/test/train-sets/ref/search_dep_parser_one_learner.stderr
@@ -1,3 +1,4 @@
+Use activation 'tanh' for neural network training
 Enabling FTRL based optimization
 Algorithm used: Proximal-FTRL
 ftrl_alpha = 0.005
@@ -9,8 +10,8 @@ power_t = 0.5
 creating cache_file = train-sets/wsj_small.dparser.vw.gz.cache
 Reading datafile = train-sets/wsj_small.dparser.vw.gz
 num sources = 1
-average    since      instance            current true      current predicted   cur   cur   predic    cache  examples          
-loss       last        counter           output prefix          output prefix  pass   pol     made     hits    gener  beta    
+average    since      instance            current true      current predicted   cur   cur   predic    cache  examples
+loss       last        counter           output prefix          output prefix  pass   pol     made     hits    gener  beta
 89.000000  89.000000         1  [43:1 5:2 5:2 5:2 1..] [20:9 20:9 20:9 20:..]     0     0       96        0       96  0.000950
 48.500000  8.000000          2  [2:2 3:5 0:8 3:7 3:4 ] [0:8 1:2 2:2 3:2 4:2 ]     0     0      104        0      104  0.001029
 

--- a/vowpalwabbit/nn.cc
+++ b/vowpalwabbit/nn.cc
@@ -451,8 +451,9 @@ base_learner* nn_setup(vw& all)
   n.k = (uint64_t)vm["nn"].as<size_t>();
 
   //parse for activation function type
-  n.nonlinearity = getNonlinearity(vm["activation"].as<string>());
-  *all.file_options << " --activation";
+  const string activation_type = vm["activation"].as<string>();
+  n.nonlinearity = getNonlinearity(activation_type);
+  *all.file_options << " --activation " << activation_type;
   if (! all.quiet) {
     std::cerr << "Use activation \'" << n.nonlinearity->getName() << "\' for neural network "
               << (all.training ? "training" : "testing")

--- a/vowpalwabbit/nn.h
+++ b/vowpalwabbit/nn.h
@@ -3,4 +3,13 @@ Copyright (c) by respective owners including Yahoo!, Microsoft, and
 individual contributors. All rights reserved.  Released under a BSD
 license as described in the file LICENSE.
  */
+class activation_function
+{
+public :
+  virtual ~activation_function(){};
+  virtual inline float fire(float x) = 0;
+  virtual inline float first_derivative(float x) = 0;
+  virtual inline string getName() = 0;
+};
+
 LEARNER::base_learner* nn_setup(vw& all);


### PR DESCRIPTION
This pull request addresses issue #1028 (adding different activation functions to the neural net). 

Specifically it adds a `nonlinearity` member to the `nn` struct, which defines a `fire` function for the forward pass and a `first_derivative` for the backward pass. Adding additional activation functions can now be down by creating additional sub-classes that override these methods. My c++ is a bit rusty and I'm not too familiar with the vowpal wabbit code base, so criticism is definitely welcome.

However as it is written now, the relu neural net is not learning.. I believe it is because the hidden weights are currently initialized to zero, which for the relu is a point of zero gradient so there is no chance of learning to occur. Looking through the code I couldn't find the best place to set a different initialization for the weights (only `calloc`), so if you could point me to where I could make that change that would be great. Of course, if you see another reason why the relu layer is not learning, let me know and I will make the change.

Once I fix the learning issue I will go ahead and add a test. Thanks!

cc: @pmineiro @JohnLangford 
