### PR TITLE
Improve some parsing in vw-hyperopt.py

### DIFF
--- a/utl/vw-hyperopt.py
+++ b/utl/vw-hyperopt.py
@@ -251,7 +251,7 @@ class HyperOptimizer(object):
         yh = open(self.holdout_set, 'r')
         self.y_true_holdout = []
         for line in yh:
-            self.y_true_holdout.append(float(line.split('|')[0]))
+            self.y_true_holdout.append(float(line.split()[0]))
         if not self.is_regression:
             self.y_true_holdout = [int((i + 1.) / 2) for i in self.y_true_holdout]
         self.logger.info("holdout length: %d" % len(self.y_true_holdout))


### PR DESCRIPTION
In this utility script, this part reads the holdout file and it seems like weights and tags are converted to float along with the label.
For the input `-1 0.2 1|`, this is trying to do `float("-1 0.2 1")` and thus raising a ValueError exception.
I think it's fair to consider the label only up to the first space.