### PR TITLE
check for endLine when parsing

### DIFF
--- a/vowpalwabbit/parse_example.cc
+++ b/vowpalwabbit/parse_example.cc
@@ -306,7 +306,7 @@ public:
 
   inline void listFeatures()
   {
-    while(*reading_head == ' ' || *reading_head == '\t')
+    while((*reading_head == ' ' || *reading_head == '\t') && (reading_head < endLine))
     {
       //listFeatures --> ' ' MaybeFeature ListFeatures
       ++reading_head;
@@ -359,7 +359,7 @@ public:
 
   inline void listNameSpace()
   {
-    while(*reading_head == '|')   // ListNameSpace --> '|' NameSpace ListNameSpace
+    while((*reading_head == '|') && (reading_head < endLine))   // ListNameSpace --> '|' NameSpace ListNameSpace
     {
       ++reading_head;
       nameSpace();

--- a/vowpalwabbit/parse_example.cc
+++ b/vowpalwabbit/parse_example.cc
@@ -91,7 +91,7 @@ public:
       // featureValue --> ':' 'Float'
       ++reading_head;
       char *end_read = nullptr;
-      v = parseFloat(reading_head,&end_read);
+      v = parseFloat(reading_head, &end_read, endLine);
       if(end_read == reading_head)
       {
         parserWarning("malformed example! Float expected after : \"", beginLine, reading_head, "\"");

--- a/vowpalwabbit/parse_primitives.h
+++ b/vowpalwabbit/parse_primitives.h
@@ -4,7 +4,7 @@ individual contributors. All rights reserved.  Released under a BSD
 license as described in the file LICENSE.
  */
 #pragma once
-#include<iostream>
+#include <iostream>
 #include <stdint.h>
 #include <math.h>
 #include "v_array.h"
@@ -61,27 +61,28 @@ hash_func_t getHasher(const std::string& s);
 //  - much faster (around 50% but depends on the string to parse)
 //  - less error control, but utilised inside a very strict parser
 //    in charge of error detection.
-inline float parseFloat(char * p, char **end)
+inline float parseFloat(char * p, char **end, char * endLine = nullptr)
 { char* start = p;
+  bool endLine_is_null = endLine == nullptr;
 
   if (!*p)
   { *end = p;
     return 0;
   }
   int s = 1;
-  while (*p == ' ') p++;
+  while ((*p == ' ') && (endLine_is_null || p < endLine)) p++;
 
   if (*p == '-')
   { s = -1; p++;
   }
 
   float acc = 0;
-  while (*p >= '0' && *p <= '9')
+  while (*p >= '0' && *p <= '9' && (endLine_is_null || p < endLine))
     acc = acc * 10 + *p++ - '0';
 
   int num_dec = 0;
   if (*p == '.')
-  { while (*(++p) >= '0' && *p <= '9')
+  { while (*(++p) >= '0' && *p <= '9' && (endLine_is_null || p < endLine))
     { if (num_dec < 35)
       { acc = acc *10 + (*p - '0');
         num_dec++;
@@ -90,18 +91,18 @@ inline float parseFloat(char * p, char **end)
   }
 
   int exp_acc = 0;
-  if(*p == 'e' || *p == 'E')
+  if((*p == 'e' || *p == 'E') && (endLine_is_null || p < endLine))
   { p++;
     int exp_s = 1;
-    if (*p == '-')
+    if (*p == '-' && (endLine_is_null || p < endLine))
     { exp_s = -1; p++;
     }
-    while (*p >= '0' && *p <= '9')
+    while (*p >= '0' && *p <= '9' && (endLine_is_null || p < endLine))
       exp_acc = exp_acc * 10 + *p++ - '0';
     exp_acc *= exp_s;
 
   }
-  if (*p == ' ' || *p == '\n' || *p == '\t')//easy case succeeded.
+  if (*p == ' ' || *p == '\n' || *p == '\t' || p == endLine)//easy case succeeded.
   { acc *= powf(10,(float)(exp_acc-num_dec));
     *end = p;
     return s * acc;


### PR DESCRIPTION
When running in daemon mode, example parsing sometimes fails because the parser reads past the end of the example line.  These edits prevent that from happening.