### PR TITLE
fix vw-lda

### DIFF
--- a/utl/vw-lda
+++ b/utl/vw-lda
@@ -274,7 +274,7 @@ class vw_lda(object):
         self.populate_hash()
         self.f = open(self.hashed_lda_model, "r")
         lines = self.f.readlines()
-        p = re.compile("^options")
+        p = re.compile("^Checksum")
         got_data = 0
         topics = []
         line_count = 0


### PR DESCRIPTION
`vw-lda` with the latest vw crashes with the following error:
```
transforming outputs
Exception: 'Checksum:'
Traceback (most recent call last):
  File "/usr/local/bin/vw-lda", line 400, in main
    vw_lda().process_args(args)
  File "/usr/local/bin/vw-lda", line 252, in process_args
    self.transform_outputs(args.max_terms)
  File "/usr/local/bin/vw-lda", line 287, in transform_outputs
    w = self.new_hash[str(word_list[0])]
KeyError: 'Checksum:
```

This PR fixes the issue by skipping past the Checksum line in the readable model.