### PR TITLE
Test cases for --audit output.

### DIFF
--- a/test/RunTests
+++ b/test/RunTests
@@ -1485,3 +1485,9 @@ printf '3 |f a b c |e x y z\n2 |f a y c |e x\n' | \
 {VW} -d train-sets/cb_adf_crash_2.data -i models/cb_adf_crash.model -t
     train-sets/ref/cb_adf_crash2.stderr
 
+# Test 137: Fix for regression introduced by badeedb.  
+# Ensure audit output continues to work correctly in the presence of anon features.
+# Github issue 1038 (https://github.com/JohnLangford/vowpal_wabbit/issues/1038)
+{VW} --audit -d train-sets/audit.dat --noconstant
+    train-sets/ref/audit.stderr
+    train-sets/ref/audit.stdout

--- a/test/train-sets/audit.dat
+++ b/test/train-sets/audit.dat
@@ -1,0 +1,4 @@
+1 | feature
+2 |namespace feature
+3 | :1
+4 |other_namespace :1

--- a/test/train-sets/ref/audit.stderr
+++ b/test/train-sets/ref/audit.stderr
@@ -1,0 +1,21 @@
+Num weight bits = 18
+learning rate = 0.5
+initial_t = 0
+power_t = 0.5
+using no cache
+Reading datafile = train-sets/audit.dat
+num sources = 1
+average  since         example        example  current  current  current
+loss     last          counter         weight    label  predict features
+1.000000 1.000000            1            1.0   1.0000   0.0000        1
+2.500000 4.000000            2            2.0   2.0000   0.0000        1
+7.500000 12.500000            4            4.0   4.0000   0.0000        1
+
+finished run
+number of examples per pass = 4
+passes used = 1
+weighted example sum = 4.000000
+weighted label sum = 10.000000
+average loss = 7.500000
+best constant = 2.500000
+total feature number = 4

--- a/test/train-sets/ref/audit.stdout
+++ b/test/train-sets/ref/audit.stdout
@@ -1,0 +1,8 @@
+0
+	feature:118880:1:0@0
+0
+	namespace^feature:242309:1:0@0
+0
+	:0:1:0@0
+0
+	other_namespace^:207177:1:0@0


### PR DESCRIPTION
As requested, here's a test case for the --audit regression.

Also, while looking at this, I realized that the --audit output actually goes to stdout, not stderr.  Not sure if that's intended or not.

One of the issues I see is that the test case will fail if the hash function used by VW is ever changed.  I don't see a good way to template it in the current test framework.