### PR TITLE
Removing spurious "cout" statements

### DIFF
--- a/vowpalwabbit/search.cc
+++ b/vowpalwabbit/search.cc
@@ -467,7 +467,6 @@ void add_new_feature(search_private& priv, float val, uint64_t idx)
 
 void del_features_in_top_namespace(search_private& priv, example& ec, size_t ns)
 {
-  cout << "del_top " << endl;
   if ((ec.indices.size() == 0) || (ec.indices.last() != ns))
   { if (ec.indices.size() == 0)
     { THROW("internal error (bug): expecting top namespace to be '" << ns << "' but it was empty"); }
@@ -528,7 +527,6 @@ void add_neighbor_features(search_private& priv)
 
 void del_neighbor_features(search_private& priv)
 { if (priv.neighbor_features.size() == 0) return;
-  cout << "del_neighbor_feat" << endl;
   for (size_t n=0; n<priv.ec_seq.size(); n++)
     del_features_in_top_namespace(priv, *priv.ec_seq[n], neighbor_namespace);
 }
@@ -676,7 +674,7 @@ void add_example_conditioning(search_private& priv, example& ec, size_t conditio
 }
 
 void del_example_conditioning(search_private& priv, example& ec)
-{cout << "del_example_cond" << endl;
+{
   if ((ec.indices.size() > 0) && (ec.indices.last() == conditioning_namespace))
     del_features_in_top_namespace(priv, ec, conditioning_namespace);
 }


### PR DESCRIPTION
When running in --search mode, there are *lots* of printed lines that contain
- "del_top"
- "del_example_cond"
