### PR TITLE
Fixed bug causing to reset dump_interval to 1 when input model -i is provided

### DIFF
--- a/vowpalwabbit/cb.cc
+++ b/vowpalwabbit/cb.cc
@@ -210,7 +210,7 @@ void print_update(vw& all, bool is_test, example& ec, multi_ex* ec_seq, bool act
       else
         pred_buf << "no action";
       all.sd->print_update(all.holdout_set_off, all.current_pass, label_buf, pred_buf.str(),
-                           num_features, all.progress_add, all.progress_arg);;
+                           num_features, all.progress_add, all.progress_arg);
     }
     else
       all.sd->print_update(all.holdout_set_off, all.current_pass, label_buf, (uint32_t)pred,

--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -850,9 +850,12 @@ void save_load_online_state(vw& all, io_buf& model_file, bool read, bool text, g
   bin_text_read_write_fixed(model_file, (char*)&all.sd->sum_loss_since_last_dump, sizeof(all.sd->sum_loss_since_last_dump),
                             "", read, msg, text);
 
-  msg << "dump_interval " << all.sd->dump_interval << "\n";
-  bin_text_read_write_fixed(model_file, (char*)&all.sd->dump_interval, sizeof(all.sd->dump_interval),
+  float dump_interval = all.sd->dump_interval;
+  msg << "dump_interval " << dump_interval << "\n";
+  bin_text_read_write_fixed(model_file, (char*)&dump_interval, sizeof(dump_interval),
                             "", read, msg, text);
+  if (!read || (all.training && all.preserve_performance_counters)) // update dump_interval from input model
+    all.sd->dump_interval = dump_interval;
 
   msg << "min_label " << all.sd->min_label << "\n";
   bin_text_read_write_fixed(model_file, (char*)&all.sd->min_label, sizeof(all.sd->min_label),
@@ -918,7 +921,6 @@ void save_load_online_state(vw& all, io_buf& model_file, bool read, bool text, g
   {
     all.sd->sum_loss = 0;
     all.sd->sum_loss_since_last_dump = 0;
-    all.sd->dump_interval = 1.;
     all.sd->weighted_labeled_examples = 0.;
     all.sd->weighted_labels = 0.;
     all.sd->weighted_unlabeled_examples = 0.;


### PR DESCRIPTION
Order of dump_interval modifications before bug fix:
1) dump_interval is initialized to 1 (see [here](https://github.com/JohnLangford/vowpal_wabbit/blob/master/vowpalwabbit/global_data.cc#L270))
2) dump_interval is updated according to -P input (see [here](https://github.com/JohnLangford/vowpal_wabbit/blob/master/vowpalwabbit/parse_args.cc#L353))
3) If -i is present, dump_interval is updated according to dump_interval at time of model saving (see [here](https://github.com/JohnLangford/vowpal_wabbit/blob/master/vowpalwabbit/gd.cc#L854))
4) if --preserve_performance_counter is not present (see [here](https://github.com/JohnLangford/vowpal_wabbit/blob/master/vowpalwabbit/gd.cc#L917)), dump_interval is WRONGLY reset to 1 (see [here](https://github.com/JohnLangford/vowpal_wabbit/blob/master/vowpalwabbit/gd.cc#L921)) rather than be reset to value after step 2