### PR TITLE
add --hash_seed option

### DIFF
--- a/cs/cli/vowpalwabbit.cpp
+++ b/cs/cli/vowpalwabbit.cpp
@@ -112,7 +112,7 @@ VowpalWabbitPerformanceStatistics^ VowpalWabbit::PerformanceStatistics::get()
 }
 
 uint64_t VowpalWabbit::HashSpace(String^ s)
-{ auto newHash = m_hasher(s, hash_base);
+{ auto newHash = m_hasher(s, 0);
 
 #ifdef _DEBUG
   auto oldHash = HashSpaceNative(s);

--- a/test/RunTests
+++ b/test/RunTests
@@ -1601,3 +1601,11 @@ echo "1 | feature:1" | {VW} -a --initial_weight 0.1 --initial_t 0.3
 # Test 165: cs_active high mellowness
 {VW} --cs_active 3 -d ../test/train-sets/cs_test --cost_max 2 --mellowness 1.0 --simulation --adax
     train-sets/ref/cs_active_1.0.stderr
+
+# Test 166: hash_seed train
+{VW} --hash_seed 5 -d train-sets/rcv1_mini.dat --holdout_off --passes 2 -f hash_seed5.model -c -k --ngram 2 -q ::
+    train-sets/ref/hash_seed_train.stderr
+
+# Test 167: hash_seed test
+{VW} -d train-sets/rcv1_mini.dat -i hash_seed5.model -t
+    train-sets/ref/hash_seed_test.stderr

--- a/test/save_resume_test.py
+++ b/test/save_resume_test.py
@@ -113,6 +113,7 @@ if __name__ == '__main__':
     else:
         errors += do_test(filename, '')
         errors += do_test(filename, '-b 22')
+        errors += do_test(filename, '--hash_seed 10')
         errors += do_test(filename, '--loss_function logistic')
         errors += do_test(filename, '--boosting 10')
         errors += do_test(filename, '--bootstrap 10')

--- a/test/train-sets/ref/hash_seed_test.stderr
+++ b/test/train-sets/ref/hash_seed_test.stderr
@@ -1,0 +1,32 @@
+Generating 2-grams for all namespaces.
+creating quadratic features for pairs: :: 
+WARNING: duplicate namespace interactions were found. Removed: 4278.
+You can use --leave_duplicate_interactions to disable this behaviour.
+only testing
+Num weight bits = 18
+learning rate = 0.5
+initial_t = 0
+power_t = 0.5
+using no cache
+Reading datafile = train-sets/rcv1_mini.dat
+num sources = 1
+average  since         example        example  current  current  current
+loss     last          counter         weight    label  predict features
+0.077284 0.077284            1            1.0  -1.0000  -0.7220    32385
+0.041674 0.006065            2            2.0  -1.0000  -0.9221     3741
+0.030923 0.020171            4            4.0  -1.0000  -0.8484    71631
+0.027502 0.024082            8            8.0   1.0000   0.9214     2211
+0.035515 0.043529           16           16.0   1.0000   0.9767     3570
+0.024695 0.013874           32           32.0  -1.0000  -0.9606     4278
+0.031099 0.037503           64           64.0   1.0000   1.0000     5671
+0.022095 0.013092          128          128.0  -1.0000  -1.0000     8778
+
+finished run
+number of examples per pass = 250
+passes used = 1
+weighted example sum = 250.000000
+weighted label sum = -30.000000
+average loss = 0.014494
+best constant = -0.120000
+best constant's loss = 0.985600
+total feature number = 4176509

--- a/test/train-sets/ref/hash_seed_train.stderr
+++ b/test/train-sets/ref/hash_seed_train.stderr
@@ -1,0 +1,34 @@
+Generating 2-grams for all namespaces.
+creating quadratic features for pairs: :: 
+WARNING: duplicate namespace interactions were found. Removed: 4278.
+You can use --leave_duplicate_interactions to disable this behaviour.
+final_regressor = hash_seed5.model
+Num weight bits = 18
+learning rate = 0.5
+initial_t = 0
+power_t = 0.5
+decay_learning_rate = 1
+creating cache_file = train-sets/rcv1_mini.dat.cache
+Reading datafile = train-sets/rcv1_mini.dat
+num sources = 1
+average  since         example        example  current  current  current
+loss     last          counter         weight    label  predict features
+1.000000 1.000000            1            1.0  -1.0000   0.0000    32385
+0.747407 0.494815            2            2.0  -1.0000  -0.2966     3741
+0.772949 0.798490            4            4.0  -1.0000  -1.0000    71631
+1.622789 2.472629            8            8.0   1.0000  -0.1378     2211
+1.372107 1.121425           16           16.0   1.0000   0.7096     3570
+1.483492 1.594877           32           32.0  -1.0000  -0.0765     4278
+1.323154 1.162815           64           64.0   1.0000   0.0982     5671
+1.230178 1.137203          128          128.0  -1.0000   0.0846     8778
+1.093884 0.957590          256          256.0  -1.0000  -0.9719    38781
+
+finished run
+number of examples per pass = 250
+passes used = 2
+weighted example sum = 500.000000
+weighted label sum = -60.000000
+average loss = 0.638042
+best constant = -0.120000
+best constant's loss = 0.985600
+total feature number = 8353018

--- a/vowpalwabbit/global_data.h
+++ b/vowpalwabbit/global_data.h
@@ -470,6 +470,8 @@ struct vw
   uint32_t num_bits; // log_2 of the number of features.
   bool default_bits;
 
+  uint32_t hash_seed;
+
   std::string data_filename; // was vm["data"]
 
   bool daemon;

--- a/vowpalwabbit/hash.h
+++ b/vowpalwabbit/hash.h
@@ -44,6 +44,4 @@ static inline uint32_t fmix(uint32_t h)
 }
 }
 
