### PR TITLE
fix --binary when used together with bootstrap

### DIFF
--- a/test/RunTests
+++ b/test/RunTests
@@ -1573,3 +1573,11 @@ echo "1 | feature:1" | {VW} -a --initial_weight 0.1 --initial_t 0.3
 {VW} -d train-sets/decisionservice.json --dsjson --cb_explore_adf --epsilon 0.2 --quadratic GT
     train-sets/ref/decisionservice.stderr
 
+# Test 159: test --bootstrap & --binary interaction
+{VW} train-sets/rcv1_mini.dat --bootstrap 5 --binary -c -k --passes 2
+    train-sets/ref/bootstrap_and_binary.stderr
+
+# Test 160: test --bootstrap & --oaa interaction
+# # (Also adds -q :: and -P1 to get & verify perfect predictions in 2nd pass)
+{VW} train-sets/multiclass --bootstrap 4 --oaa 10 -q :: --leave_duplicate_interactions  -c -k --passes 2 --holdout_off -P1
+    train-sets/ref/bootstrap_and_oaa.stderr

--- a/test/train-sets/ref/bootstrap_and_binary.stderr
+++ b/test/train-sets/ref/bootstrap_and_binary.stderr
@@ -1,0 +1,29 @@
+Num weight bits = 18
+learning rate = 0.5
+initial_t = 0
+power_t = 0.5
+decay_learning_rate = 1
+creating cache_file = train-sets/rcv1_mini.dat.cache
+Reading datafile = train-sets/rcv1_mini.dat
+num sources = 1
+average  since         example        example  current  current  current
+loss     last          counter         weight    label  predict features
+0.000000 0.000000            1            1.0  -1.0000  -1.0000      128
+0.000000 0.000000            2            2.0  -1.0000  -1.0000       44
+0.250000 0.500000            4            4.0  -1.0000  -1.0000      190
+0.250000 0.250000            8            8.0   1.0000   1.0000       34
+0.312500 0.375000           16           16.0   1.0000  -1.0000      193
+0.250000 0.187500           32           32.0   1.0000   1.0000       48
+0.359375 0.468750           64           64.0  -1.0000  -1.0000      119
+0.281250 0.203125          128          128.0  -1.0000   1.0000       38
+0.214286 0.214286          256          256.0  -1.0000  -1.0000       78 h
+
+finished run
+number of examples per pass = 225
+passes used = 2
+weighted example sum = 450.000000
+weighted label sum = -58.000000
+average loss = 0.200000 h
+best constant = -0.128889
+best constant's loss = 0.983388
+total feature number = 34586

--- a/test/train-sets/ref/bootstrap_and_oaa.stderr
+++ b/test/train-sets/ref/bootstrap_and_oaa.stderr
@@ -1,0 +1,39 @@
+creating quadratic features for pairs: :: 
+Num weight bits = 18
+learning rate = 0.5
+initial_t = 0
+power_t = 0.5
+decay_learning_rate = 1
+creating cache_file = train-sets/multiclass.cache
+Reading datafile = train-sets/multiclass
+num sources = 1
+average  since         example        example  current  current  current
+loss     last          counter         weight    label  predict features
+0.000000 0.000000            1            1.0        1        1        3
+0.500000 1.000000            2            2.0        2        1        3
+0.666667 1.000000            3            3.0        3        1        3
+0.750000 1.000000            4            4.0        4        1        3
+0.800000 1.000000            5            5.0        5        2        3
+0.833333 1.000000            6            6.0        6        3        3
+0.857143 1.000000            7            7.0        7        6        3
+0.875000 1.000000            8            8.0        8        6        3
+0.888889 1.000000            9            9.0        9        8        3
+0.900000 1.000000           10           10.0       10        8        3
+0.818182 0.000000           11           11.0        1        1        3
+0.750000 0.000000           12           12.0        2        2        3
+0.692308 0.000000           13           13.0        3        3        3
+0.642857 0.000000           14           14.0        4        4        3
+0.600000 0.000000           15           15.0        5        5        3
+0.562500 0.000000           16           16.0        6        6        3
+0.529412 0.000000           17           17.0        7        7        3
+0.500000 0.000000           18           18.0        8        8        3
+0.473684 0.000000           19           19.0        9        9        3
+0.450000 0.000000           20           20.0       10       10        3
+
+finished run
+number of examples per pass = 10
+passes used = 2
+weighted example sum = 20.000000
+weighted label sum = 0.000000
+average loss = 0.450000
+total feature number = 60

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -1115,6 +1115,7 @@ void parse_reductions(vw& all)
   all.reduction_stack.push_back(scorer_setup);
 
   //Reductions
+  all.reduction_stack.push_back(bs_setup);
   all.reduction_stack.push_back(binary_setup);
 
   all.reduction_stack.push_back(ExpReplay::expreplay_setup<'m', MULTICLASS::mc_label>);
@@ -1136,11 +1137,9 @@ void parse_reductions(vw& all)
   all.reduction_stack.push_back(cb_explore_adf_setup);
   all.reduction_stack.push_back(cbify_setup);
   all.reduction_stack.push_back(explore_eval_setup);
-
   all.reduction_stack.push_back(ExpReplay::expreplay_setup<'c', COST_SENSITIVE::cs_label>);
-  all.reduction_stack.push_back(Search::setup);
-  all.reduction_stack.push_back(bs_setup);
 
+  all.reduction_stack.push_back(Search::setup);
   all.reduction_stack.push_back(audit_regressor_setup);
 
   all.l = setup_base(all);


### PR DESCRIPTION
When --binary and --bootstrap are used together, the binary's logic is currently applied
before bootstrap's causing undesirable effect: the finaly loss reported is no longer binary,
the predictions are no longer -1 / 1.

This commit puts binary's reduction last which fixes the behavior in this case: --bootstrap is no
longer affected by whether binary is present, but final predictions and loss are correctly binarized.

Note, I haven't tested or tried to understand how that affects interations of binary and other
reductions that change order because of this commit.