### PR TITLE
Correctly exit loop searching for Boost libs on Linux

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -30,7 +30,7 @@ def find_boost():
             for candidate in ['-py36', '-py35', '-py34', '3']:
                 boost_lib = 'boost_python{}'.format(candidate)
                 if find_library(boost_lib):
-                    exit
+                    break
         if not find_library(boost_lib):
             boost_lib = "boost_python"
     elif system == 'Darwin':


### PR DESCRIPTION
It looks like line 33 in this file is supposed to stop iterating through candidates whenever `find_library` returns a non-empty result. However, `exit` is not what does that. `exit` is just a Python function (see https://docs.python.org/3/library/constants.html?highlight=exit#exit) which is simply sitting there, without being called. Even if it was called, it would exit the whole process, not the loop. Please see this for details: https://gist.github.com/jaidevd/81b870dacae045faabba587b73185386