### PR TITLE
build instructions: program_options insufficient

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This is the *vowpal wabbit* fast online learning code.  For Windows, look at [RE
 These prerequisites are usually pre-installed on many platforms. However, you may need to consult your favorite package
 manager (*yum*, *apt*, *MacPorts*, *brew*, ...) to install missing software.
 
-- [Boost](http://www.boost.org) library, with the `Boost::Program_Options` library option enabled.
+- [Boost](http://www.boost.org) library, (for `Boost::Program_Options` and a few others).
 - The zlib compression library + headers. In linux distros: package `zlib-devel` (Red Hat/CentOS), or `zlib1g-dev` (Ubuntu/Debian)
 - lsb-release  (RedHat/CentOS: redhat-lsb-core, Debian: lsb-release, Ubuntu: you're all set, OSX: not required)
 - GNU *autotools*: *autoconf*, *automake*, *libtool*, *autoheader*, et. al. This is not a strict prereq. On many systems (notably Ubuntu with `libboost-program-options-dev` installed), the provided `Makefile` works fine.
@@ -97,8 +97,8 @@ On Ubuntu/Debian/Mint and similar the following sequence should work
 for building the latest from github:
 
 ```
-# -- Get libboost program-options and zlib:
-apt-get install libboost-program-options-dev zlib1g-dev
+# -- Get libboost and zlib:
+apt-get install libboost-dev zlib1g-dev
 
 # -- Get the python libboost bindings (python subdir) - optional:
 apt-get install libboost-python-dev
@@ -137,7 +137,7 @@ make CXX='clang++ -static' clean vw test     # ignore warnings
 
 Ensure boost-library and c-compiler are installed:
 ```
-apt-get install libboost-program-options-dev zlib1g-dev libboost-python-dev clang make automake
+apt-get install libboost-dev zlib1g-dev libboost-python-dev clang make automake
 ```
 
 Set Python 3.x and its boost-library as default:


### PR DESCRIPTION
We now need other boost parts, so the simplest is to prereq `libboost-dev`