### PR TITLE
nn.cc: Add human readable named for hashes

### DIFF
--- a/vowpalwabbit/nn.cc
+++ b/vowpalwabbit/nn.cc
@@ -77,12 +77,18 @@ void finish_setup (nn& n, vw& all)
   features& fs = n.output_layer.feature_space[nn_output_namespace];
   for (unsigned int i = 0; i < n.k; ++i)
   { fs.push_back(1., nn_index);
+    if (all.audit || all.hash_inv) {
+      std::stringstream ss;
+      ss << "OutputLayer" << i;
+      fs.space_names.push_back(audit_strings_ptr(new audit_strings("", ss.str())));
+    }
     nn_index += (uint64_t)n.increment;
   }
   n.output_layer.num_features += n.k;
 
   if (! n.inpass)
   { fs.push_back(1.,nn_index);
+    if (all.audit || all.hash_inv) fs.space_names.push_back(audit_strings_ptr(new audit_strings("", "OutputLayerConst")));
     ++n.output_layer.num_features;
   }
 
@@ -92,6 +98,7 @@ void finish_setup (nn& n, vw& all)
   memset (&n.hiddenbias, 0, sizeof (n.hiddenbias));
   n.hiddenbias.indices.push_back(constant_namespace);
   n.hiddenbias.feature_space[constant_namespace].push_back(1,(uint64_t)constant);
+  if (all.audit || all.hash_inv) n.hiddenbias.feature_space[constant_namespace].space_names.push_back(audit_strings_ptr(new audit_strings("", "HiddenBias")));
   n.hiddenbias.total_sum_feat_sq++;
   n.hiddenbias.l.simple.label = FLT_MAX;
   n.hiddenbias.weight = 1;
@@ -101,6 +108,7 @@ void finish_setup (nn& n, vw& all)
   n.outputweight.indices.push_back(nn_output_namespace);
   features& outfs = n.output_layer.feature_space[nn_output_namespace];
   n.outputweight.feature_space[nn_output_namespace].push_back(outfs.values[0],outfs.indicies[0]);
+  if (all.audit || all.hash_inv) n.outputweight.feature_space[nn_output_namespace].space_names.push_back(audit_strings_ptr(new audit_strings("", "OutputWeight")));
   n.outputweight.feature_space[nn_output_namespace].values[0] = 1;
   n.outputweight.total_sum_feat_sq++;
   n.outputweight.l.simple.label = FLT_MAX;


### PR DESCRIPTION
In Neural networks, some of the hidden networks had weights but there
was no human readable string associated to the weight. This made it difficult to read in
the Human readable format because the names were clashing (All the names
for the weights into the output layer had no space_name and hence the
name was always empty). This commit adds names for these weights which
are not seen.

I believe this fixes https://github.com/JohnLangford/vowpal_wabbit/issues/1169