### PR TITLE
Python Client Library: Improvements to docs

### DIFF
--- a/reinforcement_learning/bindings/python/test/log_test_driver.py
+++ b/reinforcement_learning/bindings/python/test/log_test_driver.py
@@ -33,7 +33,7 @@ def main(args):
             current_example = json.loads(line)
 
             context_json = json.dumps(current_example["c"])
-            model_id, chosen_action_id, action_probabilities = model.choose_rank(current_example["EventId"], context_json)
+            model_id, chosen_action_id, actions_probabilities = model.choose_rank(current_example["EventId"], context_json)
 
             if("o" in current_example):
                 for observation in current_example["o"]:

--- a/reinforcement_learning/doc/python.dox
+++ b/reinforcement_learning/doc/python.dox
@@ -64,20 +64,20 @@ Note: `https://aka.ms/rl_client_python` points to a binary targeting x64 Linux P
 \param event_id The unique identifier for this interaction. This event_id must be used when reporting the outcome for this action
 \param context_json Contains action, action features and context features in JSON format
 \exception RuntimeError Thrown if an internal error occurs
-\return model_id, chosen_action_id, action_probabilities
+\return model_id, chosen_action_id, actions_probabilities
 \return model_id - Get the model id. Every call to choose action is associated with a unique model used to predict. A unique model id is associated with each unique model. (This is set internally by the API)
 \return chosen_action_id - ID of action chosen by model
-\return action_probabilities - List of pairs (action_id, probability) ranked by the model's prediction
+\return actions_probabilities - List of pairs (action_id, probability) ranked by the model's prediction
 
 \fn rl_client::live_model::choose_rank(context_json)
 \memberof rl_client::live_model
 \brief Choose an action, given a list of actions, action features and context features. The inference library chooses an action by creating a probability distribution over the actions and then sampling from it.
 \param context_json Contains action, action features and context features in JSON format
 \exception RuntimeError Thrown if an internal error occurs
-\return model_id, chosen_action_id, action_probabilities, event_id
+\return model_id, chosen_action_id, actions_probabilities, event_id
 \return model_id - Get the model id. Every call to choose action is associated with a unique model used to predict. A unique model id is associated with each unique model. (This is set internally by the API)
 \return chosen_action_id - ID of action chosen by model
-\return action_probabilities - List of pairs (action_id, probability) ranked by the model's prediction
+\return actions_probabilities - List of pairs (action_id, probability) ranked by the model's prediction
 \return event_id - 	Unique id for this ranking request. This event_id must be used when calling report_outcome so it can be joined with the chosen action
 
 \fn rl_client::live_model::report_outcome(event_id, outcome)

--- a/reinforcement_learning/examples/python/basic_usage.py
+++ b/reinforcement_learning/examples/python/basic_usage.py
@@ -19,19 +19,19 @@ def main():
     event_id = "event_id"
     context = '{"User":{"id":"a","major":"eng","hobby":"hiking"},"_multi":[{"N1":{"F1":"V1"},"N2":{"F2":"V2"}},{"N3":{"F1":"V3"}}]}'
 
-    model_id, chosen_action_id, action_probabilities = model.choose_rank(event_id, context)
+    model_id, chosen_action_id, actions_probabilities = model.choose_rank(event_id, context)
 
     print("event_id: " + event_id)
     print("model_id: " + model_id)
     print("chosen action id: " + str(chosen_action_id))
-    print("all action probabilities " + str(action_probabilities))
+    print("all action probabilities " + str(actions_probabilities))
 
-    model_id, chosen_action_id, action_probabilities, event_id = model.choose_rank(context)
+    model_id, chosen_action_id, actions_probabilities, event_id = model.choose_rank(context)
 
     print("event_id: " + event_id)
     print("model_id: " + model_id)
     print("chosen action id: " + str(chosen_action_id))
-    print("all action probabilities " + str(action_probabilities))
+    print("actions probabilities list: " + str(actions_probabilities))
 
     outcome = 1.0
     model.report_outcome(event_id, outcome)

