### PR TITLE
workaround GCC 6.x compilation issue

### DIFF
--- a/vowpalwabbit/array_parameters.h
+++ b/vowpalwabbit/array_parameters.h
@@ -137,18 +137,18 @@ private:
 
 	inline weight& strided_index(size_t index){ return operator[](index << _stride_shift);}
 
-	template<class R, void(*T)(iterator&, R&)> void set_default(R& info)
+	template<class R, class T> void set_default(R& info)
 	{
 	  iterator iter = begin();
 	  for (size_t i = 0; iter != end(); ++iter, i += stride())
-	    T(iter, info);
+	    T::func(iter, info);
 	}
 
-	template<void(*T)(iterator&)> void set_default()
+	template<class T> void set_default()
 	{ 
 	  iterator iter = begin();
 	  for (size_t i = 0; iter != end(); ++iter, i += stride())
-	    T(iter);
+	    T::func(iter);
 	}
 
 	void set_zero(size_t offset)
@@ -310,15 +310,15 @@ public:
 		_seeded = true;
 	}
 
-	template<class R, void(*T)(iterator&, R&)> void set_default(R& info)
+	template<class R, class T> void set_default(R& info)
 	{
 	  R& new_R = calloc_or_throw<R>();
 	  new_R = info;
 	  default_data = &new_R;
-	  fun = (void(*)(iterator&, void*))T;
+	  fun = (void(*)(iterator&, void*))T::func;
 	}
 
-	template<void(*T)(iterator&)> void set_default() { fun = (void(*)(iterator&, void*))T; }
+	template<class T> void set_default() { fun = (void(*)(iterator&, void*))T::func; }
 
 	void set_zero(size_t offset)
 	{

--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -824,11 +824,15 @@ void save_load_online_state(vw& all, io_buf& model_file, bool read, bool text, g
 		save_load_online_state(all, model_file, read, text, g, msg, all.weights.dense_weights);
 }
 
-  template<class T> void set_initial_gd(typename T::iterator& iter, pair<float,float>& initial)
+  template<class T> class set_initial_gd_wrapper 
   {
-    (&(*iter))[0] = initial.first;
-    (&(*iter))[1] = initial.second;
-  }
+      public: 
+          static void func(typename T::iterator& iter, pair<float,float>& initial)
+              {
+                (&(*iter))[0] = initial.first;
+                (&(*iter))[1] = initial.second;
+              }
+  };
 
 void save_load(gd& g, io_buf& model_file, bool read, bool text)
 { vw& all = *g.all;
@@ -840,9 +844,9 @@ void save_load(gd& g, io_buf& model_file, bool read, bool text)
       float init_weight = all.initial_weight;
       pair<float,float> p = make_pair(init_weight, all.initial_t);
       if (all.weights.sparse)
-	all.weights.sparse_weights.set_default<pair<float,float>, set_initial_gd<sparse_parameters> >(p);
+	all.weights.sparse_weights.set_default<pair<float,float>, set_initial_gd_wrapper<sparse_parameters> >(p);
       else
-	all.weights.dense_weights.set_default<pair<float,float>, set_initial_gd<dense_parameters> >(p);
+	all.weights.dense_weights.set_default<pair<float,float>, set_initial_gd_wrapper<dense_parameters> >(p);
       //for adaptive update, we interpret initial_t as previously seeing initial_t fake datapoints, all with squared gradient=1
       //NOTE: this is not invariant to the scaling of the data (i.e. when combined with normalized). Since scaling the data scales the gradient, this should ideally be
       //feature_range*initial_t, or something like that. We could potentially fix this by just adding this base quantity times the current range to the sum of gradients

--- a/vowpalwabbit/gd_mf.cc
+++ b/vowpalwabbit/gd_mf.cc
@@ -220,13 +220,17 @@ void mf_train(gdmf& d, example& ec)
 		mf_train(d, ec, d.all->weights.dense_weights);
 }
 
-template <class T>
-void set_rand(typename T::iterator& iter, uint32_t& stride)
+template <class T> class set_rand_wrapper 
 {
-  uint64_t index = iter.index();
-  for (weight_iterator_iterator w = iter.begin(); w != iter.end(stride); ++w, ++index)
-    *w = (float)(0.1 * merand48(index));
-}
+public:
+    
+    static void func(typename T::iterator& iter, uint32_t& stride)
+    {
+      uint64_t index = iter.index();
+      for (weight_iterator_iterator w = iter.begin(); w != iter.end(stride); ++w, ++index)
+        *w = (float)(0.1 * merand48(index));
+    }
+};
 
 void save_load(gdmf& d, io_buf& model_file, bool read, bool text)
 { vw& all = *d.all;
@@ -237,9 +241,9 @@ void save_load(gdmf& d, io_buf& model_file, bool read, bool text)
 	{
 	  uint32_t stride = all.weights.stride();
 	  if (all.weights.sparse)
-	    all.weights.sparse_weights.set_default<uint32_t, set_rand<sparse_parameters> >(stride);
+	    all.weights.sparse_weights.set_default<uint32_t, set_rand_wrapper<sparse_parameters> >(stride);
 	  else
-	    all.weights.dense_weights.set_default<uint32_t, set_rand<dense_parameters> >(stride);
+	    all.weights.dense_weights.set_default<uint32_t, set_rand_wrapper<dense_parameters> >(stride);
 	}
     }
 

