### PR TITLE
Update instruction for Python 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ brew install vowpal-wabbit
 brew install libtool
 brew install autoconf
 brew install automake
-brew install boost --with-python
+brew install boost
+brew install boost-python
 ```
 
 #### OSX Dependencies (if using MacPorts):

--- a/python/README.rst
+++ b/python/README.rst
@@ -95,7 +95,8 @@ For Mac OSX
 .. code-block:: bash
 
     $ brew install libtool autoconf automake
-    $ brew install boost --with-python
+    $ brew install boost
+    $ brew install boost-python
     # or for python3 (you may have to uninstall boost and reinstall to build python3 libs)
     $ brew install boost --with-python3
 


### PR DESCRIPTION
At least on my machine (el capitan) `brew install boost --with-python` doesn't work. `pip install vowpalwabbit` after running that still complains about missing boost library. On the other hand, `brew install boost-python` worked.