### PR TITLE
Baseline + cb changes

### DIFF
--- a/vowpalwabbit/baseline.cc
+++ b/vowpalwabbit/baseline.cc
@@ -149,19 +149,21 @@ base_learner* baseline_setup(vw& all)
     data.lr_multiplier = all.vm["lr_multiplier"].as<float>();
   data.check_enabled = all.vm.count("check_enabled") > 0;
   data.global_only = all.vm.count("global_only") > 0;
-  if (data.global_only)
-  { // use a separate global
-    data.ec->indices.push_back(constant_namespace);
-    // shifted index to avoid conflicts
-    data.ec->feature_space[constant_namespace].push_back(1, constant - 17);
-    data.ec->total_sum_feat_sq++;
-    data.ec->num_features++;
-  }
 
   base_learner* base = setup_base(all);
   learner<baseline>& l = init_learner(&data, base, predict_or_learn<true>, predict_or_learn<false>);
 
   l.set_finish(finish);
+
+  if (data.global_only)
+  { // use a separate example for global constant
+    data.ec->indices.push_back(constant_namespace);
+    // different index from constant to avoid conflicts
+    data.ec->feature_space[constant_namespace].push_back(
+        1, (constant - 17) << all.weights.stride_shift());
+    data.ec->total_sum_feat_sq++;
+    data.ec->num_features++;
+  }
 
   return make_base(l);
 }

--- a/vowpalwabbit/baseline.h
+++ b/vowpalwabbit/baseline.h
@@ -3,4 +3,14 @@ Copyright (c) by respective owners including Yahoo!, Microsoft, and
 individual contributors. All rights reserved.  Released under a BSD
 license as described in the file LICENSE.
  */
+#pragma once
+
 LEARNER::base_learner* baseline_setup(vw& all);
+
+namespace BASELINE
+{
+// utility functions for disabling baseline on a given example
+void set_baseline_enabled(example* ec);
+void reset_baseline_disabled(example* ec);
+bool baseline_enabled(example* ec);
+}

--- a/vowpalwabbit/cb_adf.cc
+++ b/vowpalwabbit/cb_adf.cc
@@ -360,6 +360,7 @@ base_learner* cb_adf_setup(vw& all)
 
   // number of weight vectors needed
   size_t problem_multiplier = 1;//default for IPS
+  bool check_baseline_enabled = false;
   if (all.vm.count("cb_type"))
   { std::string type_string;
 
@@ -369,6 +370,8 @@ base_learner* cb_adf_setup(vw& all)
     if (type_string.compare("dr") == 0)
     { ld.gen_cs.cb_type = CB_TYPE_DR;
       problem_multiplier = 2;
+      // only use baseline when manually enabled for loss estimation
+      check_baseline_enabled = true;
     }
     else if (type_string.compare("ips") == 0)
     { ld.gen_cs.cb_type = CB_TYPE_IPS;
@@ -413,6 +416,9 @@ base_learner* cb_adf_setup(vw& all)
       all.args.push_back("multiline");
     if (count(all.args.begin(), all.args.end(), "--csoaa_rank") == 0)
       all.args.push_back("--csoaa_rank");
+  }
+  if (count(all.args.begin(), all.args.end(), "--baseline") && check_baseline_enabled)
+  { all.args.push_back("--check_enabled");
   }
 
   base_learner* base = setup_base(all);

--- a/vowpalwabbit/cb_algs.h
+++ b/vowpalwabbit/cb_algs.h
@@ -4,6 +4,9 @@ individual contributors. All rights reserved.  Released under a BSD
 license as described in the file LICENSE.
  */
 #pragma once
+
+#include "baseline.h"
+
 //TODO: extend to handle CSOAA_LDF and WAP_LDF
 LEARNER::base_learner* cb_algs_setup(vw& all);
 
@@ -14,6 +17,8 @@ LEARNER::base_learner* cb_algs_setup(vw& all);
 
 namespace CB_ALGS
 {
+
+
 template <bool is_learn>
 float get_cost_pred(LEARNER::base_learner* scorer, CB::cb_class* known_cost, example& ec, uint32_t index, uint32_t base)
 { CB::label ld = ec.l.cb;
@@ -25,6 +30,8 @@ float get_cost_pred(LEARNER::base_learner* scorer, CB::cb_class* known_cost, exa
   else
     simple_temp.label = FLT_MAX;
 
+  const bool baseline_enabled_old = BASELINE::baseline_enabled(&ec);
+  BASELINE::set_baseline_enabled(&ec);
   ec.l.simple = simple_temp;
   polyprediction p = ec.pred;
   if (is_learn && known_cost != nullptr && index == known_cost->action)
@@ -35,6 +42,9 @@ float get_cost_pred(LEARNER::base_learner* scorer, CB::cb_class* known_cost, exa
   }
   else
     scorer->predict(ec, index-1+base);
+
+  if (!baseline_enabled_old)
+    BASELINE::reset_baseline_disabled(&ec);
   float pred = ec.pred.scalar;
   ec.pred = p;
 

--- a/vowpalwabbit/cbify.cc
+++ b/vowpalwabbit/cbify.cc
@@ -228,6 +228,12 @@ base_learner* cbify_setup(vw& all)
     ss << num_actions;
     all.args.push_back(ss.str());
   }
+  if (count(all.args.begin(), all.args.end(), "--baseline"))
+  { all.args.push_back("--lr_multiplier");
+    stringstream ss;
+    ss << max<float>(abs(data.loss0), abs(data.loss1)) / (data.loss1 - data.loss0);
+    all.args.push_back(ss.str());
+  }
   base_learner* base = setup_base(all);
 
   all.delete_prediction = nullptr;

--- a/vowpalwabbit/example.h
+++ b/vowpalwabbit/example.h
@@ -26,6 +26,7 @@ const unsigned char spelling_namespace  = 133;   // this is \x85
 const unsigned char conditioning_namespace = 134;// this is \x86
 const unsigned char dictionary_namespace  = 135; // this is \x87
 const unsigned char node_id_namespace  = 136; // this is \x88
+const unsigned char message_namespace  = 137; // this is \x89
 
 typedef union
 { label_data simple;


### PR DESCRIPTION
* parameter for lr multiplier, added automatically in cbify
* mechanism to only use baseline when manually specified in a feature. Used in DR to only use baseline for loss estimates.

cc @JohnLangford 