### PR TITLE
Update parse_args.cc

### DIFF
--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -873,7 +873,7 @@ void parse_example_tweaks(vw& all)
   else
     all.training = true;
 
-  if(all.numpasses > 1)
+  if(all.numpasses > 1 || all.holdout_after > 0)
     all.holdout_set_off = false;
 
   if(vm.count("holdout_off"))


### PR DESCRIPTION
Enable reporting on test loss when using holdout_after parameter.
