### PR TITLE
Add --onethread option to disable parsing thread

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ java: vw
 test: .FORCE vw library_example
 	@echo "vw running test-suite..."
 	(cd test && ./RunTests -d -fe -E 0.001 ../vowpalwabbit/vw)
+	(cd test && ./RunTests -d -fe -E 0.001 -O --onethread ../vowpalwabbit/vw)
 
 test_gcov: .FORCE vw_gcov library_example_gcov
 	@echo "vw running test-suite..."

--- a/vowpalwabbit/global_data.h
+++ b/vowpalwabbit/global_data.h
@@ -474,6 +474,7 @@ struct vw
 
   std::string data_filename; // was vm["data"]
 
+  bool onethread;
   bool daemon;
   size_t num_children;
 

--- a/vowpalwabbit/learner.cc
+++ b/vowpalwabbit/learner.cc
@@ -60,6 +60,71 @@ void process_example(vw& all, example* ec)
     dispatch_example(all, *ec);
 }
 
+template <class T, void(*f)(T, example*)> void generic_driver_onethread(vw& x_all, T context)
+{
+  vw* all = &x_all;
+
+  v_array<example*> examples = v_init<example*>();
+  size_t example_number = 0;  // for variable-size batch learning algorithms
+
+  // XXX get rid of ring buffer there?
+
+  try
+  {
+    size_t examples_available;
+    while(!all->p->done)
+    {
+      examples.push_back(&VW::get_unused_example(all)); // need at least 1 example
+      if (!all->do_reset_source && example_number != all->pass_length && all->max_examples > example_number && all->p->reader(all, examples) > 0)
+      {
+        VW::setup_examples(*all, examples);
+        example_number+=examples.size();
+        examples_available=examples.size();
+      }
+      else
+      {
+        reset_source(*all, all->num_bits);
+        all->do_reset_source = false;
+        all->passes_complete++;
+
+        examples[0]->end_pass = true;
+        all->p->in_pass_counter = 0;
+
+        if (all->passes_complete == all->numpasses && example_number == all->pass_length)
+        {
+          all->passes_complete = 0;
+          all->pass_length = all->pass_length*2+1;
+        }
+        if (all->passes_complete >= all->numpasses && all->max_examples >= example_number)
+        {
+          all->p->done = true;
+        }
+        example_number = 0;
+        examples_available=1;
+      }
+
+      all->p->end_parsed_examples+=examples_available;
+
+      for (int i = 0; i < examples_available; ++i)
+        f(context, examples[i]);
+
+      examples.erase();
+    }
+    all->l->end_examples();
+  }
+  catch (VW::vw_exception& e)
+  {
+    cerr << "vw example #" << example_number << "(" << e.Filename() << ":" << e.LineNumber() << "): " << e.what() << endl;
+  }
+  catch (exception& e)
+  {
+    cerr << "vw: example #" << example_number << e.what() << endl;
+  }
+
+  all->p->done = true;
+  examples.delete_v();
+}
+
 template <class T, void(*f)(T, example*)> void generic_driver(vw& all, T context)
 {
   example* ec = nullptr;
@@ -92,6 +157,19 @@ void generic_driver(vector<vw*> alls)
     (*it)->l->end_examples();
 }
 
+void generic_driver_onethread(vector<vw*> alls)
+{
+  generic_driver_onethread<vector<vw*>, process_multiple>(**alls.begin(), alls);
+
+  // skip first as it already called end_examples()
+  auto it = alls.begin();
+  for (it++; it != alls.end(); it++)
+    (*it)->l->end_examples();
+}
+
 void generic_driver(vw& all)
 { generic_driver<vw&, process_example>(all, all); }
+
+void generic_driver_onethread(vw& all)
+{ generic_driver_onethread<vw&, process_example>(all, all); }
 }

--- a/vowpalwabbit/learner.h
+++ b/vowpalwabbit/learner.h
@@ -76,6 +76,8 @@ struct finish_example_data
 
 void generic_driver(vw& all);
 void generic_driver(std::vector<vw*> alls);
+void generic_driver_onethread(vw& all);
+void generic_driver_onethread(std::vector<vw*> alls);
 
 inline void noop_sl(void*, io_buf&, bool, bool) {}
 inline void noop(void*) {}

--- a/vowpalwabbit/main.cc
+++ b/vowpalwabbit/main.cc
@@ -101,13 +101,20 @@ int main(int argc, char *argv[])
     //struct timeb t_start, t_end;
     //ftime(&t_start);
 
-    VW::start_parser(all);
-    if (alls.size() == 1)
-      LEARNER::generic_driver(all);
-    else
-      LEARNER::generic_driver(alls);
+    if (all.onethread) {
+        if (alls.size() == 1)
+          LEARNER::generic_driver_onethread(all);
+        else
+          LEARNER::generic_driver_onethread(alls);
+    } else {
+        VW::start_parser(all);
+        if (alls.size() == 1)
+          LEARNER::generic_driver(all);
+        else
+          LEARNER::generic_driver(alls);
 
-    VW::end_parser(all);
+        VW::end_parser(all);
+    }
 
     // ftime(&t_end);
     // double net_time = (int) (1000.0 * (t_end.time - t_start.time) + (t_end.millitm - t_start.millitm));

--- a/vowpalwabbit/parse_args.cc
+++ b/vowpalwabbit/parse_args.cc
@@ -1313,7 +1313,9 @@ vw& parse_args(int argc, char *argv[], trace_message_t trace_listener, void* tra
 
     new_options(all, "VW options")
     ("random_seed", po::value<uint64_t>(&(all.random_seed)), "seed random number generator")
-    ("ring_size", po::value<size_t>(&(all.p->ring_size)), "size of example ring");
+    ("ring_size", po::value<size_t>(&(all.p->ring_size)), "size of example ring")
+    ("onethread", "Disable parse thread")
+    ;
     add_options(all);
 
     new_options(all, "Update options")
@@ -1340,6 +1342,8 @@ vw& parse_args(int argc, char *argv[], trace_message_t trace_listener, void* tra
       all.weights.sparse = true;
     else
       all.weights.sparse = false;
+
+    all.onethread = vm.count("onethread");
 
     new_options(all, "Parallelization options")
     ("span_server", po::value<string>(), "Location of server for setting up spanning tree")


### PR DESCRIPTION
Enabling this option fixes races conditions, like the one in #1383 

I've also modified 'make test' to run all the tests with --onethread enabled.

Another benefit of --onethread is that when running multiple vw instances on a multi-core machine it makes it easier to manage resources (the optimal number of vw processes is number of cores) whereas if vw uses two threads this is no longer true.