### PR TITLE
OpenSsl linking problem workaround

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,9 @@ shallow_clone: true
 clone_folder: C:\vowpal_wabbit
 # need to install nuget packages before Visual Studio starts to make ANTLR targets available.
 build_script:
+# Temporary workaround: https://github.com/Microsoft/vcpkg/issues/4189#issuecomment-417462822
+- rd /s /q C:\OpenSSL-v11-Win32
+- rd /s /q C:\OpenSSL-v11-Win64
 - vcpkg install cpprestsdk:x64-windows
 - cd c:\vowpal_wabbit
 - vowpalwabbit\.nuget\nuget install -o vowpalwabbit\packages cs\cs\packages.config


### PR DESCRIPTION
Issue was introduced by installing openssl-1.1 on appveyor images which is wrongly picked up by CMake.

Workaround copied from here:
https://github.com/Microsoft/vcpkg/issues/4189#issuecomment-417462822

Fix is not released yet:
https://github.com/appveyor/ci/issues/2600