### PR TITLE
New line workaround for rlclientlib

### DIFF
--- a/reinforcement_learning/rlclientlib/live_model_impl.cc
+++ b/reinforcement_learning/rlclientlib/live_model_impl.cc
@@ -103,7 +103,7 @@ namespace reinforcement_learning {
       _model(nullptr),
       _model_download(nullptr),
       _bg_model_proc(config.get_int(name::MODEL_REFRESH_INTERVAL_MS, 60 * 1000), &_error_cb),
-      _buffer_pool(new u::buffer_factory()) { }
+      _buffer_pool(new u::buffer_factory(utility::translate_func('\n', ' '))) { }
 
   int live_model_impl::init_model(api_status* status) {
     const auto model_impl = _configuration.get(name::MODEL_IMPLEMENTATION, value::VW);

--- a/reinforcement_learning/rlclientlib/logger/logger.h
+++ b/reinforcement_learning/rlclientlib/logger/logger.h
@@ -23,7 +23,7 @@ namespace reinforcement_learning {
 		//log to the outcome eventhub (direct sending, no batching)
 		int append_outcome(std::string&, api_status* = nullptr);
 
-	  private:
+	private:
     eventhub_client _ranking_client, _outcome_client; //clients to send data to the eventhub
 		async_batcher<eventhub_client> _ranking_batcher;    //handle batching for the data sent to the eventhub client
     async_batcher<eventhub_client> _outcome_batcher;    //handle batching for the data sent to the eventhub client

--- a/reinforcement_learning/rlclientlib/utility/data_buffer.cc
+++ b/reinforcement_learning/rlclientlib/utility/data_buffer.cc
@@ -4,6 +4,10 @@
 #include <iostream>
 
 namespace reinforcement_learning { namespace utility {
+  data_buffer::data_buffer() {}
+
+  data_buffer::data_buffer(const translate_func& _translate) : translate(_translate) {}
+
   void data_buffer::reset() { _buffer.clear(); }
 
   std::string data_buffer::str() const{
@@ -13,7 +17,9 @@ namespace reinforcement_learning { namespace utility {
 
   void data_buffer::remove_last() { _buffer.pop_back(); }
 
-  data_buffer* buffer_factory::operator()() const { return new data_buffer(); }
+  buffer_factory::buffer_factory(const translate_func& _translate) : translate(_translate) {}
+
+  data_buffer* buffer_factory::operator()() const { return new data_buffer(translate); }
 
   data_buffer& data_buffer::operator<<(const std::string& cs) {
     const auto data_len = cs.length();
@@ -21,7 +27,10 @@ namespace reinforcement_learning { namespace utility {
     // Ensure vector is big enough
     if (_buffer.capacity() < buff_sz + data_len)
       _buffer.reserve(buff_sz + data_len);
-    std::copy(cs.begin(), cs.end(), std::back_inserter(_buffer));
+    //workaround to be able to suppress '\n' on client side
+    for (auto c : cs)
+      _buffer.push_back(translate(c));
+    
     return *this;
   }
 
@@ -30,4 +39,10 @@ namespace reinforcement_learning { namespace utility {
   data_buffer& data_buffer::operator<<(size_t rhs) { return operator<<(std::to_string(rhs)); }
 
   data_buffer& data_buffer::operator<<(float rhs) { return operator<<(std::to_string(rhs)); }
+
+  translate_func::translate_func() : empty(true) {}
+
+  translate_func::translate_func(char _src, char _dst) : empty(false), src(_src), dst(_dst) {}
+
+  char translate_func::operator()(char c) const { return empty || c != src ? c : dst; }
 }}

--- a/reinforcement_learning/rlclientlib/utility/data_buffer.h
+++ b/reinforcement_learning/rlclientlib/utility/data_buffer.h
@@ -3,8 +3,24 @@
 #include <vector>
 
 namespace reinforcement_learning { namespace utility {
+  class translate_func
+  {
+  public:
+    translate_func();
+    translate_func(char _src, char _dst);
+
+    char operator()(char c) const;
+
+  private:
+    bool empty = true;
+    char src;
+    char dst;
+  };
+
   class data_buffer {
   public:
+    data_buffer();
+    data_buffer(const translate_func& _translate);
 
     void reset();
     std::string str() const;
@@ -17,11 +33,17 @@ namespace reinforcement_learning { namespace utility {
 
   private:
     std::vector<char> _buffer;
+    translate_func translate;
   };
 
   class buffer_factory {
   public:
+    buffer_factory(const translate_func& _translate);
+
     data_buffer* operator()() const;
+
+  private:
+    translate_func translate;
   };
 }}
 

--- a/reinforcement_learning/unit_test/data_buffer_test.cc
+++ b/reinforcement_learning/unit_test/data_buffer_test.cc
@@ -43,3 +43,20 @@ BOOST_AUTO_TEST_CASE(remove_last_from_nonempty_data_buffer) {
 
   BOOST_CHECK_EQUAL(buffer.str(), "test");
 }
+
+BOOST_AUTO_TEST_CASE(empty_data_buffer_reset) {
+  data_buffer buffer;
+
+  buffer.reset();
+
+  BOOST_CHECK_EQUAL(buffer.str(), "");
+}
+
+BOOST_AUTO_TEST_CASE(nonempty_data_buffer_reset) {
+  data_buffer buffer;
+
+  buffer << "test";
+  buffer.reset();
+
+  BOOST_CHECK_EQUAL(buffer.str(), "");
+}

--- a/reinforcement_learning/unit_test/data_buffer_test.cc
+++ b/reinforcement_learning/unit_test/data_buffer_test.cc
@@ -60,3 +60,12 @@ BOOST_AUTO_TEST_CASE(nonempty_data_buffer_reset) {
 
   BOOST_CHECK_EQUAL(buffer.str(), "");
 }
+
+BOOST_AUTO_TEST_CASE(translation_data_buffer_reset) {
+  data_buffer buffer(translate_func('s', 'n'));
+
+  buffer << "test";
+
+  BOOST_CHECK_EQUAL(buffer.str(), "tent");
+}
+

--- a/reinforcement_learning/unit_test/data_buffer_test.cc
+++ b/reinforcement_learning/unit_test/data_buffer_test.cc
@@ -1,0 +1,45 @@
+#define BOOST_TEST_DYN_LINK
+#ifdef STAND_ALONE
+#   define BOOST_TEST_MODULE Main
+#endif
+
+#include <boost/test/unit_test.hpp>
+#include "utility/data_buffer.h"
+
+using namespace reinforcement_learning;
+using namespace utility;
+using namespace std;
+
+BOOST_AUTO_TEST_CASE(new_data_buffer_is_empty) {
+  data_buffer buffer;
+
+  BOOST_CHECK_EQUAL(buffer.str(), "");
+}
+
+BOOST_AUTO_TEST_CASE(single_output_to_data_buffer) {
+  data_buffer buffer;
+
+  buffer << "test";
+
+  BOOST_CHECK_EQUAL(buffer.str(), "test");
+}
+
+BOOST_AUTO_TEST_CASE(multiple_outputs_to_data_buffer) {
+  data_buffer buffer;
+
+  const string value_string = "test";
+  const size_t value_size_t = 2;
+
+  buffer << value_string << value_size_t << value_string.c_str();
+
+  BOOST_CHECK_EQUAL(buffer.str(), "test2test");
+}
+
+BOOST_AUTO_TEST_CASE(remove_last_from_nonempty_data_buffer) {
+  data_buffer buffer;
+
+  buffer << "test1";
+  buffer.remove_last();
+
+  BOOST_CHECK_EQUAL(buffer.str(), "test");
+}

--- a/reinforcement_learning/unit_test/unit_test.vcxproj
+++ b/reinforcement_learning/unit_test/unit_test.vcxproj
@@ -161,6 +161,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="async_batcher_test.cc" />
+    <ClCompile Include="data_buffer_test.cc" />
     <ClCompile Include="data_callback_test.cc" />
     <ClCompile Include="err_callback_test.cc" />
     <ClCompile Include="concurrent_queue_test.cc" />

--- a/reinforcement_learning/unit_test/unit_test.vcxproj.filters
+++ b/reinforcement_learning/unit_test/unit_test.vcxproj.filters
@@ -80,6 +80,9 @@
     <ClCompile Include="status_builder_test.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="data_buffer_test.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
Getting rid of newlines within single request (workaround, while server-side parsing is not fixed)