### PR TITLE
call return_example in lda_core.cc

### DIFF
--- a/vowpalwabbit/lda_core.cc
+++ b/vowpalwabbit/lda_core.cc
@@ -765,7 +765,7 @@ void learn_batch(lda &l)
 	l.examples[d]->pred.scalars.end() = l.examples[d]->pred.scalars.begin() + l.topics;
 
 	l.examples[d]->pred.scalars.erase();
-	return_simple_example(*l.all, nullptr, *l.examples[d]);
+	return_example(*l.all, *l.examples[d]);
       }
     l.examples.erase();
     return;
@@ -840,7 +840,7 @@ void learn_batch(lda &l)
     { l.all->sd->sum_loss -= score;
       l.all->sd->sum_loss_since_last_dump -= score;
     }
-    return_simple_example(*l.all, nullptr, *l.examples[d]);
+    return_example(*l.all, *l.examples[d]);
   }
 
   // -t there's no need to update weights (especially since it's a noop)


### PR DESCRIPTION
Hi John,

I might be missing something but it looks the new `return_example` method in lda_core.cc (bea9ce4) isn't called anywhere.
This PR replaces the calls to `return_simple_example` with `return_example` in lda_core.cc, which makes your fix for #1096 work beautifully :-)