### PR TITLE
fix --audit for --affix

### DIFF
--- a/vowpalwabbit/parse_example.cc
+++ b/vowpalwabbit/parse_example.cc
@@ -189,7 +189,7 @@ public:
                      affix_v.push_back('=');
                      push_many(affix_v, affix_name.begin, affix_name.end - affix_name.begin);
                      affix_v.push_back('\0');
-                     fs.space_names.push_back(audit_strings_ptr(new audit_strings("affix",affix_v.begin())));
+                     affix_fs.space_names.push_back(audit_strings_ptr(new audit_strings("affix",affix_v.begin())));
                    }
                  affix >>= 4;
               }


### PR DESCRIPTION
Push audit strings into the right namespace.

Before:

$ echo "1 | aa" | ./vw -a  --quiet --affix 2
0
    :13622:1:0@0    aa:37289:1:0@0  Constant:116060:1:0@0

After:

$ echo "1 | aa" | ./vw -a  --quiet --affix 2
0
    affix^+2=aa:13622:1:0@0 aa:37289:1:0@0  Constant:116060:1:0@0