### PR TITLE
Fix issue where invert_hash doesn't print parameters due to save_resume and passes > 0

### DIFF
--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -225,7 +225,7 @@ inline void audit_feature(audit_results& dat, const float ft_weight, const uint6
       dat.results.push_back(sv);
     }
   
-  if (dat.all.current_pass == 0 && dat.all.hash_inv)
+  if ((dat.all.current_pass == 0 || dat.all.training == false) && dat.all.hash_inv)
     { //for invert_hash
       
       if (dat.offset != 0)


### PR DESCRIPTION
This commit fixes #1185 and allows the invert_hash to be printed in testing mode when passes > 0 and save_resume option has been used.