### PR TITLE
Fix JavaScript quoting around pipe symbol in vw-validate.html (resolving LGTM.com alerts)

### DIFF
--- a/utl/vw-validate.html
+++ b/utl/vw-validate.html
@@ -107,7 +107,7 @@ p {
 
       var vwExPipeIdx = vwExample.indexOf("|");
       if (vwExPipeIdx == null) {
-        addExampleFeedback(i, "Missing pipe ("|") separator in example.");
+        addExampleFeedback(i, "Missing pipe ('|') separator in example.");
         continue;
       }
       var vwExPrefix = vwExample.substr(0, vwExPipeIdx);

--- a/utl/vw-validate.html
+++ b/utl/vw-validate.html
@@ -107,7 +107,7 @@ p {
 
       var vwExPipeIdx = vwExample.indexOf("|");
       if (vwExPipeIdx == null) {
-        addExampleFeedback(i, "Missing pipe ('|') separator in example.");
+        addExampleFeedback(i, "Missing pipe ('|') separator in example."); 
         continue;
       }
       var vwExPrefix = vwExample.substr(0, vwExPipeIdx);

--- a/utl/vw-validate.html
+++ b/utl/vw-validate.html
@@ -107,7 +107,7 @@ p {
 
       var vwExPipeIdx = vwExample.indexOf("|");
       if (vwExPipeIdx == null) {
-        addExampleFeedback(i, "Missing pipe ('|') separator in example."); 
+        addExampleFeedback(i, "Missing pipe ('|') separator in example.");
         continue;
       }
       var vwExPrefix = vwExample.substr(0, vwExPipeIdx);


### PR DESCRIPTION
LGTM.com correctly points out that there's something wrong in this JavaScript string:
  https://lgtm.com/projects/g/JohnLangford/vowpal_wabbit/snapshot/cb017a413b4dc4ce9e384af8cf34744881147f21/files/utl/vw-validate.html#xb9d8c0da7aca9de8:1

This should fix the last two alerts for vowpal_wabbit's JavaScript code, so should bump up the code quality score to an A+ :slightly_smiling_face: 

(Full disclosure: I'm part of the team that build LGTM.com)