### PR TITLE
Adds a check if building within VirtualEnv

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -18,8 +18,13 @@ ifeq ($(PYTHON_LIBS),)
   PYTHON_LIBS = -l boost_python
 endif
 
-PYTHON_INCLUDE = $(shell python$(PYTHON_VERSION)-config --includes)
-PYTHON_LDFLAGS = $(shell python$(PYTHON_VERSION)-config --ldflags)
+ifeq ($(VIRTUAL_ENV), )
+  PYTHON_INCLUDE = $(shell python$(PTHON_VERSION)-config --includes)
+  PYTHON_LDFLAGS = $(shell python$(PTHON_VERSION)-config --ldflags)
+else
+  PYTHON_INCLUDE = $(shell python-config --includes)
+  PYTHON_LDFLAGS = $(shell python-config --ldflags)
+endif
 
 JSON_INCLUDE = -I ../rapidjson/include
 


### PR DESCRIPTION
When building in Python VirtualEnv the Makefile sets the wrong python source

This fix is a proposed solution for the issue discussed at the end of the thread to https://github.com/JohnLangford/vowpal_wabbit/issues/415

When executing
`PYTHON_LDFLAGS = $(shell python$(PYTHON_VERSION)-config --ldflags)`
in a virtual environment the Python being linked is the system Python instead of the Python in the virtual environment. As a consequence the `pylibvw.so` contains system python leading to a Segfault when trying to run
`from vowpalwabbit import pyvw`

The proposed solution is to check the `VIRTUAL_ENV` environment variable that is set when working in a virtual env. If this flag is present we use just python instead of a versioned python
