### PR TITLE
cb: greedified bagging

### DIFF
--- a/vowpalwabbit/cb_explore_adf.cc
+++ b/vowpalwabbit/cb_explore_adf.cc
@@ -37,6 +37,7 @@ struct cb_explore_adf
   size_t cover_size;
   float lambda;
   uint64_t offset;
+  bool greedify;
 
   bool need_to_clear;
   vw* all;
@@ -137,46 +138,49 @@ void predict_or_learn_first(cb_explore_adf& data, base_learner& base, v_array<ex
     preds[0].score += 1.f - data.epsilon;
   }
   
-  template <bool is_learn>
-  void predict_or_learn_bag(cb_explore_adf& data, base_learner& base, v_array<example*>& examples)
-  { //Randomize over predictions from a base set of predictors
-    v_array<action_score>& preds = examples[0]->pred.a_s;
-    uint32_t num_actions = (uint32_t)(examples.size() - 1);
-    if (CB::ec_is_example_header(*examples[0]))
-      num_actions--;
-    if (num_actions == 0)
-      {
-	preds.erase();
-	return;
-      }
-
-    data.action_probs.resize(num_actions);
-    data.action_probs.erase();
-    for (uint32_t i = 0; i < num_actions; i++)
-      data.action_probs.push_back({ i,0. });
-    float prob = 1.f / (float)data.bag_size;
-    bool test_sequence = test_adf_sequence(data.ec_seq) == nullptr;
-    for (uint32_t i = 0; i < data.bag_size; i++) 
-      {
-		// avoid updates to the random num generator
-	uint32_t count = is_learn ? BS::weight_gen(*data.all) : 0;
-	if (is_learn && count > 0 && !test_sequence)
-	  multiline_learn_or_predict<true>(base, examples, data.offset, i);
-	else
-	  multiline_learn_or_predict<false>(base, examples, data.offset, i);
-	assert(preds.size() == num_actions);
-	data.action_probs[preds[0].action].score += prob;
-	if (is_learn && !test_sequence)
-	  for (uint32_t j = 1; j < count; j++)
-	    multiline_learn_or_predict<true>(base, examples, data.offset, i);
-      }
-    
-    CB_EXPLORE::safety(data.action_probs, data.epsilon, true);
-    qsort((void*) data.action_probs.begin(), data.action_probs.size(), sizeof(action_score), reverse_order);
-    
-    for (size_t i = 0; i < num_actions; i++)
-      preds[i] = data.action_probs[i];
+template <bool is_learn>
+void predict_or_learn_bag(cb_explore_adf& data, base_learner& base, v_array<example*>& examples)
+{ //Randomize over predictions from a base set of predictors
+  v_array<action_score>& preds = examples[0]->pred.a_s;
+  uint32_t num_actions = (uint32_t)(examples.size() - 1);
+  if (CB::ec_is_example_header(*examples[0]))
+    num_actions--;
+  if (num_actions == 0)
+  {
+    preds.erase();
+    return;
   }
+
+  data.action_probs.resize(num_actions);
+  data.action_probs.erase();
+  for (uint32_t i = 0; i < num_actions; i++)
+    data.action_probs.push_back({ i,0. });
+  float prob = 1.f / (float)data.bag_size;
+  bool test_sequence = test_adf_sequence(data.ec_seq) == nullptr;
+  for (uint32_t i = 0; i < data.bag_size; i++) 
+  {
+    // avoid updates to the random num generator
+    // for greedify, always update first policy once
+    uint32_t count = is_learn
+      ? ((data.greedify && i == 0) ? 1 : BS::weight_gen(*data.all))
+      : 0;
+    if (is_learn && count > 0 && !test_sequence)
+      multiline_learn_or_predict<true>(base, examples, data.offset, i);
+    else
+      multiline_learn_or_predict<false>(base, examples, data.offset, i);
+    assert(preds.size() == num_actions);
+    data.action_probs[preds[0].action].score += prob;
+    if (is_learn && !test_sequence)
+      for (uint32_t j = 1; j < count; j++)
+        multiline_learn_or_predict<true>(base, examples, data.offset, i);
+  }
+
+  CB_EXPLORE::safety(data.action_probs, data.epsilon, true);
+  qsort((void*) data.action_probs.begin(), data.action_probs.size(), sizeof(action_score), reverse_order);
+
+  for (size_t i = 0; i < num_actions; i++)
+    preds[i] = data.action_probs[i];
+}
   
 template <bool is_learn>
 void predict_or_learn_cover(cb_explore_adf& data, base_learner& base, v_array<example*>& examples)
@@ -460,6 +464,7 @@ base_learner* cb_explore_adf_setup(vw& all)
   ("bag", po::value<size_t>(), "bagging-based exploration")
   ("cover",po::value<size_t>() ,"Online cover based exploration")
   ("softmax", "softmax exploration")
+  ("greedify", "always update first policy once in bagging")
   ("lambda", po::value<float>(), "parameter for softmax");
   add_options(all);
 
@@ -491,9 +496,12 @@ base_learner* cb_explore_adf_setup(vw& all)
   }
   else if (vm.count("bag"))
   { data.bag_size = (uint32_t)vm["bag"].as<size_t>();
+    data.greedify = vm.count("greedify") > 0;
     data.explore_type = BAG_EXPLORE;
     problem_multiplier = data.bag_size;
     *all.file_options << " --bag "<< data.bag_size;
+    if (data.greedify)
+      *all.file_options << " --greedify";
   }
   else if (vm.count("first"))
   { data.tau = (uint32_t)vm["first"].as<size_t>();


### PR DESCRIPTION
This adds the --greedify option for bagging: updates happen exactly once for the
first policy in the bag (based on discussions with @JohnLangford). This seems to often help in practice.
Perhaps the option name could be improved.
I also fixed indentation in the entire function.