### PR TITLE
fixing a small bug

### DIFF
--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -447,7 +447,7 @@ const char* are_features_compatible(vw& vw1, vw& vw2)
   if (vw1.num_bits != vw2.num_bits)
     return "num_bits";
 
-  if (vw1.permutations != vw1.permutations)
+  if (vw1.permutations != vw2.permutations)
     return "permutations";
 
   if (vw1.interactions.size() != vw2.interactions.size())


### PR DESCRIPTION
My compiler is barking:
```
parse_args.cc: In function ‘const char* VW::are_features_compatible(vw&, vw&)’:
parse_args.cc:450:24: warning: self-comparison always evaluates to false [-Wtautological-compare]
   if (vw1.permutations != vw1.permutations)
```