--- a/reinforcement_learning/examples/python/rl_sim.py
+++ b/reinforcement_learning/examples/python/rl_sim.py
@@ -2,7 +2,6 @@ import argparse
 import random
 import sys
 import time
-import uuid
 
 import rl_client
 
@@ -16,19 +15,18 @@ def load_config_from_json(file_name):
         return rl_client.create_config_from_json(config_file.read())
 
 class person:
-    def __init__(self, id, major, hobby, fav_char, p):
+    def __init__(self, id, major, hobby, fav_char, prob):
         self._id = id
         self._major = major
         self._hobby = hobby
         self._favorite_character = fav_char
-        self._topic_click_probability = p
+        self._topic_click_probability = prob
 
     def get_features(self):
         return '"User":{{"id":"{}","major":"{}","hobby":"{}","favorite_character":"{}"}}'.format(self._id, self._major, self._hobby, self._favorite_character)
 
     def get_outcome(self, chosen_action):
-        draw_uniform = random.uniform(0, 10000)
-        norm_draw_val = draw_uniform / 10000.0
+        norm_draw_val = random.random()
         click_prob = self._topic_click_probability[chosen_action]
         if (norm_draw_val <= click_prob):
             return 1.0
@@ -40,11 +38,11 @@ class rl_sim:
         self._options = args
 
         self.config = load_config_from_json(self._options.json_config)
-        self._rl = rl_client.live_model(self.config, my_error_callback())
-        self._rl.init()
+        self._rl_client = rl_client.live_model(self.config, my_error_callback())
+        self._rl_client.init()
 
-        tp1 = {'HerbGarden': 0.6, "MachineLearning": 0.4 }
-        tp2 = {'HerbGarden': 0.2, "MachineLearning": 0.8 }
+        tp1 = {'HerbGarden': 0.3, "MachineLearning": 0.2 }
+        tp2 = {'HerbGarden': 0.1, "MachineLearning": 0.4 }
 
         self._actions = ['HerbGarden', 'MachineLearning']
         self._people = [
@@ -55,31 +53,28 @@ class rl_sim:
         round = 0
         while (True):
             try:
-                p = self.pick_a_random_person()
-                context_features = p.get_features()
+                # random.sample() returns a list
+                person = random.sample(self._people, 1)[0]
+                
+                # create context
+                shared_features = person.get_features()
                 action_features = '"_multi": [ {"topic":"HerbGarden"}, {"topic":"MachineLearning"} ]'
-                context_json = self.create_context_json(context_features, action_features)
-                req_id = str(uuid.uuid4())
+                context = '{{ {}, {} }}'.format(shared_features, action_features)
 
-                model_id, chosen_action_id, action_probabilities = self._rl.choose_rank(req_id, context_json)
-                outcome = p.get_outcome(self._actions[chosen_action_id])
-                self._rl.report_outcome(req_id, outcome)
+                model_id, chosen_action_id, actions_probabilities, event_id = self._rl_client.choose_rank(context)
+                
+                outcome = person.get_outcome(self._actions[chosen_action_id])
+                self._rl_client.report_outcome(event_id, outcome)
 
                 print('Round: {}, Person: {}, Action: {}, Outcome: {}'
-                    .format(round, p._id, chosen_action_id, outcome))
+                    .format(round, person._id, chosen_action_id, outcome))
 
-                round = round + 1
+                round += 1
                 time.sleep(0.1)
             except Exception as e:
                 print(e)
                 time.sleep(2)
                 continue
-
-    def pick_a_random_person(self):
-        return self._people[random.randint(0, len(self._people) - 1)]
-
-    def create_context_json(self, context, action):
-        return '{{ {}, {} }}'.format(context, action)
 
 def process_cmd_line(args):
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
action_probabilities -> actions_probabilities

In rl_sim.py:
- `p` was used both for probability and person: used `person`, and `prob` now
- removed one line functions used only once (e.g., pick_a_random_person, create_context_json)
- renamed req_id to event_id