### PR TITLE
JNI memory leak fix + CentOS6 build manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,24 +239,10 @@ git clone https://github.com/JohnLangford/vowpal_wabbit.git
 cd vowpal_wabbit
 git checkout <VERSION_TAG>
 
-CFLAGS='-fPIC' CXXFLAGS='-fPIC' ./autogen.sh
-sudo make install
+sudo make JAVA_HOME='/usr/lib/jvm/java-openjdk/' install
 ```
 
-### Build JNI bindings
-```bash
-sudo yum install -y java-1.8.0-openjdk java-1.8.0-openjdk-devel
-make FLAGS='-fPIC -I../rapidjson/include -std=c++11' JAVA_HOME='/usr/lib/jvm/java-openjdk/' UNAME=`uname` -C java things
-```
-
-### (Optional) additional OS tools
-##### Install `lsb_release`
-The tool is needed for Java JNI runtime to find the correct version of `vw_jni...` binding file in the classpath.
-Install this if you see `NullPointerException` from `vowpalWabbit.jni.NativeUtils.lsbRelease`.
-
-```
-sudo yum install -y redhat-lsb
-```
+This also builds the JNI bindings at `java/target/libvw_jni.so`.
 
 ## Code Documentation
 To browse the code more easily, do

--- a/README.md
+++ b/README.md
@@ -192,6 +192,72 @@ cd python
 python setup.py install
 ```
 
+## CentOS 6-specific info
+
+The following steps describe compiling and installation of VW (including the JNI bindings) from scratch and assumes a bare CentOS 6 system.
+
+The compilation requires **libboost v1.59** modules available as shared objects to be present on the target system. If already present on the system the second step can be skipped.
+
+To check if boost is available run the following:
+
+```bash
+ldconfig -p | grep program_options
+```
+
+If installed the output should contain lines like these:
+
+```bash
+libboost_program_options.so.1.59.0 (libc6,x86-64) => /usr/local/lib/libboost_program_options.so.1.59.0
+libboost_program_options.so (libc6,x86-64) => /usr/local/lib/libboost_program_options.so
+```
+
+### Install and enable a c++11 compatible compiler
+```bash
+sudo wget http://people.centos.org/tru/devtools-2/devtools-2.repo -O /etc/yum.repos.d/devtools-2.repo
+sudo yum -y install gcc gcc-c++ devtoolset-2-gcc devtoolset-2-binutils devtoolset-2-gcc-c++ zlib-devel automake libtool
+scl enable devtoolset-2 bash
+```
+
+### Compile and install boost 1.59 as a shared object library
+```bash
+sudo yum install -y python-devel libxml2-devel libxslt-devel bzip2-devel
+wget https://freefr.dl.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.gz
+tar -xzf boost_1_59_0.tar.gz
+cd boost_1_59_0
+./bootstrap.sh
+sudo ./b2 -a -d2 -q -j 2 variant=release cxxflags="-fPIC" cflags="-fPIC" install
+
+sudo bash -c "echo /usr/local/lib > /etc/ld.so.conf.d/boost-x86_64.conf"
+sudo ldconfig
+```
+
+### Compile and install VW
+```bash
+cd ~
+sudo yum install -y git
+git clone https://github.com/JohnLangford/vowpal_wabbit.git
+cd vowpal_wabbit
+git checkout <VERSION_TAG>
+
+CFLAGS='-fPIC' CXXFLAGS='-fPIC' ./autogen.sh
+sudo make install
+```
+
+### Build JNI bindings
+```bash
+sudo yum install -y java-1.8.0-openjdk java-1.8.0-openjdk-devel
+make FLAGS='-fPIC -I../rapidjson/include -std=c++11' JAVA_HOME='/usr/lib/jvm/java-openjdk/' UNAME=`uname` -C java things
+```
+
+### (Optional) additional OS tools
+##### Install `lsb_release`
+The tool is needed for Java JNI runtime to find the correct version of `vw_jni...` binding file in the classpath.
+Install this if you see `NullPointerException` from `vowpalWabbit.jni.NativeUtils.lsbRelease`.
+
+```
+sudo yum install -y redhat-lsb
+```
+
 ## Code Documentation
 To browse the code more easily, do
 

