### PR TITLE
Don't clobber --with-boost and --with-boost-libdir

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -19,20 +19,24 @@ case $( uname -s ) in
   ;;
  Linux)
   AC_PATH=/usr/share
-  ldconfig=""
-  for p in `echo ${PATH} | sed 's/:/ /g'` /sbin /usr/sbin; do
-    if test -x ${p}/ldconfig; then
-      ldconfig=${p}/ldconfig
-      break
-    fi
-  done
-  if test "x${ldconfig}" = x; then
-    ldconfig=ldconfig
+  if [[ "${@#--with-boost}" = "$@" ]]; then
+   ldconfig=""
+   for p in `echo ${PATH} | sed 's/:/ /g'` /sbin /usr/sbin; do
+     if test -x ${p}/ldconfig; then
+       ldconfig=${p}/ldconfig
+       break
+     fi
+   done
+   if test "x${ldconfig}" = x; then
+     ldconfig=ldconfig
+   fi
+   LIBFILE=`${ldconfig} -p | grep program_options | tail -n 1 | cut -d '>' -f 2`
+   echo "Boost at: $LIBFILE"
+   BOOST_DIR_ARG="--with-boost-libdir=`dirname $LIBFILE`"
+   echo "Using $BOOST_DIR_ARG"
+  else
+   BOOST_DIR_ARG=''
   fi
-  LIBFILE=`${ldconfig} -p | grep program_options | tail -n 1 | cut -d '>' -f 2`
-  echo "Boost at: $LIBFILE"
-  BOOST_DIR_ARG="--with-boost-libdir=`dirname $LIBFILE`"
-  echo "Using $BOOST_DIR_ARG"
   alias vwlibtool=libtoolize
   ;;
  *)


### PR DESCRIPTION
This is necessary to specify a different boost on CentOS.