### PR TITLE
Denik classweight2

### DIFF
--- a/test/RunTests
+++ b/test/RunTests
@@ -1587,11 +1587,11 @@ echo "1 | feature:1" | {VW} -a --initial_weight 0.1 --initial_t 0.3
     train-sets/ref/classweight.stderr
 
 # Test 162: --classweight with multiclass
-{VW} --oaa 10 -d train-sets/multiclass --classweight 4:0,7:0.1,2:10,10:3
+{VW} --oaa 10 -d train-sets/multiclass --classweight 4:0,7:0.1,2:10 --classweight 10:3
     train-sets/ref/classweight_multiclass.stderr
 
 # Test 163: --classweight with multiclass
-{VW} --recall_tree 10 -d train-sets/multiclass --classweight 4:0,7:0.1,2:10,10:3
+{VW} --recall_tree 10 -d train-sets/multiclass --classweight 4:0,7:0.1 --classweight 2:10,10:3
     train-sets/ref/classweight_recall_tree.stderr
 
 # Test 164: cs_active low mellowness

--- a/vowpalwabbit/classweight.cc
+++ b/vowpalwabbit/classweight.cc
@@ -71,13 +71,15 @@ using namespace CLASSWEIGHTS;
 
 LEARNER::base_learner* classweight_setup(arguments& arg)
 {
-  string classweight;
+  vector<string> classweight_array;
+  auto cweights = scoped_calloc_or_throw<classweights>();
   if (arg.new_options("importance weight classes")
-      .critical("classweight", classweight, "importance weight multiplier for class").missing())
+      .critical_vector<string>("classweight", po::value<vector<string> >(&classweight_array), "importance weight multiplier for class", false).missing())
     return nullptr;
 
-  auto cweights = scoped_calloc_or_throw<classweights>();
-  cweights->load_string(classweight);
+  for (auto& s : classweight_array)
+    cweights->load_string(s);
+
   if (!arg.all->quiet)
     arg.trace_message << "parsed " << cweights->weights.size() << " class weights" << endl;
 

--- a/vowpalwabbit/parser_helper.h
+++ b/vowpalwabbit/parser_helper.h
@@ -118,9 +118,12 @@ class arguments {
       missing_critical = !vm.count(option);
       return *this;
     }
-  template<class T> arguments& critical_vector(const char* option, po::typed_value<std::vector<T>>* type, const char* description)
+  template<class T> arguments& critical_vector(const char* option, po::typed_value<std::vector<T>>* type, const char* description, bool keep = true)
     {
-      keep_vector(option, type, description);
+      if (keep)
+        keep_vector(option, type, description);
+      else
+        operator()(option, type->multitoken()->composing(), description);
       missing();
       new_options();
       missing_critical = !vm.count(option);


### PR DESCRIPTION
Reconciling #1406   This also adds a 'keep=true' default argument to critical_vector() which we can set to 'false' so as to not keep classweight in the model file.