### PR TITLE
retaining example tag in python lib

### DIFF
--- a/python/examples/test.py
+++ b/python/examples/test.py
@@ -80,7 +80,6 @@ for i in range(2):
     ex = vw.example("1 foo| a b")
     ex.learn()
     print('tag =', ex.get_tag())
-    print('counter =', ex.get_example_counter())
     print('partial pred =', ex.get_partial_prediction())
     print('loss =', ex.get_loss())
 

--- a/python/pylibvw.cc
+++ b/python/pylibvw.cc
@@ -77,7 +77,7 @@ size_t my_get_label_type(vw*all)
 
 void my_delete_example(void*voidec)
 { example* ec = (example*) voidec;
-  size_t labelType = (ec->tag.size() == 0) ? lDEFAULT : ec->tag[0];
+  size_t labelType = ec->example_counter;
   label_parser* lp = get_label_parser(NULL, labelType);
   VW::dealloc_example(lp ? lp->delete_label : NULL, *ec);
   free(ec);
@@ -92,9 +92,7 @@ example* my_empty_example0(vw_ptr vw, size_t labelType)
   { COST_SENSITIVE::wclass zero = { 0., 1, 0., 0. };
     ec->l.cs.costs.push_back(zero);
   }
-  ec->tag.erase();
-  if (labelType != lDEFAULT)
-    ec->tag.push_back((char)labelType);  // hide the label type in the tag
+  ec->example_counter = labelType;
   return ec;
 }
 
@@ -109,9 +107,6 @@ example_ptr my_read_example(vw_ptr all, size_t labelType, char*str)
   VW::parse_atomic_example(*all, ec, false);
   VW::setup_example(*all, ec);
   ec->example_counter = labelType;
-  ec->tag.erase();
-  if (labelType != lDEFAULT)
-    ec->tag.push_back((char)labelType);  // hide the label type in the tag
   return boost::shared_ptr<example>(ec, my_delete_example);
 }
 
@@ -374,6 +369,7 @@ uint32_t ex_get_cbandits_class(example_ptr ec, uint32_t i) { return ec->l.cb.cos
 float ex_get_cbandits_probability(example_ptr ec, uint32_t i) { return ec->l.cb.costs[i].probability; }
 float ex_get_cbandits_partial_prediction(example_ptr ec, uint32_t i) { return ec->l.cb.costs[i].partial_prediction; }
 
+// example_counter is being overriden by lableType!
 size_t   get_example_counter(example_ptr ec) { return ec->example_counter; }
 uint32_t get_ft_offset(example_ptr ec) { return ec->ft_offset; }
 size_t   get_num_features(example_ptr ec) { return ec->num_features; }

--- a/python/vowpalwabbit/pyvw.py
+++ b/python/vowpalwabbit/pyvw.py
@@ -437,7 +437,9 @@ class example(pylibvw.example):
         get an "empty" example which you can construct by hand (see, eg,
         example.push_features). If initString is a string, then this
         string is parsed as it would be from a VW data file into an
-        example (and "setup_example" is run). if it is a dict, then we add all features in that dictionary. finally, if it's a function, we (repeatedly) execute it fn() until it's not a function any more (for lazy feature computation)."""
+        example (and "setup_example" is run). if it is a dict, then we add all features in that dictionary.
+        finally, if it's a function, we (repeatedly) execute it fn() until it's not a function any more
+        (for lazy feature computation)."""
 
         while hasattr(initStringOrDict, '__call__'):
             initStringOrDict = initStringOrDict()


### PR DESCRIPTION
this is to fix issue #758 

there was some hacky stuff in pylibvw which erased the tag and used it to store the label type because that was needed to deallocate memory when the example was destroyed.

I couldn't find an easy way to retain the size_t labelType variable on it's own, and since example_counter was also being overridden to store this info I kept it there and used example_counter in the dealloc_example function.

this is still a bit hacky, but I didn't want to modify the base example class for this case, maybe someone has a better implementation for dealloc_example that can resolve this issue, but for now this works to get the tag.  The example counter information is still not valid, but that seems less relevant for the python library.