### PR TITLE
Fix crash when running with --audit.

### DIFF
--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -183,8 +183,14 @@ struct audit_results
 
 
 inline void audit_interaction(audit_results& dat, const audit_strings* f)
-{ if (f == nullptr)
-  { dat.ns_pre.pop_back();
+{ 
+  if (f == nullptr)
+  {
+    if (!dat.ns_pre.empty())
+    { 
+        dat.ns_pre.pop_back();
+    }
+
     return;
   }
 

--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -199,15 +199,20 @@ inline void audit_interaction(audit_results& dat, const audit_strings* f)
     ns_pre += '*';
 
   if (f->first != "" && ((f->first) != " "))
-    {
-      ns_pre.append(f->first);
-      ns_pre += '^';
-    }
+  {
+    ns_pre.append(f->first);
+    ns_pre += '^';
+  }
+  
   if (f->second != "")
-    {
-      ns_pre.append(f->second);
-      dat.ns_pre.push_back(ns_pre);
-    }
+  {
+    ns_pre.append(f->second);
+  }
+
+  if (!ns_pre.empty())
+  {
+    dat.ns_pre.push_back(ns_pre);
+  }
 }
 
 inline void audit_feature(audit_results& dat, const float ft_weight, const uint64_t ft_idx)


### PR DESCRIPTION
When running with --audit, if an anonymous feature is present, VW will segv.