### PR TITLE
reset current_pass to 0 rather than 1 in test_only

### DIFF
--- a/test/test-sets/ref/0099.stderr
+++ b/test/test-sets/ref/0099.stderr
@@ -8,7 +8,7 @@ Reading datafile = train-sets/0001.dat
 num sources = 1
 average  since         example        example  current  current  current
 loss     last          counter         weight    label  predict features
-0.000000 -0.000000            1            1.0   1.0000   1.0000       51
+0.000000 0.000000            1            1.0   1.0000   1.0000       51
 0.135919 0.271838            2            2.0   0.0000   0.5214      104
 0.120355 0.104791            4            4.0   0.0000   0.1711      135
 0.081709 0.043063            8            8.0   0.0000   0.0000      146
@@ -18,8 +18,8 @@ loss     last          counter         weight    label  predict features
 0.016897 0.006737          128          128.0   1.0000   0.8131      106
 
 finished run
-number of examples per pass = 100
-passes used = 2
+number of examples per pass = 200
+passes used = 1
 weighted example sum = 200.000000
 weighted label sum = 91.000000
 average loss = 0.012333

--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -827,7 +827,7 @@ void save_load_online_state(vw& all, io_buf& model_file, bool read, bool text, g
 		all.sd->old_weighted_labeled_examples = 0.;
 		all.sd->example_number = 0;
 		all.sd->total_features = 0;
-		all.current_pass = 1;
+		all.current_pass = 0;
 	}
 	if (all.weights.sparse)
 		save_load_online_state(all, model_file, read, text, g, msg, all.weights.sparse_weights);


### PR DESCRIPTION
Otherwise "vw -t" reports halved 'number of examples per pass'.

without this patch

$ vw test/train-sets/rcv1_micro.dat -f tmp.model --save_resume --quiet && vw test/train-sets/rcv1_micro.dat -i tmp.model -t 2>&1 | egrep 'number of|passes'
number of examples per pass = 5
passes used = 2

with this patch:

$ vw test/train-sets/rcv1_micro.dat -f tmp.model --save_resume --quiet && vw test/train-sets/rcv1_micro.dat -i tmp.model -t 2>&1 | egrep 'number of|passes'
number of examples per pass = 10
passes used = 1