--- a/vowpalwabbit/lda_core.cc
+++ b/vowpalwabbit/lda_core.cc
@@ -668,11 +668,13 @@ struct initial_weights
     : _initial(initial), _initial_random(initial_random), _random(random), _lda(lda), _stride(stride){}
 };
 
-template<class T>
-void set_initial_lda(typename T::iterator& iter, initial_weights& iw)
+template<class T> class set_initial_lda_wrapper
 {
-	uint32_t lda = iw._lda;
-	weight initial_random = iw._initial_random;
+public:    
+    static void func(typename T::iterator& iter, initial_weights& iw)
+    {
+    	uint32_t lda = iw._lda;
+    	weight initial_random = iw._initial_random;
 	if (iw._random)
 	  {
 	    uint64_t index = iter.index();
@@ -682,7 +684,8 @@ void set_initial_lda(typename T::iterator& iter, initial_weights& iw)
 		}
 	  }
 	(&(*iter))[lda] = iw._initial;
-}
+    }
+};
 
 void save_load(lda &l, io_buf &model_file, bool read, bool text)
 { vw& all = *(l.all);
@@ -691,9 +694,9 @@ void save_load(lda &l, io_buf &model_file, bool read, bool text)
   { initialize_regressor(all);
     initial_weights init(all.initial_t, (float)(l.lda_D / all.lda / all.length() * 200), all.random_weights, all.lda, all.weights.stride());
     if (all.weights.sparse)
-      all.weights.sparse_weights.set_default<initial_weights, set_initial_lda<sparse_parameters> >(init);
+      all.weights.sparse_weights.set_default<initial_weights, set_initial_lda_wrapper<sparse_parameters> >(init);
     else
-      all.weights.dense_weights.set_default<initial_weights, set_initial_lda<dense_parameters> >(init);
+      all.weights.dense_weights.set_default<initial_weights, set_initial_lda_wrapper<dense_parameters> >(init);
   }
   if (model_file.files.size() > 0)
   { uint64_t i = 0;

--- a/vowpalwabbit/parse_regressor.cc
+++ b/vowpalwabbit/parse_regressor.cc
@@ -25,19 +25,31 @@ using namespace std;
 #include "vw_validate.h"
 #include "vw_versions.h"
 
-template <class T> void set_initial(typename T::iterator& iter, float& initial) { *iter = initial; }
+template <class T> class set_initial_wrapper 
+{
+public:
+    static void func(typename T::iterator& iter, float& initial) { *iter = initial; }    
+};
 	
-template <class T> void random_positive(typename T::iterator& iter)
+template <class T> class random_positive_wrapper 
 {
-  uint64_t index = iter.index();
-  *iter = (float)(0.1 * merand48(index));
-}
+public:
+   static void func(typename T::iterator& iter)
+    {
+      uint64_t index = iter.index();
+      *iter = (float)(0.1 * merand48(index));
+    }
+};
 
-template <class T> void random_weights(typename T::iterator& iter)
+template <class T> class random_weights_wrapper
 {
-  uint64_t index = iter.index();
-  *iter = (float)(merand48(index) - 0.5);
-}
+public:    
+    static void func(typename T::iterator& iter)
+    {
+      uint64_t index = iter.index();
+      *iter = (float)(merand48(index) - 0.5);
+    }
+};
 
 template<class T> void initialize_regressor(vw& all, T& weights)
 { // Regressor is already initialized.
@@ -52,11 +64,11 @@ template<class T> void initialize_regressor(vw& all, T& weights)
   if (weights.mask() == 0)
     { THROW(" Failed to allocate weight array with " << all.num_bits << " bits: try decreasing -b <bits>"); }
   else if (all.initial_weight != 0.)
-    weights.template set_default<float,set_initial<T> >(all.initial_weight);
+    weights.template set_default<float,set_initial_wrapper<T> >(all.initial_weight);
   else if (all.random_positive_weights)
-    weights.template set_default<random_positive<T> >();
+    weights.template set_default<random_positive_wrapper<T> >();
   else if (all.random_weights)
-    weights.template set_default<random_weights<T> >();
+    weights.template set_default<random_weights_wrapper<T> >();
 }
 
 void initialize_regressor(vw& all)


### PR DESCRIPTION
resolves #1183 
The problem with GCC 6.x is described here: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=79508
It's a regression. In short - GCC since 5.4.1 understands only template classes in nested template list arguments while VW tries to push function pointer there. So I've just wrapped all functions in classes and make them static.