### PR TITLE
Add ability to pass a list in a python wrapper parameter, which will be translated into multiple keys

### DIFF
--- a/python/tests/test_pyvw.py
+++ b/python/tests/test_pyvw.py
@@ -138,3 +138,12 @@ def test_regressor_args():
     # clean up
     os.remove('{}.cache'.format(data_file))
     os.remove('tmp.model')
+
+
+def test_keys_with_list_of_values():
+    # No exception in creating and executing model with a key/list pair
+    model = vw(quiet=True, q=["fa", "fb"])
+    model.learn('1 | a b c')
+    prediction = model.predict(' | a b c')
+    assert isinstance(prediction, float)
+    del model

--- a/python/vowpalwabbit/pyvw.py
+++ b/python/vowpalwabbit/pyvw.py
@@ -57,9 +57,12 @@ class vw(pylibvw.vw):
         you can also use key/value pairs as in:
           pyvw.vw(audit=True, b=24, k=True, c=True, l2=0.001)
         or a combination, for instance:
-          pyvw.vw("--audit", b=26)"""
+          pyvw.vw("--audit", b=26)
+        value in a pair could also be a list of values, for instance:
+          pyvw.vw("-q", ["ab", "ac"])
+        will be translated into passing two -q keys"""
 
-        def format_inputs(key, val):
+        def format_input_pair(key, val):
             if type(val) is bool and not val:
                 s = ''
             else:
@@ -68,7 +71,14 @@ class vw(pylibvw.vw):
                 s = '{p}{k}{v}'.format(p=prefix, k=key, v=value)
             return s
 
-        l = [format_inputs(k, v) for k, v in kw.items()]
+        def format_input(key, val):
+            if isinstance(val, list):
+                # if a list is passed as a parameter value - create a key for each list element
+                return ' '.join([format_input_pair(key, value) for value in val])
+            else:
+                return format_input_pair(key, val)
+
+        l = [format_input(k, v) for k, v in kw.items()]
         if arg_str is not None:
             l = [arg_str] + l
 


### PR DESCRIPTION
Currently vowpal-wabbit in cmd accepts multiple instances of the same key, for example, quadratic features could be configured thru "-q ab -q ac", on the same time it's impossible to make ```pyvw.vw(q="ab", q="ac")``` by python syntax limitation and to make ```pyvw.vw(q=["ab", "ac"])``` by the current implementation. And the only one way to do it now - mixing separate parameters with plain ```arg_str='-q ab -q ac'```.

A goal of this pull request is to make the second way of passing multi-valued keys acceptable.