### PR TITLE
Update boost-python installation info

### DIFF
--- a/python/README.rst
+++ b/python/README.rst
@@ -101,7 +101,7 @@ For Mac OSX
     $ brew install boost
     $ brew install boost-python
     # or for python3 (you may have to uninstall boost and reinstall to build python3 libs)
-    $ brew install boost-python --with-python3
+    $ brew install boost-python3
 
 Also, having Anaconda in your path can cause segmentation faults when importing the pyvw module. Providing Conda support
 is an open issue and efforts are welcome, but in the meantime it is suggested to remove any conda bin directory from your path


### PR DESCRIPTION
`--with-python3` flag isn't supported anymore for brew's `boost-python` https://stackoverflow.com/questions/48994346/installing-boost-python-for-python3-using-brew

Using flag caused me errors, but was able to install `vowpalwabbit` python package using `brew boost-python3` instead