-const uint32_t hash_base = 0;
-
 uint64_t uniform_hash(const void *key, size_t length, uint64_t seed);

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -577,6 +577,7 @@ void parse_feature_tweaks(vw& all)
   ("keep", po::value< vector<string> >(), "keep namespaces beginning with character <arg>")
   ("redefine", po::value< vector<string> >(), "redefine namespaces beginning with characters of string S as namespace N. <arg> shall be in form 'N:=S' where := is operator. Empty N or S are treated as default namespace. Use ':' as a wildcard in S.")
   ("bit_precision,b", po::value<size_t>(), "number of bits in the feature table")
+  ("hash_seed", po::value<size_t>(), "seed for hash function")
   ("noconstant", "Don't add a constant feature")
   ("constant,C", po::value<float>(&(all.initial_constant)), "Set initial value of constant")
   ("ngram", po::value< vector<string> >(), "Generate N grams. To generate N grams for a single namespace 'foo', arg should be fN.")
@@ -662,6 +663,13 @@ void parse_feature_tweaks(vw& all)
     all.num_bits = new_bits;
 
     VW::validate_num_bits(all);
+  }
+
+  if (vm.count("hash_seed"))
+  { all.hash_seed = (uint32_t)vm["hash_seed"].as<size_t>();
+    *all.file_options << " --hash_seed " << vm["hash_seed"].as<size_t>();
+  } else {
+    all.hash_seed = 0;
   }
 
   all.permutations = vm.count("permutations") > 0;

--- a/vowpalwabbit/parse_example.cc
+++ b/vowpalwabbit/parse_example.cc
@@ -69,6 +69,7 @@ public:
   uint64_t* affix_features;
   bool* spelling_features;
   v_array<char> spelling;
+  uint32_t hash_seed;
 
   vector<feature_dict*>* namespace_dictionaries;
 
@@ -298,7 +299,7 @@ public:
           free(base);
         base = base_v_array.begin();
       }
-      channel_hash = p->hasher(name, hash_base);
+      channel_hash = p->hasher(name, this->hash_seed);
       nameSpaceInfoValue();
     }
   }
@@ -338,7 +339,7 @@ public:
         base[0] = ' ';
         base[1] = '\0';
       }
-      channel_hash = 0;
+      channel_hash = this->hash_seed == 0 ? 0 : uniform_hash("", 0, this->hash_seed);
       listFeatures();
     }
     else if(*reading_head != ':')
@@ -386,6 +387,7 @@ public:
       this->spelling_features = all.spelling_features;
       this->namespace_dictionaries = all.namespace_dictionaries;
       this->base = nullptr;
+      this->hash_seed = all.hash_seed;
       listNameSpace();
       if (base != nullptr)
         free(base);

--- a/vowpalwabbit/vw.h
+++ b/vowpalwabbit/vw.h
@@ -118,13 +118,13 @@ inline uint32_t hash_space(vw& all, std::string s)
 { substring ss;
   ss.begin = (char*)s.c_str();
   ss.end = ss.begin + s.length();
-  return (uint32_t)all.p->hasher(ss,hash_base);
+  return (uint32_t)all.p->hasher(ss, all.hash_seed);
 }
 inline uint32_t hash_space_static(std::string s, std::string hash)
 { substring ss;
   ss.begin = (char*)s.c_str();
   ss.end = ss.begin + s.length();
-  return (uint32_t)getHasher(hash)(ss, hash_base);
+  return (uint32_t)getHasher(hash)(ss, 0);
 }
 //Then use it as the seed for hashing features.
 inline uint32_t hash_feature(vw& all, std::string s, uint64_t u)


### PR DESCRIPTION
When collisions are present, setting this will change the groups of features that collide.
If VW is used as a base model for ensemble classifier, setting different hash_seeds will reduce correlations.

I cleaned up hash_base static variable since I did not want there to be two places where hash seed can be set.