--- a/java/Makefile
+++ b/java/Makefile
@@ -41,7 +41,7 @@ pom_version: pom.xml
 	newVer=$$(perl -e "@a=split('\.', '$$ver'); \$$a[2]++; print(join('.', @a))") && \
 	perl -pi -e "s/(\s*)<version>.*-SNAPSHOT/\1<version>$$newVer-SNAPSHOT/" pom.xml
 
-$(LOCAL_LIBRARY): $(jni_OBJS) ../vowpalwabbit/main.o ../vowpalwabbit/libvw.a ../vowpalwabbit/liballreduce.a
+$(LOCAL_LIBRARY): $(jni_OBJS) ../vowpalwabbit/main.o ../vowpalwabbit/.libs/libvw.a ../vowpalwabbit/.libs/liballreduce.a
 	mkdir -p target;
 	$(CXX) -shared $(FLAGS) -o $@ $^ $(VWLIBS) $(STDLIBS) $(JAVA_INCLUDE)
 
@@ -58,5 +58,5 @@ install: $(LOCAL_LIBRARY)
 
 .PHONY: clean
 clean:
-	rm -f $(LOCAL_LIBRARY)
+	rm -rf $(LOCAL_LIBRARY)
 	rm -f $(jni_SRCS:.cc=.o)

--- a/java/Makefile
+++ b/java/Makefile
@@ -41,7 +41,7 @@ pom_version: pom.xml
 	newVer=$$(perl -e "@a=split('\.', '$$ver'); \$$a[2]++; print(join('.', @a))") && \
 	perl -pi -e "s/(\s*)<version>.*-SNAPSHOT/\1<version>$$newVer-SNAPSHOT/" pom.xml
 
-$(LOCAL_LIBRARY): $(jni_OBJS) ../vowpalwabbit/main.o ../vowpalwabbit/.libs/libvw.a ../vowpalwabbit/.libs/liballreduce.a
+$(LOCAL_LIBRARY): $(jni_OBJS) ../vowpalwabbit/main.o ../vowpalwabbit/libvw.a ../vowpalwabbit/liballreduce.a
 	mkdir -p target;
 	$(CXX) -shared $(FLAGS) -o $@ $^ $(VWLIBS) $(STDLIBS) $(JAVA_INCLUDE)
 

--- a/java/src/main/c++/vowpalWabbit_learner_VWLearners.cc
+++ b/java/src/main/c++/vowpalWabbit_learner_VWLearners.cc
@@ -7,13 +7,16 @@
 
 JNIEXPORT jlong JNICALL Java_vowpalWabbit_learner_VWLearners_initialize(JNIEnv *env, jclass obj, jstring command)
 { jlong vwPtr = 0;
+  const char* utf_string = env->GetStringUTFChars(command, NULL);
   try
-  { vw* vwInstance = VW::initialize(env->GetStringUTFChars(command, NULL));
+  { vw* vwInstance = VW::initialize(utf_string);
     vwPtr = (jlong)vwInstance;
   }
   catch(...)
-  { rethrow_cpp_exception_as_java_exception(env);
+  { env->ReleaseStringUTFChars(command, utf_string);
+    rethrow_cpp_exception_as_java_exception(env);
   }
+  env->ReleaseStringUTFChars(command, utf_string);
   return vwPtr;
 }
 


### PR DESCRIPTION
Hi guys,

I've updated the JNI bindings with a fix that addresses a memory leak when creating new VWLearner instances: every `env->GetStringUTFChars` should be paired with a corresponding `env->ReleaseStringUTFChars` otherwise the string arrays never get cleaned up. (docs: [JNIEnv.GetStringUTFChars](https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#GetStringUTFChars)).

Additionally, I've extended the README with CentOS 6 build and install steps.

Looking forward to your feedback.

Thanks,

Anton