### PR TITLE
do not use deprecated sklearn module

### DIFF
--- a/python/README.rst
+++ b/python/README.rst
@@ -60,7 +60,7 @@ Or you can use the included scikit-learn interface like this:
 
     >>> import numpy as np
     >>> from sklearn import datasets
-    >>> from sklearn.cross_validation import train_test_split
+    >>> from sklearn.model_selection import train_test_split
     >>> from vowpalwabbit.sklearn_vw import VWClassifier
     >>>
     >>> # generate some data

--- a/python/examples/sklearn_vw.ipynb
+++ b/python/examples/sklearn_vw.ipynb
@@ -24,7 +24,7 @@
     "\n",
     "import numpy as np\n",
     "from sklearn import datasets\n",
-    "from sklearn.cross_validation import train_test_split\n",
+    "from sklearn.model_selection import train_test_split\n",
     "\n",
     "# get some data\n",
     "X, y = datasets.make_hastie_10_2(n_samples=10000, random_state=1)\n",


### PR DESCRIPTION
sklearn.cross_validation module was deprecated in version 0.18 in favor of the model_selection module into which all the refactored classes and functions are moved. This module will be removed in 0.20