### PR TITLE
README: Mention Graphviz dependency for doc generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,4 +224,5 @@ To browse the code more easily, do
 
 and then point your browser to `doc/html/index.html`.
 
-Note that documentation generates class diagrams -- among other things -- using [Graphviz](https://www.graphviz.org). For best results, ensure that it is installed beforehand.
+Note that documentation generates class diagrams using [Graphviz](https://www.graphviz.org). For best results, ensure that it is
+installed beforehand.

--- a/README.md
+++ b/README.md
@@ -224,5 +224,4 @@ To browse the code more easily, do
 
 and then point your browser to `doc/html/index.html`.
 
-Note that documentation generates class diagrams using [Graphviz](https://www.graphviz.org). For best results, ensure that it is
-installed beforehand.
+Note that documentation generates class diagrams using [Graphviz](https://www.graphviz.org). For best results, ensure that it is installed beforehand.

--- a/README.md
+++ b/README.md
@@ -223,3 +223,5 @@ To browse the code more easily, do
 `make doc`
 
 and then point your browser to `doc/html/index.html`.
+
+Note that documentation generates class diagrams -- among other things -- using [Graphviz](https://www.graphviz.org). For best results, ensure that it is installed beforehand.


### PR DESCRIPTION
Doxyfile has `HAVE_DOT` hard-coded to `YES`, which causes `command not found`
warnings when attempting to generate documentation on systems that don't have
Graphviz currently installed.

We add a clause in the corresponding section of the README that makes note of
this dependency.