### PR TITLE
Fix to https://github.com/JohnLangford/vowpal_wabbit/issues/1107

### DIFF
--- a/vowpalwabbit/Makefile.am
+++ b/vowpalwabbit/Makefile.am
@@ -10,11 +10,12 @@ libvw_c_wrapper_la_SOURCES = vwdll.cpp
 
 # accumulate.cc uses all_reduce
 libvw_la_LIBADD = liballreduce.la
+libvw_c_wrapper_la_LIBADD = libvw.la
 
 ACLOCAL_AMFLAGS = -I acinclude.d
 
 AM_CXXFLAGS = ${BOOST_CPPFLAGS} ${ZLIB_CPPFLAGS} ${PTHREAD_CFLAGS} -Wall -Wno-unused-local-typedefs
-AM_LDFLAGS = ${BOOST_LDFLAGS} ${BOOST_PROGRAM_OPTIONS_LIB} ${ZLIB_LDFLAGS} ${PTHREAD_LIBS}
+LIBS = ${BOOST_LDFLAGS} ${BOOST_PROGRAM_OPTIONS_LIB} ${ZLIB_LDFLAGS} ${PTHREAD_LIBS}
 
 CXXOPTIMIZE = 
 


### PR DESCRIPTION
Contributed by david-geiger:
    Modified file:  vowpalwabbit/Makefile.am
    Based on Mageia patch:
        http://svnweb.mageia.org/packages/cauldron/vowpal-wabbit/current/SOURCES/vowpal_wabbit-8.2.1-linking.patch?view=markup&pathrev=1057904

Verified by me on Ubuntu.
I get a smooth build and no errors after applying the patch:

```
   autogen.sh
   make
   make test
```

Many thanks to David (and the anonymous Mageia packager) for the fix.
