### PR TITLE
Make namespace ignored when used singularly, but not when used as int…

### DIFF
--- a/vowpalwabbit/feature_group.h
+++ b/vowpalwabbit/feature_group.h
@@ -213,7 +213,7 @@ struct features {
   typedef features_value_index_iterator iterator;
   typedef features_value_iterator iterator_value;
   typedef features_value_index_audit_iterator iterator_all;
-
+  char ignored;
   /// defines a "range" usable by C++ 11 for loops
   class features_value_index_audit_range {
   private:
@@ -231,6 +231,7 @@ struct features {
     indicies = v_init<feature_index>();
     space_names = v_init<audit_strings_ptr>();
     sum_feat_sq = 0.f;
+    ignored = 0;
   }
 
   inline size_t size() const { return values.size(); }

--- a/vowpalwabbit/gd.h
+++ b/vowpalwabbit/gd.h
@@ -69,7 +69,8 @@ inline void foreach_feature(vw& all, example& ec, R& dat)
 { uint64_t offset = ec.ft_offset;
 
 for (features& f : ec)
-    foreach_feature<R,T>(all.reg.weight_vector, all.reg.weight_mask, f, dat, offset);
+    if (!f.ignored)
+      foreach_feature<R,T>(all.reg.weight_vector, all.reg.weight_mask, f, dat, offset);
 
   INTERACTIONS::generate_interactions<R,S,T>(all, ec, dat);
 }

--- a/vowpalwabbit/parser.cc
+++ b/vowpalwabbit/parser.cc
@@ -716,11 +716,8 @@ void setup_example(vw& all, example* ae)
   if (all.ignore_some)
     for (unsigned char* i = ae->indices.begin(); i != ae->indices.end(); i++)
       if (all.ignore[*i])
-      { //delete namespace
-        ae->feature_space[*i].erase();
-        memmove(i, i + 1, (ae->indices.end() - (i + 1))*sizeof(*i));
-        ae->indices.end()--;
-        i--;
+      { //ignore this namespace
+        ae->feature_space[*i].ignored = 1;      
       }
 
   if(all.ngram_strings.size() > 0)
@@ -740,8 +737,11 @@ void setup_example(vw& all, example* ae)
   ae->num_features = 0;
   ae->total_sum_feat_sq = 0;
   for (features& fs : *ae)
-  { ae->num_features += fs.size();
-    ae->total_sum_feat_sq += fs.sum_feat_sq;
+  { 
+    if (!fs.ignored) {
+      ae->num_features += fs.size();
+      ae->total_sum_feat_sq += fs.sum_feat_sq;
+    }
   }
 
   size_t new_features_cnt;


### PR DESCRIPTION
When using namespaces in interactions, even when explicitely ignoring namespace in command line, it gets pulled back in as part of interaction.
This changes the behavior, so "ignore" really means ignoring it and using the namespace in an interaction does not by default also uses it in singular form.
