### PR TITLE
consider precision

### DIFF
--- a/vowpalwabbit/explore_eval.cc
+++ b/vowpalwabbit/explore_eval.cc
@@ -191,7 +191,7 @@ namespace EXPLORE_EVAL {
 	
 	threshold *= data.multiplier;
 	
-	if (threshold > 1.)
+	if (threshold > 1. + 1e-6)
 	  data.violations++;
 	
 	if (frand48() < threshold)


### PR DESCRIPTION
The policy probabilities can sometimes be > 1 with very small precision leading to unjustified violations 