### PR TITLE
Fixed bug causing to reset dump_interval to 1 when input model -i is provided

### DIFF
--- a/vowpalwabbit/cb.cc
+++ b/vowpalwabbit/cb.cc
@@ -210,7 +210,7 @@ void print_update(vw& all, bool is_test, example& ec, multi_ex* ec_seq, bool act
       else
         pred_buf << "no action";
       all.sd->print_update(all.holdout_set_off, all.current_pass, label_buf, pred_buf.str(),
-                           num_features, all.progress_add, all.progress_arg);;
+                           num_features, all.progress_add, all.progress_arg);
     }
     else
       all.sd->print_update(all.holdout_set_off, all.current_pass, label_buf, (uint32_t)pred,


### PR DESCRIPTION
Order of dump_interval modifications before bug fix:
1) dump_interval is initialized to 1 (see [here](https://github.com/JohnLangford/vowpal_wabbit/blob/master/vowpalwabbit/global_data.cc#L270))
2) dump_interval is updated according to -P input (see [here](https://github.com/JohnLangford/vowpal_wabbit/blob/master/vowpalwabbit/parse_args.cc#L353))
3) If -i is present, dump_interval is updated according to dump_interval at time of model saving (see [here](https://github.com/JohnLangford/vowpal_wabbit/blob/master/vowpalwabbit/gd.cc#L854))
4) if --preserve_performance_counter is not present (see [here](https://github.com/JohnLangford/vowpal_wabbit/blob/master/vowpalwabbit/gd.cc#L917)), dump_interval is WRONGLY reset to 1 (see [here](https://github.com/JohnLangford/vowpal_wabbit/blob/master/vowpalwabbit/gd.cc#L921)) rather than be reset to value after step 2