### PR TITLE
Add a test that exposes race condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ script:
   - make python
   - mvn clean test -f java/pom.xml
   - make test
+  - cd test
+  - ./test_race_condition.sh
+  - cd ..
   - make test_gcov --always-make
   - cd python
   - source activate test-python27

--- a/test/repeat.py
+++ b/test/repeat.py
@@ -1,0 +1,46 @@
+import subprocess
+import difflib
+import sys
+
+
+count = int(sys.argv[1])
+cmd = sys.argv[2:]
+counter = 0
+next_print = 1
+error = 0
+expected = None
+
+for counter in xrange(1, count + 1):
+    p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    out, err = p.communicate('')
+    out += err or ''
+    if expected is None:
+        expected = out
+        continue
+
+    failed = False
+    if p.wait() != 0:
+        failed = True
+        sys.stderr.write("Return code: %s\n" % p.wait())
+
+    if expected != out:
+        failed = True
+        sys.stderr.write('\nOutput changed:\n\n')
+        d = difflib.Differ()
+        diff = d.compare(expected.split('\n'), out.split('\n'))
+        sys.stderr.write('\n'.join(diff) + '\n')
+
+    if failed:
+        error += 1
+
+    if counter >= next_print or failed:
+        sys.stderr.write("%s failed out of%5s\n" % (error, counter))
+        if counter >= next_print:
+            next_print *= 2
+
+    if error:
+        break
+
+
+if error:
+    sys.exit(1)

--- a/test/test_race_condition.sh
+++ b/test/test_race_condition.sh
@@ -1,0 +1,1 @@
+exec python repeat.py 1024 ../vowpalwabbit/vw train-sets/rcv1_small.dat --holdout_after 100


### PR DESCRIPTION
This test repeatedly runs `vw train-sets/rcv1_small.dat --holdout_after 100` and checks if the output remains the same. It finds that sometimes vw incorrectly reports that average loss is undefined.

Second commit runs this test on travis and makes it fail there. 

```
./test_race_condition.sh
0 failed out of    2
0 failed out of    3
0 failed out of    4
0 failed out of    8
0 failed out of   16
0 failed out of   32

Output changed:

  Num weight bits = 18
  learning rate = 0.5
  initial_t = 0
  power_t = 0.5
  using no cache
  Reading datafile = train-sets/rcv1_small.dat
  num sources = 1
  average  since         example        example  current  current  current
  loss     last          counter         weight    label  predict features
  1.000000 1.000000            1            1.0  -1.0000   0.0000      128
  0.893728 0.787455            2            2.0  -1.0000  -0.1126       44
  0.905122 0.916517            4            4.0  -1.0000  -0.1701      190
  0.924790 0.944458            8            8.0   1.0000  -0.0231       34
  0.894742 0.864695           16           16.0   1.0000   0.0065       43
  0.875196 0.855650           32           32.0  -1.0000   0.0423       47
  0.838072 0.800947           64           64.0   1.0000   0.0619       54
  
  finished run
- number of examples per pass = 99
?                    ---------

+ number of examples = 99
- passes used = 1
  weighted example sum = 99.000000
  weighted label sum = -13.000000
- average loss = 0.669583 h
+ average loss = undefined (no holdout)
  best constant = -0.131313
  best constant's loss = 0.982757
  total feature number = 7788
  
1 failed out of   45
```
  